### PR TITLE
Fix agent equip installing empty skills under docker

### DIFF
--- a/api/src/agents/hermes-equip.ts
+++ b/api/src/agents/hermes-equip.ts
@@ -108,6 +108,20 @@ export async function installCircleChatTooling(params: {
     }
   }
 
+  // Post-install sanity check. A "successful" copy that left no DESCRIPTION.md
+  // behind almost always means the template source didn't resolve — e.g. a
+  // relative CC_SKILL_TEMPLATE that Docker can't bind-mount on the host daemon,
+  // which silently mounts an empty dir. Flip skillInstalled to false and say so
+  // rather than ship an empty "(missing DESCRIPTION.md)" skill.
+  if (skillInstalled && !(await skillHasDescription(skillDest))) {
+    skillInstalled = false;
+    notes.push(
+      `circlechat skill is empty after install — no DESCRIPTION.md in ${skillDest}. ` +
+        `Check that CC_SKILL_TEMPLATE (${SKILL_TEMPLATE_DIR}) is an absolute path that ` +
+        `resolves on the docker host.`,
+    );
+  }
+
   // In docker mode we must stage the MCP stdio script inside HERMES_HOME so
   // that the containerised hermes process can spawn it — `/opt/cc-scripts/…`
   // from the CircleChat host isn't visible inside the container.
@@ -258,6 +272,18 @@ async function copyDir(src: string, dest: string): Promise<void> {
     const d = join(dest, e.name);
     if (e.isDirectory()) await copyDir(s, d);
     else if (e.isFile()) await fs.copyFile(s, d);
+  }
+}
+
+// True only if the skill dir holds a non-empty DESCRIPTION.md — the file the
+// Skills UI reads. Used as a post-install guard so a copy that produced an
+// empty folder is reported as failed instead of silently "installed".
+export async function skillHasDescription(skillDir: string): Promise<boolean> {
+  try {
+    const st = await fs.stat(join(skillDir, "DESCRIPTION.md"));
+    return st.isFile() && st.size > 0;
+  } catch {
+    return false;
   }
 }
 

--- a/api/src/agents/openclaw-equip.ts
+++ b/api/src/agents/openclaw-equip.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { promises as fs } from "node:fs";
 import { join, resolve as pathResolve, basename } from "node:path";
 import { buildOpenClawCommand, CONTAINER_OPENCLAW_HOME } from "./openclaw-runtime.js";
+import { skillHasDescription } from "./hermes-equip.js";
 
 const MCP_SCRIPT =
   process.env.CC_MCP_SCRIPT ??
@@ -57,6 +58,16 @@ export async function equipOpenClawAgent(params: {
     skillInstalled = true;
   } catch (e) {
     notes.push(`skill copy failed: ${(e as Error).message.slice(0, 200)}`);
+  }
+  // Guard against a copy that left an empty folder (usually a CC_SKILL_TEMPLATE
+  // that doesn't resolve from this container) — report it instead of shipping a
+  // "(missing DESCRIPTION.md)" skill.
+  if (skillInstalled && !(await skillHasDescription(skillDest))) {
+    skillInstalled = false;
+    notes.push(
+      `circlechat skill is empty after install — no DESCRIPTION.md in ${skillDest}. ` +
+        `Check that CC_SKILL_TEMPLATE (${SKILL_TEMPLATE_DIR}) resolves to the template dir.`,
+    );
   }
   // Stage agent-browser skill next to circlechat. Non-fatal on old deploys
   // that don't have the template yet.

--- a/compose.agents.yml
+++ b/compose.agents.yml
@@ -29,9 +29,26 @@ services:
       CC_API_BASE: ${PUBLIC_BASE_URL:-http://localhost:8080}/api
       CC_HERMES_IMAGE: ${CC_HERMES_IMAGE:-nousresearch/hermes-agent:latest}
       CC_OPENCLAW_IMAGE: ${CC_OPENCLAW_IMAGE:-alpine/openclaw:latest}
+      # Where the equip step finds the skill docs + MCP stdio script to install
+      # into each new agent. These MUST be absolute HOST paths: Hermes equip
+      # bind-mounts the template dir into a throw-away skill-ops container
+      # (resolved by the *host* daemon), while OpenClaw equip reads it from this
+      # container's filesystem. The identical-path mounts below make one value
+      # satisfy both. Left unset, equip falls back to /app/templates (a path
+      # that exists only inside this container) and the host bind-mount silently
+      # resolves to an empty dir — producing an empty "(missing DESCRIPTION.md)"
+      # skill. Override CC_REPO_HOST_DIR if the repo isn't at /opt/circlechat.
+      CC_SKILL_TEMPLATE: ${CC_REPO_HOST_DIR:-/opt/circlechat}/api/templates/circlechat-skill
+      CC_BROWSER_SKILL_TEMPLATE: ${CC_REPO_HOST_DIR:-/opt/circlechat}/api/templates/browser-skill
+      CC_MCP_SCRIPT: ${CC_REPO_HOST_DIR:-/opt/circlechat}/api/scripts/circlechat-mcp.mjs
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${HERMES_HOMES_DIR:-/opt/hermes-homes}:${HERMES_HOMES_DIR:-/opt/hermes-homes}
+      # Mounted at the SAME path inside the container as on the host so the
+      # template/script paths above resolve identically for both the in-container
+      # fs reads (OpenClaw) and the host-daemon bind-mounts (Hermes skill-ops).
+      - ${CC_REPO_HOST_DIR:-/opt/circlechat}/api/templates:${CC_REPO_HOST_DIR:-/opt/circlechat}/api/templates:ro
+      - ${CC_REPO_HOST_DIR:-/opt/circlechat}/api/scripts:${CC_REPO_HOST_DIR:-/opt/circlechat}/api/scripts:ro
 
   worker:
     environment:


### PR DESCRIPTION
## What

New Hermes/OpenClaw agents were provisioned with an empty `circlechat` skill (UI showed **"(missing DESCRIPTION.md)"**) and `mcpRegistered: false`. Previously repaired by hand on the box; this fixes it in code.

## Root causes

1. **`compose.agents.yml` set no `CC_SKILL_TEMPLATE` / `CC_MCP_SCRIPT`.** Equip fell back to `process.cwd()/templates` = `/app/templates` *inside* the api container. The Hermes path hands that to the **host** docker daemon as a skill-ops bind-mount source — the host has no `/app`, so Docker silently mounts an empty dir and the copy yields an empty skill.
2. **The equip code trusted a "successful" copy** even when it produced nothing.

## Fix

- Point the equip env at **absolute host paths** and mount the repo's `templates/` + `scripts/` at **identical host==container paths**, so one value works for both the Hermes host-daemon bind-mount *and* the OpenClaw in-container fs copy. Override via `CC_REPO_HOST_DIR` (default `/opt/circlechat`).
- Add a **post-install check** that the skill holds a non-empty `DESCRIPTION.md`; if not, report `skillInstalled: false` with a diagnostic note instead of shipping an empty skill silently.

## Related (done out-of-band, not in this PR)

The live agents (samantha, remy, dara, eli, hermestest) were missing the `tasks.write` scope; widened directly on the prod DB so they're ready before `ENFORCE_AGENT_SCOPES` is ever enabled. New agents already get `tasks.write` by default.

## Notes / deploy

- This supersedes the box-side `compose.agents.yml` skill-template patch. On next redeploy, confirm `CC_REPO_HOST_DIR` resolves to the repo root on the host (`/opt/circlechat`) so the new identical-path mounts line up.
- `npx tsc -p tsconfig.json --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)