### PR TITLE
Measurement, not vibes: §16 perf harness + report-only CI

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,95 @@
+name: perf
+
+# Report-only performance check (PLAN.html §16). Runs Lighthouse + bundle-size
+# on the public pages and a backend/WS latency benchmark against an ephemeral
+# stack, compares to perf/baseline.json, and posts the result. It never blocks a
+# merge (the run always exits 0). Update the baseline on main with:
+#   cd perf && node run.mjs --update-baseline   (then commit perf/baseline.json)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: perf-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  perf:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Chrome (for Lighthouse)
+        id: chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Build web
+        working-directory: web
+        run: |
+          npm install --no-audit --no-fund
+          npm run build
+
+      - name: Bring up ephemeral stack (best-effort)
+        continue-on-error: true
+        run: |
+          docker compose -f compose.yml -f perf/compose.ci.yml \
+            up -d --build postgres redis minio minio-setup api
+
+      - name: Install perf deps
+        working-directory: perf
+        run: npm install --no-audit --no-fund
+
+      - name: Run perf harness
+        working-directory: perf
+        continue-on-error: true
+        env:
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+          PERF_BASE_URL: http://localhost:3000
+        run: node run.mjs
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-report
+          path: |
+            perf/report.md
+            perf/results.json
+          if-no-files-found: ignore
+
+      - name: Comment report on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body;
+            try { body = fs.readFileSync('perf/report.md', 'utf8'); }
+            catch { body = '_perf report not produced._'; }
+            const marker = '<!-- circlechat-perf-report -->';
+            body = marker + '\n' + body;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose -f compose.yml -f perf/compose.ci.yml down -v || true

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ coverage/
 # the line below is defensive in case it ever gets moved inside.
 ../marketing-site/
 marketing-site/
+
+# perf harness local outputs
+perf/node_modules/
+perf/results.json
+perf/report.md

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,66 @@
+# Performance harness — "Measurement, not vibes" (PLAN.html §16)
+
+Report-only, regression-vs-baseline. Nothing here blocks a merge; it measures
+the §16 budgets, compares each run to `baseline.json`, and posts a report.
+
+## Stages
+
+| Stage | Needs | Measures |
+|---|---|---|
+| `bundle` | `web/dist` (run `npm --prefix ../web run build`) | gzip size of the **initial** client payload (entry + preloads parsed from `index.html`) → `client_bundle_gzip_kb` |
+| `lighthouse` | `web/dist` + Chrome | FCP / LCP / TBT / TTI / perf-score on the public `/login` & `/signup` pages |
+| `backend` | a running stack at `$PERF_BASE_URL` | `POST /messages` round-trip p50/p95 and WS fan-out p95 (`POST → message.new`) |
+| `wsload` | a running stack | delivered WS throughput across N subscriber sockets (scaled-down proxy — see caveat) |
+
+The authed chat shell is **not** Lighthouse-audited (would need a seeded login
+flow); `backend`/`wsload` cover the server hot paths instead.
+
+## Run it
+
+```bash
+npm install
+
+# Synthetic only (no backend needed):
+npm --prefix ../web run build
+node run.mjs bundle lighthouse
+
+# Everything, against a local stack:
+#   docker compose -f ../compose.yml -f compose.ci.yml up -d --build \
+#     postgres redis minio minio-setup api
+PERF_BASE_URL=http://localhost:3000 node run.mjs
+
+# Update the committed baseline after an intentional perf change:
+node run.mjs --update-baseline      # then commit baseline.json
+```
+
+Flags: `--strict` (exit 1 on a 🔒-gated regression — off by default),
+`--base-url <url>`, `--update-baseline`. Env knobs: `PERF_BASE_URL`,
+`PERF_BACKEND_SAMPLES`, `PERF_WS_CONNS`, `PERF_WS_MSGS`, `CHROME_PATH`.
+
+## Budgets & gating
+
+`budgets.json` holds the §16 numbers. `regressionPct` is the allowed drift vs
+baseline before a metric is flagged `REGRESSED` (10% for paint/bundle, 20% for
+latency — the §16 rule). `gate: true` marks the metrics that *would* fail a
+future `--strict` run. Today everything is report-only.
+
+## CI
+
+`.github/workflows/perf.yml` runs on every PR/push: builds web, boots an
+ephemeral stack (api published on `:3000`, no Caddy/TLS), runs all stages,
+uploads `report.md`/`results.json`, and upserts a single PR comment. It always
+exits 0.
+
+## Honest caveats
+
+- **`ws_throughput_msgs_per_sec` is a scaled-down proxy**, not §16's
+  ">50,000 msgs/sec/core". One CI poster + a handful of sockets won't reach 50k;
+  the number is for tracking regressions, not certifying the absolute budget. A
+  real multi-node load generator (k6 / autocannon) is the eventual upgrade.
+- **`tti_login_ms`** is a cold Lighthouse measurement; §16's 250 ms TTI budget
+  is the *warm/cached* shell. Treated as informational.
+- **`api_post_message_p50_ms`** is a server round-trip; §16's 30 ms
+  send-to-render budget is *client optimistic-UI* (instant), which RUM (deferred)
+  would capture. This is the closest server-side proxy.
+- RUM (web-vitals from real browsers) is **not** built yet — deliberately
+  deferred. When added it supersedes the synthetic numbers for real p50/p95.

