### PR TITLE
Lower substance-floor to 120B (avoid false-positives)

### DIFF
--- a/api/src/lib/task-artifacts.ts
+++ b/api/src/lib/task-artifacts.ts
@@ -15,9 +15,13 @@ export const MAX_ARTIFACTS_PER_TASK = 500;
 // reject placeholder/title-only "deliverables" (the junk-file bypass). Cheap
 // and instant; a determined agent could pad past it, but the human-sign-off
 // override covers that and an LLM judge can layer on later.
-export const MIN_SUBSTANTIVE_BYTES = 200; // below this is a stub, not a deliverable
+// Floor sized to kill the observed stubs (the 26–34 byte title-echoes) with
+// margin, without false-positiving a legit-but-terse deliverable (e.g. a short
+// list of links is ~150B). Padding past the floor is caught by the title-echo
+// + low-distinct-word checks below; semantic relevance is the LLM judge's job.
+export const MIN_SUBSTANTIVE_BYTES = 120; // below this is a stub, not a deliverable
 const TRUST_SIZE_BYTES = 2048;            // above this, trust size; don't read bytes
-const MIN_SUBSTANTIVE_TEXT_CHARS = 120;   // borderline text must carry real content
+const MIN_SUBSTANTIVE_TEXT_CHARS = 90;    // borderline text must carry real content
 
 function normalizeText(s: string): string {
   return s.toLowerCase().replace(/\s+/g, " ").trim();


### PR DESCRIPTION
Follow-up to #18/#19. The 200B floor false-positived a legit ~155B 7-URL list. Lowered to 120B — still catches the observed 26–34B stubs with margin; padding is caught by the title-echo + low-distinct-word checks. Backend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)