### PR TITLE
Add "Reports to" assignment to the profile panel

### DIFF
--- a/web/src/components/MemberDetailsPanel.tsx
+++ b/web/src/components/MemberDetailsPanel.tsx
@@ -1,9 +1,12 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { X, MessageSquare, ExternalLink } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { X, MessageSquare, ExternalLink, Pencil } from "lucide-react";
 import { useBus } from "../state/store";
+import { api } from "../api/client";
 import Avatar from "./Avatar";
 import { usePaneResize } from "../lib/usePaneResize";
+import { AssignDialog, type OrgNode } from "../pages/Org";
 
 export default function MemberDetailsPanel() {
   const memberId = useBus((s) => s.detailsMemberId);
@@ -14,6 +17,23 @@ export default function MemberDetailsPanel() {
   const setWidth = useBus((s) => s.setDetailsWidth);
   const startResize = usePaneResize(width, setWidth);
   const nav = useNavigate();
+  const [assigning, setAssigning] = useState(false);
+
+  // Org tree — used to show & edit who this member reports to.
+  const org = useQuery({
+    queryKey: ["org"],
+    queryFn: () => api.get<{ nodes: OrgNode[] }>("/org"),
+    enabled: !!memberId,
+  });
+  const orgNodes = org.data?.nodes ?? [];
+  const orgNode = useMemo(
+    () => orgNodes.find((n) => n.memberId === memberId) ?? null,
+    [orgNodes, memberId],
+  );
+  const manager = useMemo(
+    () => (orgNode?.reportsTo ? orgNodes.find((n) => n.memberId === orgNode.reportsTo) ?? null : null),
+    [orgNodes, orgNode],
+  );
 
   const member = useMemo(() => (memberId ? dir[memberId] : null), [memberId, dir]);
   if (!memberId || !member) return null;
@@ -98,6 +118,20 @@ export default function MemberDetailsPanel() {
               <dd className="font-mono text-[12px]">{status}</dd>
             </>
           )}
+          <dt>Reports to</dt>
+          <dd className="inline-flex items-center gap-1.5 min-w-0">
+            <span className="truncate">{manager ? manager.name : "Top of tree"}</span>
+            {orgNode && (
+              <button
+                type="button"
+                onClick={() => setAssigning(true)}
+                className="tb-btn shrink-0"
+                title="Change manager"
+              >
+                <Pencil size={11} strokeWidth={2} />
+              </button>
+            )}
+          </dd>
         </dl>
 
         {brief && (
@@ -107,6 +141,14 @@ export default function MemberDetailsPanel() {
           </div>
         )}
       </div>
+
+      {assigning && orgNode && (
+        <AssignDialog
+          target={orgNode}
+          all={orgNodes}
+          onClose={() => setAssigning(false)}
+        />
+      )}
     </aside>
   );
 }

--- a/web/src/pages/Org.tsx
+++ b/web/src/pages/Org.tsx
@@ -6,7 +6,7 @@ import { humanizeError } from "../api/errors";
 import Avatar from "../components/Avatar";
 import { useBus } from "../state/store";
 
-interface OrgNode {
+export interface OrgNode {
   memberId: string;
   kind: "user" | "agent";
   name: string;
@@ -346,7 +346,7 @@ function NewReportDialog({ manager, onClose }: { manager: OrgNode; onClose: () =
   );
 }
 
-function AssignDialog({
+export function AssignDialog({
   target,
   all,
   onClose,


### PR DESCRIPTION
Lets you set who a member reports to **from their profile panel**, not just the org-chart pencil.

### What
- The member profile panel now has a **"Reports to"** row showing the current manager (or "Top of tree"), with a pencil to change it.
- Opens the existing `AssignDialog` (same manager picker, same `/org/assign` endpoint, same cycle-prevention), so behavior is consistent with the org chart.
- Works for both humans and agents.

### Why
The only way to set a reporting line was the small per-card pencil in the org chart, which is easy to miss or mis-click (especially when members sit at the same top level with no tree yet). Surfacing it on the profile makes it discoverable.

### Implementation
- Export `AssignDialog` + `OrgNode` from `pages/Org.tsx` for reuse.
- `MemberDetailsPanel` fetches the org tree (`["org"]`), resolves the member's current manager, and renders/opens the dialog. Type-checked clean.

Deployed and verified on a live instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)