--- a/perf/baseline.json
+++ b/perf/baseline.json
@@ -1,0 +1,7 @@
+{
+  "updatedAt": "2026-05-31T19:12:44.098Z",
+  "metrics": {
+    "client_bundle_gzip_kb": 203.2,
+    "client_total_gzip_kb_info": 203.2
+  }
+}

--- a/perf/budgets.json
+++ b/perf/budgets.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Budgets from PLAN.html §16. 'budget' is the absolute target; 'regressionPct' is the allowed drift vs baseline before a metric is flagged REGRESSED (the §16 rule: FCP-class 10%, send-to-render-class 20%). 'gate' marks which metrics would block in a future --strict run; everything is report-only today. lowerIsBetter=false only for throughput.",
+  "metrics": {
+    "client_bundle_gzip_kb": { "budget": 180, "regressionPct": 10, "lowerIsBetter": true, "gate": true, "unit": "kB", "label": "Client bundle (initial, gzip)" },
+    "fcp_login_ms":          { "budget": 800, "regressionPct": 10, "lowerIsBetter": true, "gate": true, "unit": "ms", "label": "First Contentful Paint (/login)" },
+    "lcp_login_ms":          { "budget": 1200, "regressionPct": 10, "lowerIsBetter": true, "gate": false, "unit": "ms", "label": "Largest Contentful Paint (/login)" },
+    "tbt_login_ms":          { "budget": 200, "regressionPct": 15, "lowerIsBetter": true, "gate": false, "unit": "ms", "label": "Total Blocking Time (/login)" },
+    "tti_login_ms":          { "budget": 250, "regressionPct": 10, "lowerIsBetter": true, "gate": false, "unit": "ms", "label": "Time To Interactive (/login, cold — informational; §16 budget is warm/cached)" },
+    "perf_score_login":      { "budget": 90, "regressionPct": 10, "lowerIsBetter": false, "gate": false, "unit": "/100", "label": "Lighthouse perf score (/login)" },
+    "fcp_signup_ms":         { "budget": 800, "regressionPct": 10, "lowerIsBetter": true, "gate": false, "unit": "ms", "label": "First Contentful Paint (/signup)" },
+    "api_post_message_p50_ms": { "budget": 30, "regressionPct": 20, "lowerIsBetter": true, "gate": false, "unit": "ms", "label": "POST message round-trip p50 (server-side proxy for send-to-render; §16 30ms budget is client optimistic-UI)" },
+    "api_post_message_p95_ms": { "budget": 120, "regressionPct": 20, "lowerIsBetter": true, "gate": true, "unit": "ms", "label": "POST message round-trip p95" },
+    "ws_fanout_p95_ms":      { "budget": 120, "regressionPct": 20, "lowerIsBetter": true, "gate": true, "unit": "ms", "label": "WS fan-out p95 (POST -> message.new on a subscribed socket)" },
+    "ws_throughput_msgs_per_sec": { "budget": 50000, "regressionPct": 20, "lowerIsBetter": false, "gate": false, "unit": "msg/s", "label": "WS delivered throughput (scaled-down proxy for the >50k/core budget — see README)" }
+  }
+}

--- a/perf/compose.ci.yml
+++ b/perf/compose.ci.yml
@@ -1,0 +1,11 @@
+# CI overlay for the backend/wsload perf benchmark. Publishes the api directly
+# on :3000 (bypassing Caddy/TLS, which is domain-specific) and tells it to mint
+# non-Secure cookies so the harness can auth over plain http on localhost.
+# Used as: docker compose -f compose.yml -f perf/compose.ci.yml up -d \
+#            postgres redis minio minio-setup api
+services:
+  api:
+    ports:
+      - "3000:3000"
+    environment:
+      PUBLIC_BASE_URL: http://localhost:3000

