### PR TITLE
Stop @mentions from pulling agents into private DMs

### DIFF
--- a/api/src/agents/mention-triggers.ts
+++ b/api/src/agents/mention-triggers.ts
@@ -193,9 +193,11 @@ export async function fireMentionTriggers(params: {
       .limit(1);
     if (mm?.kind !== "agent") continue;
 
-    // Auto-join the agent to the conversation on mention (public channels
-    // and DMs). Private channels require a pre-existing invite.
-    if (conv.kind !== "channel" || !conv.isPrivate) {
+    // Auto-join the agent to the conversation on mention ONLY in a public
+    // channel. DMs and private channels have fixed membership — mentioning a
+    // non-participant there must not pull them in (DMs are private to their
+    // participants).
+    if (conv.kind === "channel" && !conv.isPrivate) {
       await db
         .insert(conversationMembers)
         .values({
@@ -206,6 +208,23 @@ export async function fireMentionTriggers(params: {
         .onConflictDoNothing();
     }
     if (firedForAgent.has(mm.refId)) continue;
+
+    // Never trigger an agent that isn't a member of this conversation. In a
+    // public channel the auto-join above guarantees membership; in a DM or
+    // private channel this gates out @mentions of agents who don't belong,
+    // so an agent can't be tagged into a private DM it can't see. (DM
+    // participant agents are still woken by the conv.kind === "dm" block.)
+    const [mentionIsMember] = await db
+      .select({ id: conversationMembers.memberId })
+      .from(conversationMembers)
+      .where(
+        and(
+          eq(conversationMembers.conversationId, conversationId),
+          eq(conversationMembers.memberId, mentionMemberId),
+        ),
+      )
+      .limit(1);
+    if (!mentionIsMember) continue;
 
     // Loop-breaker: if author is an agent and the mentioned agent has
     // already posted in this conversation within COOLDOWN_MS, they've
@@ -294,12 +313,21 @@ export async function fireMentionTriggers(params: {
     }
     participating.delete(authorMemberId);
     if (participating.size) {
+      // Only wake thread participants who are actually members of this
+      // conversation — a recorded @mention of a non-member (e.g. an agent
+      // tagged in a private DM) must not pull them in via the thread path.
+      const convMemberRows = await db
+        .select({ memberId: conversationMembers.memberId })
+        .from(conversationMembers)
+        .where(eq(conversationMembers.conversationId, conversationId));
+      const convMemberSet = new Set(convMemberRows.map((r) => r.memberId));
       const ptMembers = await db
         .select()
         .from(members)
         .where(inArray(members.id, Array.from(participating)));
       for (const pm of ptMembers) {
         if (pm.kind !== "agent") continue;
+        if (!convMemberSet.has(pm.id)) continue;
         if (firedForAgent.has(pm.refId)) continue;
         // Same loop-breaker as direct mentions: if the author is an agent
         // and this thread participant has posted in the conversation

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -205,12 +205,30 @@ export default async function messageRoutes(app: FastifyInstance): Promise<void>
       for (const mentionMemberId of resolvedMentionIds) {
         const [mm2] = await db.select().from(members).where(eq(members.id, mentionMemberId)).limit(1);
         if (mm2?.kind !== "agent") continue;
-        if (conv.kind !== "channel" || !conv.isPrivate) {
+        // Auto-join a mentioned agent ONLY in a public channel. DMs and
+        // private channels have fixed membership — mentioning a non-participant
+        // there must not pull them in (DMs are private to their participants).
+        if (conv.kind === "channel" && !conv.isPrivate) {
           await db
             .insert(conversationMembers)
             .values({ conversationId: convId, memberId: mentionMemberId, role: "member" })
             .onConflictDoNothing();
         }
+        // Never trigger an agent that isn't a member of this conversation. In
+        // a public channel the auto-join above guarantees membership; in a DM
+        // or private channel this gates out @mentions of agents who don't
+        // belong, so an agent can't be tagged into a private DM it can't see.
+        const [mentionIsMember] = await db
+          .select({ id: conversationMembers.memberId })
+          .from(conversationMembers)
+          .where(
+            and(
+              eq(conversationMembers.conversationId, convId),
+              eq(conversationMembers.memberId, mentionMemberId),
+            ),
+          )
+          .limit(1);
+        if (!mentionIsMember) continue;
         firedForAgent.add(mm2.refId);
 
         const isDirect = directMentionIds.includes(mentionMemberId);
@@ -292,12 +310,21 @@ export default async function messageRoutes(app: FastifyInstance): Promise<void>
         }
         participatingMemberIds.delete(memberId);
         if (participatingMemberIds.size) {
+          // Only wake thread participants who are actually members of this
+          // conversation — a recorded @mention of a non-member (e.g. an agent
+          // tagged in a private DM) must not pull them in via the thread path.
+          const convMemberRows = await db
+            .select({ memberId: conversationMembers.memberId })
+            .from(conversationMembers)
+            .where(eq(conversationMembers.conversationId, convId));
+          const convMemberSet = new Set(convMemberRows.map((r) => r.memberId));
           const participatingMembers = await db
             .select()
             .from(members)
             .where(inArray(members.id, Array.from(participatingMemberIds)));
           for (const pm of participatingMembers) {
             if (pm.kind !== "agent") continue;
+            if (!convMemberSet.has(pm.id)) continue;
             if (firedForAgent.has(pm.refId)) continue;
             await enqueueAgentEvent(pm.refId, {
               trigger: "thread_reply",


### PR DESCRIPTION
## Problem
Tagging an agent who isn't a participant of a conversation **auto-joined them and fired a trigger** — including in **private DMs**. So an agent (or user) could `@`-tag a third agent inside a direct-message channel, and that agent would be added to the DM and wake up, even though DMs are private to their participants.

Root cause (in both the human-post path `routes/messages.ts` and the agent-post path `agents/mention-triggers.ts`): the auto-join gate was `conv.kind !== "channel" || !conv.isPrivate`, which is **true for DMs**.

## Fix (both paths)
- Auto-join a mentioned agent **only in a public channel**; DMs and private channels have fixed membership.
- **Never fire a mention trigger for an agent that isn't a member** of the conversation — gates out non-participant tags in DMs/private channels.
- Same membership gate on the **thread-continuation** path, so a stored `@mention` of a non-member can't pull them in via a thread reply.

DM participant agents are unaffected (still woken by the existing `conv.kind === "dm"` trigger). Public-channel mention behaviour is unchanged.

## Testing
- `tsc --noEmit` clean.
- Will verify live: tagging a non-participant agent in a DM no longer adds them or wakes them; the DM's own agent still responds; public-channel @mentions still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)