### PR TITLE
Auto-read notifications on open + show DM names in header

### DIFF
--- a/api/src/routes/notifications.ts
+++ b/api/src/routes/notifications.ts
@@ -89,6 +89,37 @@ export default async function notificationRoutes(app: FastifyInstance): Promise<
     return { ok: true };
   });
 
+  // Mark every unread notification that points at a given conversation read.
+  // Called when the user opens that conversation, so landing on a channel/DM
+  // clears its mention/DM notifications without clicking each one.
+  app.post("/notifications/read-by-conversation", async (req, reply) => {
+    const memberId = req.auth!.memberId!;
+    const Body = z.object({ conversationId: z.string().min(1) });
+    const parsed = Body.safeParse(req.body ?? {});
+    if (!parsed.success) return reply.code(400).send({ error: "conversationId_required" });
+    const rows = await db
+      .update(notifications)
+      .set({ readAt: new Date() })
+      .where(
+        and(
+          eq(notifications.memberId, memberId),
+          eq(notifications.conversationId, parsed.data.conversationId),
+          isNull(notifications.readAt),
+        ),
+      )
+      .returning({ id: notifications.id });
+    // Push a read event per affected row so the bell updates live (reuses the
+    // single-id read handler the client already has). Usually only a handful.
+    for (const r of rows) {
+      await publishToMember(memberId, {
+        type: "notification.read",
+        memberId,
+        notificationId: r.id,
+      });
+    }
+    return { ok: true, count: rows.length };
+  });
+
   // Mark all the caller's notifications read.
   app.post("/notifications/read-all", async (req) => {
     const memberId = req.auth!.memberId!;

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -363,6 +363,20 @@ export function useMarkAllNotificationsRead() {
   });
 }
 
+// Mark every notification for one conversation read — called when the user
+// opens that conversation, so they don't have to click each notification.
+export function useMarkConversationNotificationsRead() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (conversationId: string) =>
+      api.post(`/notifications/read-by-conversation`, { conversationId }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["notifications"] });
+      qc.invalidateQueries({ queryKey: ["notifications", "unread"] });
+    },
+  });
+}
+
 // ─────────────────── Workspace member admin + invites ───────────────────
 
 export interface WorkspaceMemberRow {

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -7,7 +7,7 @@ import ThreadPane from "../components/ThreadPane";
 import AgentActivity from "../components/AgentActivity";
 import Menu from "../components/Menu";
 import Avatar from "../components/Avatar";
-import { useConversation, useConversations, useMessages, usePostMessage, useMe, useMarkRead, useMembersDirectory } from "../lib/hooks";
+import { useConversation, useConversations, useMessages, usePostMessage, useMe, useMarkRead, useMembersDirectory, useMarkConversationNotificationsRead } from "../lib/hooks";
 import { api } from "../api/client";
 import { useBus } from "../state/store";
 import { useQueryClient } from "@tanstack/react-query";
@@ -34,6 +34,14 @@ export default function ChannelPage() {
     markRead();
   }, [id, msgs.data?.messages.length, markRead]);
 
+  // Opening a conversation clears its inbox notifications (mentions + DMs) so
+  // the user doesn't have to click each one in the bell. Fires once per open.
+  const markConvNotifs = useMarkConversationNotificationsRead();
+  useEffect(() => {
+    if (id) markConvNotifs.mutate(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
   const threadMsg = useMemo(
     () =>
       threadConvId === id && threadRootId
@@ -54,6 +62,19 @@ export default function ChannelPage() {
   const memberCount = (conv.data?.members ?? []).length;
   const myRole = (conv.data?.members ?? []).find((m) => m.memberId === me.data?.memberId)?.role;
   const isAdmin = myRole === "admin";
+
+  // DM conversations carry no `name` — title them by the other participant(s),
+  // resolved against the members directory (same source the sidebar uses).
+  // Without this a DM header rendered "# …" instead of the person's name.
+  const dmTitle =
+    c?.kind === "dm"
+      ? ((conv.data?.members ?? [])
+          .map((m) => m.memberId)
+          .filter((mid) => mid !== me.data?.memberId)
+          .map((mid) => dir[mid]?.name)
+          .filter(Boolean)
+          .join(", ") || null)
+      : null;
 
   // `muted` and `archived` live on the per-member conversations LIST row, not
   // on GET /conversations/:id — read them from that cache.
@@ -124,8 +145,14 @@ export default function ChannelPage() {
       <div className="workspace flex-1 min-w-0">
         <header className="chan-head">
           <div className="ch-title">
-            <span className="text-[var(--color-muted)]">#</span>
-            {c?.name ?? "…"}
+            {c?.kind === "dm" ? (
+              <span>{dmTitle ?? "…"}</span>
+            ) : (
+              <>
+                <span className="text-[var(--color-muted)]">#</span>
+                {c?.name ?? "…"}
+              </>
+            )}
           </div>
           {c?.topic && (
             <div className="ch-meta">
@@ -204,7 +231,7 @@ export default function ChannelPage() {
         )}
 
         <Composer
-          placeholder={`Message #${c?.name ?? ""}`}
+          placeholder={c?.kind === "dm" ? `Message ${dmTitle ?? ""}` : `Message #${c?.name ?? ""}`}
           conversationId={id}
           onTyping={() => {
             api.post(`/conversations/${id}/typing`).catch(() => {


### PR DESCRIPTION
Two notification fixes requested by the user.

### 1. Open a conversation → its notifications auto-mark read
Previously you had to click each notification in the bell. New endpoint `POST /notifications/read-by-conversation` marks every unread notification pointing at a conversation as read (and pushes live `notification.read` events so the bell updates). The Channel page calls it on open via the new `useMarkConversationNotificationsRead` hook. Task/approval notifications (no `conversationId`) are untouched.

### 2. DM headers showed "# …"
The header hardcoded a `#` prefix + `conversation.name`, but DMs have no name → rendered `# …`. Now a DM is titled by the **other participant(s)**, resolved from the members directory (the same source the sidebar uses); channels still render `#name`. The composer placeholder follows suit.

### Testing
- API `tsc` clean; web `tsc -b && vite build` clean.
- Will verify live: opening a channel/DM with pending notifications clears them from the bell; DM header shows the person's name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)