### PR TITLE
Fix task board 500: add task_comments.attachments_json migration

### DIFF
--- a/api/migrations/0011_task_comment_attachments.sql
+++ b/api/migrations/0011_task_comment_attachments.sql
@@ -1,0 +1,9 @@
+-- schema.ts declares task_comments.attachments_json and task_comments.parent_id
+-- (and getTaskDetail/listTaskComments select both), but no migration ever
+-- created them — 0005_tasks created task_comments without them. Result: every
+-- GET /api/tasks/:id 500s with `column "attachments_json" does not exist`.
+-- Add the missing columns to match the schema. Idempotent (IF NOT EXISTS) so it
+-- is safe on databases where they were hand-added as a hotfix.
+ALTER TABLE "task_comments" ADD COLUMN IF NOT EXISTS "attachments_json" jsonb DEFAULT '[]'::jsonb NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "task_comments" ADD COLUMN IF NOT EXISTS "parent_id" varchar(32);

--- a/api/migrations/meta/_journal.json
+++ b/api/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777130000000,
       "tag": "0010_notifications",
       "breakpoints": false
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777140000000,
+      "tag": "0011_task_comment_attachments",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Bug
Clicking a task card → `GET /api/tasks/:id` **500**: `column "attachments_json" does not exist`. Same error hit `/api/agent-api/tasks/:id`, so agents' task reads were broken too.

## Root cause
`schema.ts` and `tasks-core.ts` reference `task_comments.attachments_json` (and `parent_id`), but `0005_tasks` created the table **without** those columns and no later migration added them. Schema↔DB diverged on **every** deploy — a real repo bug, not just box drift.

## Fix
New idempotent migration **0011_task_comment_attachments** (`ADD COLUMN IF NOT EXISTS`), registered in the drizzle journal so `migrate.js` applies it.

## Live status
The Hetzner DB was hot-patched with the same two columns and **verified**: `GET /api/tasks/:id` now returns 200 with `{task, subtasks, links, comments, activity}` for multiple task ids. This PR makes the fix permanent in the repo so fresh deploys are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)