--- a/perf/lib/serve.mjs
+++ b/perf/lib/serve.mjs
@@ -1,0 +1,57 @@
+// Minimal static file server with SPA fallback, used to serve web/dist so
+// Lighthouse can load client-routed pages like /login and /signup.
+import { createServer } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { join, extname, normalize } from "node:path";
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".webp": "image/webp",
+  ".ico": "image/x-icon",
+  ".woff2": "font/woff2",
+  ".woff": "font/woff",
+  ".map": "application/json; charset=utf-8",
+};
+
+export async function serveStatic(root, port = 4180) {
+  const server = createServer(async (req, res) => {
+    try {
+      const urlPath = decodeURIComponent((req.url || "/").split("?")[0]);
+      let filePath = join(root, normalize(urlPath));
+      if (!filePath.startsWith(root)) {
+        res.writeHead(403).end("forbidden");
+        return;
+      }
+      let s = await stat(filePath).catch(() => null);
+      if (s && s.isDirectory()) {
+        filePath = join(filePath, "index.html");
+        s = await stat(filePath).catch(() => null);
+      }
+      // SPA fallback: unknown non-asset routes (e.g. /login) -> index.html
+      if (!s) {
+        if (extname(urlPath)) {
+          res.writeHead(404).end("not found");
+          return;
+        }
+        filePath = join(root, "index.html");
+      }
+      const body = await readFile(filePath);
+      res.writeHead(200, { "content-type": MIME[extname(filePath)] || "application/octet-stream" });
+      res.end(body);
+    } catch (e) {
+      res.writeHead(500).end(String(e?.message || e));
+    }
+  });
+  await new Promise((resolve) => server.listen(port, resolve));
+  return {
+    url: `http://localhost:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}

--- a/perf/lib/util.mjs
+++ b/perf/lib/util.mjs
@@ -1,0 +1,51 @@
+// Small shared helpers for the perf harness. No external deps.
+import { readFile, writeFile } from "node:fs/promises";
+import { gzipSync } from "node:zlib";
+
+export async function loadJSON(path, fallback = null) {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
+export async function saveJSON(path, obj) {
+  await writeFile(path, JSON.stringify(obj, null, 2) + "\n");
+}
+
+export function gzipKB(buf) {
+  return gzipSync(buf, { level: 9 }).length / 1024;
+}
+
+// Nearest-rank percentile over an array of numbers.
+export function percentile(samples, p) {
+  if (!samples.length) return null;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length);
+  return sorted[Math.min(rank, sorted.length) - 1];
+}
+
+export function round(n, dp = 1) {
+  if (n === null || n === undefined || Number.isNaN(n)) return null;
+  const f = 10 ** dp;
+  return Math.round(n * f) / f;
+}
+
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Poll an async predicate until it returns truthy or the deadline passes.
+export async function waitFor(fn, { timeoutMs = 60000, intervalMs = 1000, label = "condition" } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr;
+  while (Date.now() < deadline) {
+    try {
+      const v = await fn();
+      if (v) return v;
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`waitFor(${label}) timed out after ${timeoutMs}ms${lastErr ? `: ${lastErr.message}` : ""}`);
+}

--- a/perf/package.json
+++ b/perf/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "circlechat-perf",
+  "private": true,
+  "type": "module",
+  "description": "Measurement harness for the §16 performance budgets (synthetic Lighthouse + bundle size, backend latency, WS throughput). Report-only, regression-vs-baseline.",
+  "scripts": {
+    "perf": "node run.mjs",
+    "perf:synthetic": "node run.mjs bundle lighthouse",
+    "perf:bundle": "node run.mjs bundle",
+    "perf:lighthouse": "node run.mjs lighthouse",
+    "perf:backend": "node run.mjs backend",
+    "perf:wsload": "node run.mjs wsload",
+    "baseline:update": "node run.mjs --update-baseline"
+  },
+  "dependencies": {
+    "chrome-launcher": "^1.1.2",
+    "lighthouse": "^12.2.1",
+    "ws": "^8.18.0"
+  }
+}

--- a/perf/run.mjs
+++ b/perf/run.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// CircleChat performance harness — orchestrator.
+//
+//   node run.mjs [stages...] [flags]
+//
+// stages : any of  bundle  lighthouse  backend  wsload   (default: all)
+// flags  : --update-baseline   write this run's metrics into baseline.json
+//          --strict            exit 1 if a `gate` metric REGRESSED (default: report-only, exit 0)
+//          --base-url <url>    backend/wsload target (default $PERF_BASE_URL or http://localhost:8080)
+//
+// Output: prints a markdown report, writes results.json + report.md next to this
+// file, and appends the report to $GITHUB_STEP_SUMMARY when set. Compares every
+// metric to perf/baseline.json (regression-vs-baseline, per §16).
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { loadJSON, saveJSON } from "./lib/util.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ALL = ["bundle", "lighthouse", "backend", "wsload"];
+
+const argv = process.argv.slice(2);
+const flags = new Set(argv.filter((a) => a.startsWith("--")));
+const baseUrlIdx = argv.indexOf("--base-url");
+if (baseUrlIdx !== -1 && argv[baseUrlIdx + 1]) process.env.PERF_BASE_URL = argv[baseUrlIdx + 1];
+let stages = argv.filter((a) => ALL.includes(a));
+if (!stages.length) stages = ALL;
+
+const RUNNERS = {
+  bundle: () => import("./stages/bundle.mjs").then((m) => m.runBundle()),
+  lighthouse: () => import("./stages/lighthouse.mjs").then((m) => m.runLighthouse()),
+  backend: () => import("./stages/backend.mjs").then((m) => m.runBackend()),
+  wsload: () => import("./stages/wsload.mjs").then((m) => m.runWsload()),
+};
+
+function statusFor(name, val, def, baseVal) {
+  if (!def) return { regressed: false, label: "info" };
+  let label = "ok";
+  let regressed = false;
+  if (baseVal === null || baseVal === undefined) {
+    label = "new";
+  } else if (baseVal !== 0) {
+    const deltaPct = ((val - baseVal) / Math.abs(baseVal)) * 100;
+    const worse = def.lowerIsBetter ? deltaPct > 0 : deltaPct < 0;
+    const mag = Math.abs(deltaPct);
+    if (worse && mag > def.regressionPct) {
+      label = "REGRESSED";
+      regressed = true;
+    } else if (!worse && mag > 1) {
+      label = "improved";
+    }
+  }
+  return { regressed, label };
+}
+
+function deltaStr(val, baseVal) {
+  if (baseVal === null || baseVal === undefined || baseVal === 0) return "—";
+  const d = ((val - baseVal) / Math.abs(baseVal)) * 100;
+  const s = d >= 0 ? "+" : "";
+  return `${s}${d.toFixed(1)}%`;
+}
+
+function budgetStr(val, def) {
+  if (!def) return "—";
+  const ok = def.lowerIsBetter ? val <= def.budget : val >= def.budget;
+  return `${def.budget}${def.unit || ""} ${ok ? "✅" : "⚠️"}`;
+}
+
+async function main() {
+  const budgets = (await loadJSON(join(HERE, "budgets.json"), { metrics: {} })).metrics;
+  const baseline = await loadJSON(join(HERE, "baseline.json"), { metrics: {} });
+  const baseMetrics = baseline.metrics || {};
+
+  const metrics = {};
+  const notes = [];
+  for (const stage of stages) {
+    process.stderr.write(`▶ ${stage}…\n`);
+    try {
+      const out = await RUNNERS[stage]();
+      Object.assign(metrics, out.metrics || {});
+      (out.notes || []).forEach((n) => notes.push(n));
+    } catch (e) {
+      notes.push(`${stage}: ERROR — ${e?.message || e}`);
+    }
+  }
+
+  // Build report.
+  const rows = [];
+  let regressions = 0;
+  const names = Object.keys(metrics).sort();
+  for (const name of names) {
+    const val = metrics[name];
+    const def = budgets[name];
+    const baseVal = baseMetrics[name] ?? null;
+    const st = statusFor(name, val, def, baseVal);
+    if (st.regressed && def?.gate) regressions++;
+    rows.push({
+      label: def?.label || name,
+      val: `${val}${def?.unit || ""}`,
+      budget: budgetStr(val, def),
+      base: baseVal === null || baseVal === undefined ? "—" : `${baseVal}${def?.unit || ""}`,
+      delta: deltaStr(val, baseVal),
+      status: st.label,
+      gate: def?.gate ? "🔒" : "",
+    });
+  }
+
+  const ts = new Date().toISOString();
+  let md = `## ⏱️ Performance report\n\n`;
+  md += `_${ts} · stages: ${stages.join(", ")} · baseline: ${baseline.updatedAt || "none"}_\n\n`;
+  if (rows.length) {
+    md += `| Metric | Value | Budget | Baseline | Δ | Status |\n|---|--:|--:|--:|--:|:--|\n`;
+    for (const r of rows) {
+      md += `| ${r.gate} ${r.label} | ${r.val} | ${r.budget} | ${r.base} | ${r.delta} | ${r.status} |\n`;
+    }
+  } else {
+    md += `_No metrics collected._\n`;
+  }
+  md += `\n${regressions ? `**⚠️ ${regressions} gated metric(s) REGRESSED vs baseline.**` : `No gated regressions vs baseline.`}\n`;
+  if (notes.length) md += `\n<details><summary>Run notes</summary>\n\n${notes.map((n) => `- ${n}`).join("\n")}\n\n</details>\n`;
+  md += `\n🔒 = would block in \`--strict\` mode. Report-only otherwise.\n`;
+
+  console.log("\n" + md);
+  await saveJSON(join(HERE, "results.json"), { ts, stages, metrics, notes });
+  const { writeFile, appendFile } = await import("node:fs/promises");
+  await writeFile(join(HERE, "report.md"), md);
+  if (process.env.GITHUB_STEP_SUMMARY) await appendFile(process.env.GITHUB_STEP_SUMMARY, md);
+
+  if (flags.has("--update-baseline")) {
+    const next = { updatedAt: ts, metrics };
+    await saveJSON(join(HERE, "baseline.json"), next);
+    process.stderr.write(`✓ baseline updated (${Object.keys(metrics).length} metrics)\n`);
+  }
+
+  process.exit(flags.has("--strict") && regressions ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(0); // report-only: never break the build on harness error
+});

--- a/perf/stages/backend.mjs
+++ b/perf/stages/backend.mjs
@@ -1,0 +1,139 @@
+// Backend latency stage (CI benchmark against an ephemeral stack).
+// Seeds a fresh workspace via the real signup API, then measures:
+//   - api_post_message p50/p95  : POST /conversations/:id/messages round-trip
+//   - ws_fanout p95             : time from POST to receiving message.new on a
+//                                 subscribed /events socket (server-side proxy
+//                                 for §16's send-to-render budget)
+// Fully resilient: any seed/connect failure -> SKIPPED note, never throws.
+import WebSocket from "ws";
+import { percentile, round, sleep, waitFor } from "../lib/util.mjs";
+
+const BASE = (process.env.PERF_BASE_URL || "http://localhost:8080").replace(/\/$/, "");
+const API = `${BASE}/api`;
+const N = Number(process.env.PERF_BACKEND_SAMPLES || 60);
+
+function uniqueEmail() {
+  return `perf_${Date.now()}_${Math.floor(Math.random() * 1e6)}@perf.local`;
+}
+
+function cookieFrom(res) {
+  const all = typeof res.headers.getSetCookie === "function" ? res.headers.getSetCookie() : [];
+  const cc = all.find((c) => c.startsWith("cc_session="));
+  return cc ? cc.split(";")[0] : null;
+}
+
+async function postMessage(cookie, convId, bodyMd) {
+  // Field name tolerance: the API has used both bodyMd and body across history.
+  for (const payload of [{ bodyMd }, { body: bodyMd }]) {
+    const res = await fetch(`${API}/conversations/${convId}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify(payload),
+    });
+    if (res.ok) return res;
+    if (res.status !== 400) return res; // a non-validation error won't be fixed by the other field
+  }
+  return null;
+}
+
+export async function runBackend() {
+  const metrics = {};
+  const notes = [];
+
+  // 1. Stack reachable?
+  try {
+    await waitFor(
+      async () => {
+        const r = await fetch(`${API}/me`, { method: "GET" }).catch(() => null);
+        return r && (r.ok || r.status === 401); // 401 = up but unauthenticated
+      },
+      { timeoutMs: 90000, intervalMs: 2000, label: "api up" },
+    );
+  } catch (e) {
+    return { metrics, notes: [`backend: SKIPPED — API not reachable at ${API} (${e.message})`] };
+  }
+
+  // 2. Seed a workspace.
+  let cookie, convId;
+  try {
+    const res = await fetch(`${API}/auth/signup`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: uniqueEmail(),
+        password: "perftest12345",
+        name: "Perf Bench",
+        workspaceName: "Perf Bench WS",
+      }),
+    });
+    if (!res.ok) throw new Error(`signup ${res.status}`);
+    cookie = cookieFrom(res);
+    if (!cookie) throw new Error("no cc_session cookie returned");
+    const convs = await (await fetch(`${API}/conversations`, { headers: { cookie } })).json();
+    const list = Array.isArray(convs) ? convs : convs.conversations || convs.items || [];
+    convId = (list.find((c) => c.kind === "channel") || list[0])?.id;
+    if (!convId) throw new Error("no conversation found after signup");
+  } catch (e) {
+    return { metrics, notes: [`backend: SKIPPED — seed failed (${e.message})`] };
+  }
+
+  // 3. Connect a subscriber socket for fan-out timing.
+  const wsBase = BASE.replace(/^http/, "ws");
+  let ws, wsReady = false;
+  const pending = new Map(); // nonce -> postTimestamp
+  const fanout = [];
+  try {
+    ws = new WebSocket(`${wsBase}/events`, { headers: { cookie } });
+    ws.on("message", (data) => {
+      const txt = data.toString();
+      for (const [nonce, t0] of pending) {
+        if (txt.includes(nonce)) {
+          fanout.push(performance.now() - t0);
+          pending.delete(nonce);
+        }
+      }
+    });
+    await waitFor(() => wsReady || ws.readyState === 1, { timeoutMs: 15000, intervalMs: 250, label: "ws open" });
+    wsReady = true;
+  } catch (e) {
+    notes.push(`backend: ws fan-out skipped — ${e.message}`);
+  }
+
+  // 4. Verify message POST works at all before benchmarking.
+  const probe = await postMessage(cookie, convId, "perf-probe").catch(() => null);
+  if (!probe || !probe.ok) {
+    if (ws) ws.close();
+    return { metrics, notes: [`backend: SKIPPED — message POST failed (${probe ? probe.status : "no response"})`] };
+  }
+
+  // 5. Benchmark.
+  const apiLatencies = [];
+  for (let i = 0; i < N; i++) {
+    const nonce = `perfn-${Date.now()}-${i}-${Math.floor(Math.random() * 1e6)}`;
+    const t0 = performance.now();
+    if (ws && ws.readyState === 1) pending.set(nonce, t0);
+    const res = await postMessage(cookie, convId, `bench ${nonce}`).catch(() => null);
+    const dt = performance.now() - t0;
+    if (res && res.ok) apiLatencies.push(dt);
+    await sleep(15); // keep it sequential and realistic, not a flood
+  }
+  // Give in-flight fan-out events a moment to land.
+  await sleep(1500);
+  if (ws) ws.close();
+
+  if (apiLatencies.length) {
+    metrics.api_post_message_p50_ms = round(percentile(apiLatencies, 50));
+    metrics.api_post_message_p95_ms = round(percentile(apiLatencies, 95));
+    notes.push(`backend: ${apiLatencies.length}/${N} POST samples`);
+  } else {
+    notes.push("backend: no successful POST samples");
+  }
+  if (fanout.length) {
+    metrics.ws_fanout_p95_ms = round(percentile(fanout, 95));
+    notes.push(`backend: ${fanout.length} fan-out samples`);
+  } else if (wsReady) {
+    notes.push("backend: ws connected but received no matching fan-out events");
+  }
+
+  return { metrics, notes };
+}

--- a/perf/stages/bundle.mjs
+++ b/perf/stages/bundle.mjs
@@ -1,0 +1,71 @@
+// Bundle-size stage: measures the gzipped weight of the INITIAL client payload
+// (the entry script + every js/css the browser preloads on first paint), parsed
+// straight out of the built dist/index.html. Lazy/route-split chunks are not
+// counted toward the initial budget but are reported as a total for context.
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { gzipKB, round } from "../lib/util.mjs";
+
+const WEB_DIST = new URL("../../web/dist/", import.meta.url).pathname;
+
+async function gzipOf(relPath) {
+  const buf = await readFile(join(WEB_DIST, relPath.replace(/^\//, "")));
+  return gzipKB(buf);
+}
+
+// Every local .js/.css referenced by a src= or href= attribute in index.html —
+// i.e. the entry chunk, its stylesheets, and modulepreloaded chunks. Order- and
+// attribute-agnostic (the previous hand-rolled tag regex missed the entry).
+function initialRefs(html) {
+  const refs = new Set();
+  const re = /(?:src|href)="(\/[^"?]+\.(?:js|css))(?:\?[^"]*)?"/g;
+  let m;
+  while ((m = re.exec(html))) refs.add(m[1]);
+  return [...refs];
+}
+
+async function walkAssets(dir, base = "") {
+  const out = [];
+  for (const e of await readdir(join(WEB_DIST, dir), { withFileTypes: true }).catch(() => [])) {
+    const rel = join(base, e.name);
+    if (e.isDirectory()) out.push(...(await walkAssets(join(dir, e.name), rel)));
+    else if (e.name.endsWith(".js") || e.name.endsWith(".css")) out.push(rel);
+  }
+  return out;
+}
+
+export async function runBundle() {
+  const metrics = {};
+  const notes = [];
+  let indexHtml;
+  try {
+    indexHtml = await readFile(join(WEB_DIST, "index.html"), "utf8");
+  } catch {
+    return { metrics, notes: ["bundle: SKIPPED — web/dist/index.html not found (run `npm --prefix web run build` first)"] };
+  }
+
+  const refs = initialRefs(indexHtml);
+  let initialKB = 0;
+  for (const ref of refs) {
+    try {
+      initialKB += await gzipOf(ref);
+    } catch {
+      notes.push(`bundle: could not read referenced asset ${ref}`);
+    }
+  }
+  metrics.client_bundle_gzip_kb = round(initialKB, 1);
+  notes.push(`bundle: initial payload = ${refs.length} asset(s): ${refs.join(", ")}`);
+
+  // Informational: total gzipped js/css shipped (incl. lazy/route-split chunks).
+  let totalKB = 0;
+  for (const rel of await walkAssets("")) {
+    try {
+      totalKB += await gzipOf(rel);
+    } catch {
+      /* informational only */
+    }
+  }
+  if (totalKB) metrics.client_total_gzip_kb_info = round(totalKB, 1);
+
+  return { metrics, notes };
+}

--- a/perf/stages/lighthouse.mjs
+++ b/perf/stages/lighthouse.mjs
@@ -1,0 +1,61 @@
+// Lighthouse stage: serves the built web app and audits the two public,
+// non-auth-walled pages (/login, /signup). Captures the §16 paint/interaction
+// metrics. The authed chat shell is intentionally out of scope here (would need
+// a seeded login flow) — see README.
+import { serveStatic } from "../lib/serve.mjs";
+import { round } from "../lib/util.mjs";
+
+const WEB_DIST = new URL("../../web/dist/", import.meta.url).pathname;
+
+async function audit(url) {
+  // Imported lazily so `bundle`/`backend`-only runs don't pay the cost.
+  const lighthouse = (await import("lighthouse")).default;
+  const chromeLauncher = await import("chrome-launcher");
+  const chrome = await chromeLauncher.launch({
+    chromeFlags: ["--headless=new", "--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+  });
+  try {
+    const res = await lighthouse(
+      url,
+      { port: chrome.port, output: "json", logLevel: "error", onlyCategories: ["performance"] },
+      { extends: "lighthouse:default", settings: { formFactor: "desktop", screenEmulation: { disabled: true } } },
+    );
+    const a = res.lhr.audits;
+    return {
+      fcp: a["first-contentful-paint"]?.numericValue ?? null,
+      lcp: a["largest-contentful-paint"]?.numericValue ?? null,
+      tbt: a["total-blocking-time"]?.numericValue ?? null,
+      tti: a["interactive"]?.numericValue ?? null,
+      score: (res.lhr.categories.performance?.score ?? 0) * 100,
+    };
+  } finally {
+    await chrome.kill();
+  }
+}
+
+export async function runLighthouse() {
+  const metrics = {};
+  const notes = [];
+  let server;
+  try {
+    server = await serveStatic(WEB_DIST, 4180);
+  } catch (e) {
+    return { metrics, notes: [`lighthouse: SKIPPED — could not serve web/dist (${e.message})`] };
+  }
+  try {
+    const login = await audit(`${server.url}/login`);
+    metrics.fcp_login_ms = round(login.fcp);
+    metrics.lcp_login_ms = round(login.lcp);
+    metrics.tbt_login_ms = round(login.tbt);
+    metrics.tti_login_ms = round(login.tti);
+    metrics.perf_score_login = round(login.score);
+
+    const signup = await audit(`${server.url}/signup`);
+    metrics.fcp_signup_ms = round(signup.fcp);
+  } catch (e) {
+    notes.push(`lighthouse: SKIPPED — ${e.message} (is Chrome installed?)`);
+  } finally {
+    await server.close();
+  }
+  return { metrics, notes };
+}

--- a/perf/stages/wsload.mjs
+++ b/perf/stages/wsload.mjs
@@ -1,0 +1,100 @@
+// WS throughput stage. Opens C subscriber sockets on one channel, posts M
+// messages, and measures total delivered events/sec (fan-out amplification).
+//
+// HONEST SCOPE: this is a single-box, single-poster, scaled-down proxy for
+// §16's ">50,000 msgs/sec/core" budget — it will NOT hit 50k from one CI poster
+// and a handful of connections. It produces a stable, regression-trackable
+// throughput number; treat the absolute 50k budget as aspirational until a real
+// multi-node load generator (k6/autocannon) is wired up. Reported, not gated.
+import WebSocket from "ws";
+import { round, sleep, waitFor } from "../lib/util.mjs";
+
+const BASE = (process.env.PERF_BASE_URL || "http://localhost:8080").replace(/\/$/, "");
+const API = `${BASE}/api`;
+const CONNS = Number(process.env.PERF_WS_CONNS || 25);
+const MSGS = Number(process.env.PERF_WS_MSGS || 200);
+
+function cookieFrom(res) {
+  const all = typeof res.headers.getSetCookie === "function" ? res.headers.getSetCookie() : [];
+  const cc = all.find((c) => c.startsWith("cc_session="));
+  return cc ? cc.split(";")[0] : null;
+}
+
+export async function runWsload() {
+  const metrics = {};
+  const notes = [];
+
+  let cookie, convId;
+  try {
+    const res = await fetch(`${API}/auth/signup`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: `perfws_${Date.now()}_${Math.floor(Math.random() * 1e6)}@perf.local`,
+        password: "perftest12345",
+        name: "Perf WS",
+        workspaceName: "Perf WS Load",
+      }),
+    });
+    if (!res.ok) throw new Error(`signup ${res.status}`);
+    cookie = cookieFrom(res);
+    const convs = await (await fetch(`${API}/conversations`, { headers: { cookie } })).json();
+    const list = Array.isArray(convs) ? convs : convs.conversations || convs.items || [];
+    convId = (list.find((c) => c.kind === "channel") || list[0])?.id;
+    if (!cookie || !convId) throw new Error("seed incomplete");
+  } catch (e) {
+    return { metrics, notes: [`wsload: SKIPPED — seed failed (${e.message})`] };
+  }
+
+  const wsBase = BASE.replace(/^http/, "ws");
+  const sockets = [];
+  let delivered = 0;
+  try {
+    for (let i = 0; i < CONNS; i++) {
+      const ws = new WebSocket(`${wsBase}/events`, { headers: { cookie } });
+      ws.on("message", (d) => {
+        if (d.toString().includes("message.new")) delivered++;
+      });
+      sockets.push(ws);
+    }
+    await waitFor(() => sockets.every((s) => s.readyState === 1), {
+      timeoutMs: 20000,
+      intervalMs: 250,
+      label: "all ws open",
+    });
+  } catch (e) {
+    sockets.forEach((s) => s.close());
+    return { metrics, notes: [`wsload: SKIPPED — could not open ${CONNS} sockets (${e.message})`] };
+  }
+
+  async function post(n) {
+    await fetch(`${API}/conversations/${convId}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify({ bodyMd: `load ${n}` }),
+    }).catch(() => {});
+  }
+
+  const t0 = performance.now();
+  // Fire in small concurrent batches to push the fan-out without overwhelming
+  // the single poster's event loop.
+  const BATCH = 10;
+  for (let i = 0; i < MSGS; i += BATCH) {
+    await Promise.all(Array.from({ length: Math.min(BATCH, MSGS - i) }, (_, k) => post(i + k)));
+  }
+  // Drain: wait until delivery plateaus.
+  let last = -1;
+  for (let i = 0; i < 20 && delivered !== last; i++) {
+    last = delivered;
+    await sleep(500);
+  }
+  const elapsedSec = (performance.now() - t0) / 1000;
+  sockets.forEach((s) => s.close());
+
+  const expected = MSGS * CONNS;
+  metrics.ws_throughput_msgs_per_sec = round(delivered / elapsedSec, 0);
+  notes.push(
+    `wsload: ${delivered}/${expected} events delivered across ${CONNS} conns in ${round(elapsedSec, 2)}s (scaled proxy, not the 50k/core budget)`,
+  );
+  return { metrics, notes };
+}


