### PR TITLE
Scope agent reads and file serving to the caller's workspace

### DIFF
--- a/api/src/routes/agent-api.ts
+++ b/api/src/routes/agent-api.ts
@@ -46,6 +46,7 @@ declare module "fastify" {
     agentCtx?: {
       agentId: string;
       memberId: string;
+      workspaceId: string;
       handle: string;
     };
   }
@@ -72,10 +73,17 @@ async function requireAgentToken(req: FastifyRequest, reply: FastifyReply): Prom
     reply.code(500).send({ error: "agent_member_missing" });
     return;
   }
-  req.agentCtx = { agentId: a.id, memberId: m.id, handle: a.handle };
+  req.agentCtx = { agentId: a.id, memberId: m.id, workspaceId: m.workspaceId, handle: a.handle };
 }
 
-async function agentVisibleConversations(memberId: string): Promise<string[]> {
+// Conversations an agent may read: the ones it has joined, plus every public
+// channel IN ITS OWN WORKSPACE. The workspace filter on the public-channel
+// query is load-bearing — without it an agent token from one workspace could
+// enumerate and read public channels belonging to every other workspace.
+async function agentVisibleConversations(
+  memberId: string,
+  workspaceId: string,
+): Promise<string[]> {
   const rows = await db
     .select({ id: conversationMembers.conversationId })
     .from(conversationMembers)
@@ -84,7 +92,13 @@ async function agentVisibleConversations(memberId: string): Promise<string[]> {
   const pubs = await db
     .select({ id: conversations.id })
     .from(conversations)
-    .where(and(eq(conversations.kind, "channel"), eq(conversations.isPrivate, false)));
+    .where(
+      and(
+        eq(conversations.workspaceId, workspaceId),
+        eq(conversations.kind, "channel"),
+        eq(conversations.isPrivate, false),
+      ),
+    );
   const set = new Set([...joined, ...pubs.map((p) => p.id)]);
   return Array.from(set);
 }
@@ -408,7 +422,10 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
 
   // GET /agent-api/conversations — list all convs I can see
   app.get("/agent-api/conversations", async (req) => {
-    const convIds = await agentVisibleConversations(req.agentCtx!.memberId);
+    const convIds = await agentVisibleConversations(
+      req.agentCtx!.memberId,
+      req.agentCtx!.workspaceId,
+    );
     if (!convIds.length) return { conversations: [] };
     const rows = await db.select().from(conversations).where(inArray(conversations.id, convIds));
     return {
@@ -432,7 +449,10 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
       limit?: string;
     };
     if (!q.conversationId) return reply.code(400).send({ error: "conversationId_required" });
-    const convIds = await agentVisibleConversations(req.agentCtx!.memberId);
+    const convIds = await agentVisibleConversations(
+      req.agentCtx!.memberId,
+      req.agentCtx!.workspaceId,
+    );
     if (!convIds.includes(q.conversationId))
       return reply.code(403).send({ error: "not_visible" });
 
@@ -460,7 +480,10 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
     if (!q.messageId) return reply.code(400).send({ error: "messageId_required" });
     const [trig] = await db.select().from(messages).where(eq(messages.id, q.messageId)).limit(1);
     if (!trig) return reply.code(404).send({ error: "not_found" });
-    const convIds = await agentVisibleConversations(req.agentCtx!.memberId);
+    const convIds = await agentVisibleConversations(
+      req.agentCtx!.memberId,
+      req.agentCtx!.workspaceId,
+    );
     if (!convIds.includes(trig.conversationId))
       return reply.code(403).send({ error: "not_visible" });
     const rootId = trig.parentId ?? trig.id;
@@ -484,9 +507,17 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
     if (!q.q || q.q.length < 2) return reply.code(400).send({ error: "q_too_short" });
     const limit = Math.min(50, Math.max(1, Number(q.limit ?? 20)));
 
-    const convIds = q.conversationId
-      ? [q.conversationId]
-      : await agentVisibleConversations(req.agentCtx!.memberId);
+    // Always resolve what this agent may see, then restrict to a caller-supplied
+    // conversationId only if it is actually in that set. Trusting the supplied
+    // id verbatim would let an agent search any conversation by id — including
+    // private channels and DMs in other workspaces.
+    const visible = await agentVisibleConversations(
+      req.agentCtx!.memberId,
+      req.agentCtx!.workspaceId,
+    );
+    if (q.conversationId && !visible.includes(q.conversationId))
+      return reply.code(403).send({ error: "not_visible" });
+    const convIds = q.conversationId ? [q.conversationId] : visible;
     if (!convIds.length) return { matches: [] };
 
     const rows = await db

--- a/api/src/routes/files.ts
+++ b/api/src/routes/files.ts
@@ -24,7 +24,23 @@ interface AttachmentRow {
   url: string;
 }
 
-// Accept either a human session cookie OR an agent bearer token.
+// The principal behind a /files/* request — either a human session or an agent
+// bearer token — resolved to the member + workspace we authorize blob reads
+// against. memberId is null for an agent whose member row is missing (treated
+// as having no joined conversations).
+declare module "fastify" {
+  interface FastifyRequest {
+    filePrincipal?: {
+      kind: "user" | "agent";
+      memberId: string | null;
+      workspaceId: string;
+    };
+  }
+}
+
+// Accept either a human session cookie OR an agent bearer token, and resolve
+// the principal's member + workspace so the handler can authorize the specific
+// blob being requested (a valid token alone must NOT grant access to any key).
 async function requireSessionOrAgent(
   req: FastifyRequest,
   reply: FastifyReply,
@@ -33,15 +49,89 @@ async function requireSessionOrAgent(
   const bearer = header.replace(/^Bearer\s+/i, "");
   if (bearer) {
     const [a] = await db.select().from(agents).where(eq(agents.botToken, bearer)).limit(1);
-    if (a) return; // valid agent — allow
+    if (a) {
+      const [m] = await db
+        .select({ id: members.id })
+        .from(members)
+        .where(and(eq(members.kind, "agent"), eq(members.refId, a.id)))
+        .limit(1);
+      req.filePrincipal = { kind: "agent", memberId: m?.id ?? null, workspaceId: a.workspaceId };
+      return;
+    }
   }
   const cookies = (req as unknown as { cookies?: Record<string, string> }).cookies ?? {};
   const sid = cookies["cc_session"];
   if (sid) {
     const s = await loadSession(sid);
-    if (s) return;
+    if (s && s.workspaceId && s.memberId) {
+      req.filePrincipal = { kind: "user", memberId: s.memberId, workspaceId: s.workspaceId };
+      return;
+    }
   }
   reply.code(401).send({ error: "unauthorized" });
+}
+
+// True if `key` is referenced by a message or task-comment the principal can
+// actually see: a message in a conversation they've joined (or a public channel)
+// within their own workspace, or a task-comment on a task in their workspace.
+async function keyVisibleToPrincipal(
+  key: string,
+  principal: { memberId: string | null; workspaceId: string },
+): Promise<boolean> {
+  const probe = JSON.stringify([{ key }]);
+
+  // Messages that reference this key.
+  const msgRows = await db
+    .select({ conversationId: messages.conversationId })
+    .from(messages)
+    .where(dsql`${messages.attachmentsJson} @> ${probe}::jsonb` as never);
+  if (msgRows.length) {
+    const convIds = Array.from(new Set(msgRows.map((r) => r.conversationId)));
+    const convRows = await db
+      .select({
+        id: conversations.id,
+        workspaceId: conversations.workspaceId,
+        kind: conversations.kind,
+        isPrivate: conversations.isPrivate,
+      })
+      .from(conversations)
+      .where(inArray(conversations.id, convIds));
+    const joined = new Set<string>();
+    if (principal.memberId) {
+      const jm = await db
+        .select({ conversationId: conversationMembers.conversationId })
+        .from(conversationMembers)
+        .where(
+          and(
+            eq(conversationMembers.memberId, principal.memberId),
+            inArray(conversationMembers.conversationId, convIds),
+          ),
+        );
+      for (const r of jm) joined.add(r.conversationId);
+    }
+    for (const c of convRows) {
+      if (c.workspaceId !== principal.workspaceId) continue;
+      if (joined.has(c.id)) return true;
+      if (c.kind === "channel" && !c.isPrivate) return true;
+    }
+  }
+
+  // Task-comment attachments are workspace-scoped (same model as the board).
+  const tcRows = await db
+    .select({ taskId: taskComments.taskId })
+    .from(taskComments)
+    .where(dsql`${taskComments.attachmentsJson} @> ${probe}::jsonb` as never);
+  if (tcRows.length) {
+    const taskIds = Array.from(new Set(tcRows.map((r) => r.taskId)));
+    const [t] = await db
+      .select({ id: tasks.id })
+      .from(tasks)
+      .where(and(inArray(tasks.id, taskIds), eq(tasks.workspaceId, principal.workspaceId)))
+      .limit(1);
+    if (t) return true;
+  }
+
+  return false;
 }
 
 // File serving: session cookie (web UI) OR agent bearer token (agent runtime).
@@ -51,6 +141,12 @@ export async function fileServeRoutes(app: FastifyInstance): Promise<void> {
   app.get("/files/*", async (req, reply) => {
     const key = (req.params as { "*": string })["*"];
     if (!key) return reply.code(400).send({ error: "no_key" });
+    // Authorize the specific blob against the principal's visible content —
+    // a valid token is necessary but not sufficient. 404 (not 403) so we don't
+    // confirm a key exists to a caller who can't see it.
+    const principal = req.filePrincipal!;
+    if (!(await keyVisibleToPrincipal(key, principal)))
+      return reply.code(404).send({ error: "not_found" });
     const st = await statObject(key);
     if (!st || !st.isFile()) return reply.code(404).send({ error: "not_found" });
     const ct = guessContentType(key);


### PR DESCRIPTION
Fixes a cross-workspace authorization issue reported by an external researcher (Bertie). An agent bearer token from one workspace could read data belonging to other workspaces via three paths:

1. **`agentVisibleConversations()`** unioned joined conversations with *every* non-private channel in the DB, ignoring workspace → an agent could enumerate/read public channels of other workspaces (`/agent-api/conversations`, `/messages`, `/thread`). Now filtered by `conversations.workspaceId`; `agentCtx` carries `workspaceId`.
2. **`GET /agent-api/search`** trusted a caller-supplied `conversationId` with no visibility check — the widest hole, allowing reads of *any* conversation by id including private channels/DMs in other workspaces. Now intersected against the agent's visible set (403 otherwise).
3. **`GET /files/*`** authorized the principal but not the object, so leaked attachment keys were directly downloadable. Now authorizes each key against a message or task-comment visible to the principal in its workspace (404 to avoid existence disclosure).

No schema change. API typechecks and builds clean.

Follow-up: repo has no unit-test runner yet; two-workspace regression tests (channels/search/attachments) recommended once test infra lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)