### PR TITLE
Clear sidebar unread badges on mark-all-read

### DIFF
--- a/api/src/routes/notifications.ts
+++ b/api/src/routes/notifications.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { and, eq, lt, desc, isNull, sql as dsql } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { notifications } from "../db/schema.js";
+import { notifications, conversationMembers } from "../db/schema.js";
 import { requireWorkspace } from "../auth/session.js";
 import { publishToMember } from "../lib/events.js";
 
@@ -123,10 +123,21 @@ export default async function notificationRoutes(app: FastifyInstance): Promise<
   // Mark all the caller's notifications read.
   app.post("/notifications/read-all", async (req) => {
     const memberId = req.auth!.memberId!;
+    const now = new Date();
     await db
       .update(notifications)
-      .set({ readAt: new Date() })
+      .set({ readAt: now })
       .where(and(eq(notifications.memberId, memberId), isNull(notifications.readAt)));
+    // The bell (notifications table) and the left-sidebar unread badges are
+    // backed by DIFFERENT sources: the sidebar counts messages newer than each
+    // conversation's `last_read_at`. "Mark all read" must clear BOTH, so also
+    // advance the caller's read marker across every conversation they belong to
+    // — same write the per-conversation `POST /conversations/:id/read` does,
+    // just unscoped. Idempotent; only touches the caller's own rows.
+    await db
+      .update(conversationMembers)
+      .set({ lastReadAt: now })
+      .where(eq(conversationMembers.memberId, memberId));
     await publishToMember(memberId, {
       type: "notification.read",
       memberId,

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -359,6 +359,10 @@ export function useMarkAllNotificationsRead() {
     mutationFn: () => api.post(`/notifications/read-all`),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["notifications"] });
+      qc.invalidateQueries({ queryKey: ["notifications", "unread"] });
+      // read-all now also advances every conversation's read marker server-side,
+      // so refresh the sidebar to clear the per-conversation unread badges too.
+      qc.invalidateQueries({ queryKey: ["conversations"] });
     },
   });
 }


### PR DESCRIPTION
## Problem
The bell and the left-sidebar per-conversation unread badges are backed by **two independent sources**: the bell reads `notifications.read_at`; the sidebar counts messages newer than `conversation_members.last_read_at`. "Mark all read" only updated `notifications.read_at`, so the sidebar numbers stayed.

## Fix
- `POST /notifications/read-all` now also advances the caller's `last_read_at` across all their conversations (same write as `POST /conversations/:id/read`, unscoped).
- Client `useMarkAllNotificationsRead` invalidates `["conversations"]` (and `["notifications","unread"]`) so the sidebar refreshes.

No schema change. Idempotent, only touches the caller's own rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)