### PR TITLE
Persist FreeLLMAPI provider config in Hermes install (#1)

### DIFF
--- a/api/src/routes/agent-install.ts
+++ b/api/src/routes/agent-install.ts
@@ -164,18 +164,32 @@ export default async function agentInstallRoutes(app: FastifyInstance): Promise<
       const configPath = join(hermesHome, "config.yaml");
       if (isFreeApi) {
         // FreeLLMAPI is an OpenAI-compatible endpoint declared under
-        // `custom_providers` in Hermes config, NOT via `hermes auth add`. Replace
-        // the empty `custom_providers: []` placeholder with the user's entry.
-        const patched = tmpl.replace(
-          /^custom_providers:\s*\[\]\s*$/m,
-          [
-            "custom_providers:",
-            "- name: freeapi",
-            `  base_url: ${JSON.stringify(body.apiBaseUrl)}`,
-            `  api_key: ${JSON.stringify(body.apiKey)}`,
-            "  api_mode: chat_completions",
-          ].join("\n"),
-        );
+        // `custom_providers` in Hermes config, NOT via `hermes auth add`.
+        //
+        // Write the FULL desired config ourselves — model.provider,
+        // model.default, AND the custom_providers entry — and do NOT call
+        // `hermes config set` afterwards. Some `nousresearch/hermes-agent`
+        // image builds re-serialise config.yaml on `config set`, which drops
+        // the hand-injected `custom_providers` block and resets the provider to
+        // `auto`, leaving the agent with no inference provider ("No inference
+        // provider configured…"). Writing the final file directly is
+        // image-version-agnostic and needs no extra docker runs. See issue #1.
+        let patched = tmpl
+          .replace(/^(model:\n {2}default:).*$/m, `$1 ${body.model ?? "auto"}`)
+          .replace(/^( {2}provider:).*$/m, "$1 custom:freeapi");
+        const block = [
+          "custom_providers:",
+          "- name: freeapi",
+          `  base_url: ${JSON.stringify(body.apiBaseUrl)}`,
+          `  api_key: ${JSON.stringify(body.apiKey)}`,
+          "  api_mode: chat_completions",
+        ].join("\n");
+        // Replace the `custom_providers: []` placeholder if present, otherwise
+        // append. A silent regex no-op on template drift was a second way the
+        // provider config went missing, so never assume the placeholder exists.
+        patched = /^custom_providers:\s*\[\]\s*$/m.test(patched)
+          ? patched.replace(/^custom_providers:\s*\[\]\s*$/m, block)
+          : `${patched.trimEnd()}\n${block}\n`;
         await fs.writeFile(configPath, patched);
       } else {
         await fs.writeFile(configPath, tmpl);
@@ -190,22 +204,25 @@ export default async function agentInstallRoutes(app: FastifyInstance): Promise<
           ...(body.apiKeyLabel ? ["--label", body.apiKeyLabel] : []),
         ]);
         await runCmd(authCmd.cmd, authCmd.args, authCmd.env);
-      }
-      const setProviderCmd = buildHermesCommand(hermesHome, [
-        "config",
-        "set",
-        "model.provider",
-        body.provider,
-      ]);
-      await runCmd(setProviderCmd.cmd, setProviderCmd.args, setProviderCmd.env);
-      if (body.model) {
-        const setModelCmd = buildHermesCommand(hermesHome, [
+        // hosted-provider path still uses `hermes config set` — these providers
+        // are stored in the auth keyring, not custom_providers, so there's no
+        // hand-injected block for a re-serialise to clobber.
+        const setProviderCmd = buildHermesCommand(hermesHome, [
           "config",
           "set",
-          "model.default",
-          body.model,
+          "model.provider",
+          body.provider,
         ]);
-        await runCmd(setModelCmd.cmd, setModelCmd.args, setModelCmd.env);
+        await runCmd(setProviderCmd.cmd, setProviderCmd.args, setProviderCmd.env);
+        if (body.model) {
+          const setModelCmd = buildHermesCommand(hermesHome, [
+            "config",
+            "set",
+            "model.default",
+            body.model,
+          ]);
+          await runCmd(setModelCmd.cmd, setModelCmd.args, setModelCmd.env);
+        }
       }
       // Skill + MCP install MUST happen before any other docker command that
       // might invoke the image's entrypoint, because skills_sync runs as the


### PR DESCRIPTION
Fixes #1.

## Problem
Creating a Hermes agent with `provider=custom:freeapi` left the generated `HERMES_HOME/config.yaml` with `provider: auto` and **no** `custom_providers` block. The agent connected to CircleChat but reported *"No inference provider configured"* and could not answer.

## Root cause
Two independent failure modes:

1. **`hermes config set` re-serialisation.** After writing the patched template, the installer ran `hermes config set model.provider/model.default` inside the hermes image. Some image builds re-serialise `config.yaml` on `config set`, which **drops the hand-injected `custom_providers` block and resets the provider to the image default (`auto`)** — exactly the reporter's symptom. (This is image-version dependent; our box's pinned image happened to preserve it, which is why it never showed up here until reproduced.)
2. **Silent regex no-op.** The `custom_providers: []` replacement was a no-op on any template drift, independently leaving the block missing.

## Fix
- For the **freeapi** path, write the complete final config ourselves (`model.provider`, `model.default`, and the `custom_providers` entry) and **skip the `hermes config set` calls** — image-version-agnostic, and two fewer docker runs.
- The **hosted-provider** path keeps `config set` (those keys live in the auth keyring; nothing hand-injected to clobber).
- Append the `custom_providers` block when the placeholder is absent instead of assuming it exists.

## Verification (live box)
- Installed a `custom:freeapi` agent via `POST /api/agents/install-hermes` → `config.yaml` has `provider: custom:freeapi`, the requested model, and the `custom_providers` entry (`grep freeapi` → 2 hits, was 0).
- One-shot completion through the generated config returned a real answer (`PONG`) — no "No inference provider configured".
- Note for reporters: if the agent connects but returns nothing, check the model is enabled on your FreeLLMAPI (`/v1/models`); a disabled model (e.g. `gemini-2.5-pro` on a stripped instance) yields empty responses unrelated to this fix — `auto` always routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)