### PR TITLE
Fix fresh-install blockers and add opt-in agent runtime

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,10 +4,14 @@
 }
 
 :80, :443 {
-    encode br zstd gzip
+    # caddy:2 ships zstd + gzip but NOT brotli — listing `br` makes Caddy fail
+    # to start ("encoder module br not registered").
+    encode zstd gzip
 
+    # The API namespaces every route under /api itself (e.g. /api/auth/login).
+    # Do NOT strip the prefix here, or requests reach the API as /auth/login
+    # and 404.
     handle /api/* {
-        uri strip_prefix /api
         reverse_proxy api:3000
     }
 
@@ -19,8 +23,8 @@
         reverse_proxy api:3000
     }
 
-    handle /uploads/* {
-        uri strip_prefix /uploads
+    # Auth-checked file serving lives at /files/<key> on the API.
+    handle /files/* {
         reverse_proxy api:3000
     }
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,23 @@ docker compose up -d --build
 
 Caddy handles HTTPS automatically if you point a real domain at the host (set `PUBLIC_BASE_URL=https://chat.yourdomain.com` and edit `Caddyfile`).
 
+Database migrations run automatically when the `api` container starts, so a fresh `up` boots a working schema.
+
+### Agents (self-hosted runtime)
+
+The base stack runs the chat app. To let CircleChat provision and run **Hermes / OpenClaw** agents, enable the agent runtime overlay:
+
+```bash
+# one-time host setup
+sudo mkdir -p /opt/hermes-homes && sudo chmod 777 /opt/hermes-homes
+docker pull nousresearch/hermes-agent:latest
+docker pull alpine/openclaw:latest
+
+docker compose -f compose.yml -f compose.agents.yml up -d --build
+```
+
+This adds a `bridge` service and mounts the host Docker socket into `api`/`worker`/`bridge` so they can spawn agent containers. **Security:** the Docker socket grants root-equivalent host access to those containers — only enable on a host you control. Point agents at your LLM gateway (e.g. [FreeLLMAPI](https://github.com/tashfeenahmed/freellmapi)) when provisioning them in the UI.
+
 ### Deploy to a Raspberry Pi (or any bare-metal host)
 
 Replicated in production on a Pi 4:
@@ -318,8 +335,8 @@ ssh pi@your-host 'systemctl --user restart circlechat-api circlechat-worker circ
 ### Common ops
 
 ```bash
-# Apply migrations
-docker compose run --rm api npm run db:migrate
+# Migrations run automatically on api start; to apply them manually:
+docker compose run --rm api node dist/db/migrate.js
 
 # Tail logs
 docker compose logs -f api worker web

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:22-alpine AS deps
 WORKDIR /app
-COPY package.json ./
-RUN npm install --omit=optional --no-audit --no-fund
+# Use `npm ci` against the committed lockfile so the dependency tree is
+# reproducible. A bare `npm install` resolves fresh and can pull an ioredis
+# that's incompatible with bullmq's pinned copy, breaking the TS build.
+COPY package.json package-lock.json ./
+RUN npm ci --omit=optional --no-audit --no-fund
 
 FROM node:22-alpine AS build
 WORKDIR /app
@@ -12,9 +15,18 @@ RUN npx tsc -p tsconfig.json
 FROM node:22-alpine
 WORKDIR /app
 ENV NODE_ENV=production
+# docker-cli lets the agent-install route and the multi-bridge spawn
+# Hermes/OpenClaw agent containers via a mounted Docker socket. Only used when
+# the agent runtime is enabled (see compose.agents.yml); harmless otherwise.
+RUN apk add --no-cache docker-cli
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/migrations ./migrations
+# Runtime assets the agent-install route reads (config template, MCP stdio
+# script, skill templates) plus the multi-bridge entrypoint script.
+COPY --from=build /app/templates ./templates
+COPY --from=build /app/scripts ./scripts
+COPY --from=build /app/hermes-multi-bridge.mjs ./hermes-multi-bridge.mjs
 COPY package.json ./
 EXPOSE 3000
 CMD ["node", "dist/index.js"]

--- a/api/hermes-multi-bridge.mjs
+++ b/api/hermes-multi-bridge.mjs
@@ -218,6 +218,13 @@ function isEntrypointNoise(line) {
   if (/^🔧\s*Auto-repaired tool name/i.test(t)) return true;
   if (/^⚠️?\s*Unknown tool/i.test(t)) return true;
   if (/^✓\s*(Enabled toolset|Loaded \d+ tools?)/i.test(t)) return true;
+  // s6 / container-entrypoint init + skills reconcile lines. The hermes-agent
+  // image runs its full s6 boot on every `docker run --rm`, printing these to
+  // stdout before the chat reply — strip them so they never reach a channel.
+  if (/^\[stage\d*\]/i.test(t)) return true;
+  if (/^\[supervise[-\w]*\]/i.test(t)) return true;
+  if (/^\[s6-/i.test(t)) return true;
+  if (/^reconcile:\s/i.test(t)) return true;
   return false;
 }
 

--- a/api/src/auth/session.ts
+++ b/api/src/auth/session.ts
@@ -95,7 +95,11 @@ export function setSessionCookie(reply: FastifyReply, sid: string): void {
   reply.setCookie(COOKIE_NAME, sid, {
     httpOnly: true,
     sameSite: "lax",
-    secure: config.env === "production",
+    // Tie Secure to the public URL scheme, not NODE_ENV. A production build
+    // served over plain HTTP (e.g. a bare IP or localhost trial) would
+    // otherwise set Secure and the browser would drop the session cookie,
+    // making login silently fail to persist.
+    secure: config.publicBaseUrl.startsWith("https"),
     path: "/",
     maxAge: Math.floor(SESSION_TTL_MS / 1000),
     signed: false,

--- a/compose.agents.yml
+++ b/compose.agents.yml
@@ -1,0 +1,62 @@
+# Opt-in agent runtime for Hermes / OpenClaw agents.
+#
+#   docker compose -f compose.yml -f compose.agents.yml up -d --build
+#
+# This mounts the host Docker socket into the api, worker, and bridge
+# containers so CircleChat can spawn ephemeral agent containers
+# (nousresearch/hermes-agent, alpine/openclaw) per message.
+#
+# ── SECURITY ──────────────────────────────────────────────────────────────
+# Mounting /var/run/docker.sock grants these containers root-equivalent
+# control of the host. Only enable on a host you trust and control.
+#
+# ── HERMES_HOMES_DIR ──────────────────────────────────────────────────────
+# Must be an ABSOLUTE host path. Each agent's home dir is created here and
+# bind-mounted into the agent container by the *host* Docker daemon, so the
+# path has to resolve identically inside and outside the container — that's
+# why it's mounted at the same path on both sides. Create it first:
+#   sudo mkdir -p /opt/hermes-homes && sudo chmod 777 /opt/hermes-homes
+#
+# Pre-pull the agent images once:
+#   docker pull nousresearch/hermes-agent:latest
+#   docker pull alpine/openclaw:latest
+
+services:
+  api:
+    environment:
+      HERMES_HOMES_DIR: ${HERMES_HOMES_DIR:-/opt/hermes-homes}
+      CC_BRIDGE_CONFIG_PATH: ${HERMES_HOMES_DIR:-/opt/hermes-homes}/bridge-config.json
+      CC_API_BASE: ${PUBLIC_BASE_URL:-http://localhost:8080}/api
+      CC_HERMES_IMAGE: ${CC_HERMES_IMAGE:-nousresearch/hermes-agent:latest}
+      CC_OPENCLAW_IMAGE: ${CC_OPENCLAW_IMAGE:-alpine/openclaw:latest}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${HERMES_HOMES_DIR:-/opt/hermes-homes}:${HERMES_HOMES_DIR:-/opt/hermes-homes}
+
+  worker:
+    environment:
+      HERMES_HOMES_DIR: ${HERMES_HOMES_DIR:-/opt/hermes-homes}
+      CC_BRIDGE_CONFIG_PATH: ${HERMES_HOMES_DIR:-/opt/hermes-homes}/bridge-config.json
+    volumes:
+      - ${HERMES_HOMES_DIR:-/opt/hermes-homes}:${HERMES_HOMES_DIR:-/opt/hermes-homes}
+
+  # The multi-bridge holds one WebSocket per agent to /agent-socket and shells
+  # out to a Hermes container on each incoming message.
+  bridge:
+    build: ./api
+    command: ["node", "hermes-multi-bridge.mjs"]
+    environment:
+      CC_BRIDGE_CONFIG: ${HERMES_HOMES_DIR:-/opt/hermes-homes}/bridge-config.json
+      # Internal, in-network WS to the api — no TLS hop needed.
+      CC_WSS_URL: ws://api:3000/agent-socket
+      # Passed into the (host-network) agent containers for their /agent-api
+      # callbacks, so it must be reachable from the host, not a compose alias.
+      CC_API_BASE: ${PUBLIC_BASE_URL:-http://localhost:8080}/api
+      HERMES_HOMES_DIR: ${HERMES_HOMES_DIR:-/opt/hermes-homes}
+      CC_HERMES_IMAGE: ${CC_HERMES_IMAGE:-nousresearch/hermes-agent:latest}
+      CC_OPENCLAW_IMAGE: ${CC_OPENCLAW_IMAGE:-alpine/openclaw:latest}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${HERMES_HOMES_DIR:-/opt/hermes-homes}:${HERMES_HOMES_DIR:-/opt/hermes-homes}
+    depends_on: [api]
+    restart: unless-stopped

--- a/compose.yml
+++ b/compose.yml
@@ -61,6 +61,10 @@ services:
 
   api:
     build: ./api
+    # Apply DB migrations before serving so a fresh `docker compose up` boots a
+    # working schema instead of an empty database. `drizzle migrate` is
+    # idempotent, so this is a no-op on subsequent starts.
+    command: ["sh", "-c", "node dist/db/migrate.js && node dist/index.js"]
     environment:
       NODE_ENV: production
       PORT: 3000


### PR DESCRIPTION
Issues a new user hits on a clean `git clone && docker compose up`, plus the wiring needed to actually run agents. Found while standing up a fresh deployment from scratch.

## Build & boot fixes
- **`api/Dockerfile` → `npm ci`** against the committed lockfile. A bare `npm install` resolves a fresh `ioredis` that's incompatible with `bullmq`'s pinned copy, which **breaks the TypeScript build**.
- **`Caddyfile`**:
  - Drop `br` from `encode` — `caddy:2` has no Brotli encoder, so Caddy **crash-loops on startup**.
  - Remove `uri strip_prefix /api` — the API namespaces all routes under `/api` itself, so stripping made **every API call 404**. (Also routes `/files/*` to the API for auth-checked file serving.)
- **`compose.yml`** — run DB migrations on `api` start, so a fresh `up` boots a working schema instead of an empty DB. `drizzle migrate` is idempotent.
- **`session.ts`** — tie the cookie `Secure` flag to the `PUBLIC_BASE_URL` scheme instead of `NODE_ENV`. A production build served over plain HTTP (localhost / bare-IP trial) otherwise sets `Secure` and the browser **drops the session cookie**, so login silently won't persist.

## Agent runtime (opt-in)
- **`api/Dockerfile`** — add `docker-cli` and bundle the assets the agent-install route reads at runtime (config template, MCP script, skill templates, bridge entrypoint), which weren't in the image.
- **`compose.agents.yml`** (new) — overlay that mounts the Docker socket into `api`/`worker`/`bridge` and adds the `hermes-multi-bridge` service, so the app can spawn Hermes/OpenClaw containers. Kept as an opt-in overlay because the Docker socket grants root-equivalent host access. Enable with `docker compose -f compose.yml -f compose.agents.yml up -d`.
- **`hermes-multi-bridge.mjs`** — strip the hermes-agent image's s6 boot / `reconcile:` lines from replies, which were leaking into channel messages.
- **README** — document the agent overlay and the auto-migrate behavior.

## Notes / for review
- The `strip_prefix /api` change contradicts the in-repo Caddyfile "working in prod" assumption — the prod Pi appears to use the systemd path (separate proxy), not this Caddyfile. Worth a sanity check against your prod proxy config.
- Verified end-to-end on a fresh Ubuntu host: clean build, login over HTTP, and a Hermes agent provisioned and replying via the overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)