### PR DESCRIPTION
Implements PLAN.html **§16 "Measurement, not vibes"** end-to-end as a **report-only, regression-vs-baseline** system (never blocks a merge).

## What's in it
`perf/` harness (zero-config Node, runnable locally or in CI) with four stages:
- **bundle** — gzip weight of the initial client payload parsed from `dist/index.html`
- **lighthouse** — FCP/LCP/TBT/TTI/score on the public `/login` + `/signup`
- **backend** — `POST /messages` p50/p95 + WS fan-out p95 against an ephemeral stack (seeds via the real signup API)
- **wsload** — delivered WS throughput across N subscriber sockets (honest scaled-down proxy for the >50k/core budget)

`run.mjs` diffs every metric against `perf/baseline.json` (10%/20% regression rule from §16), prints a markdown report, writes it to the GH step summary, and upserts one PR comment. `budgets.json` carries the §16 numbers; `gate:true` marks what a future `--strict` run would fail.

`.github/workflows/perf.yml` runs on each PR/push: builds web, boots an ephemeral stack (api on `:3000`, no Caddy/TLS via `perf/compose.ci.yml`), runs all stages, uploads the report. Always exits 0.

## Decisions baked in
- RUM (web-vitals) **deferred** (your call); backend metrics are a **CI benchmark**, not prod instrumentation; Lighthouse targets **public pages + bundle budgets** (no auth automation).

## ⚠️ Finding the harness already surfaced
The initial client bundle is **~203 kB gzip — over the §16 180 kB budget** (it's a single un-split chunk; `dompurify` + the whole app ship together). Flagged, not fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)