### PR TITLE
Clean up task_artifacts (rows + blobs) on task delete

### DIFF
--- a/api/src/lib/task-artifacts.ts
+++ b/api/src/lib/task-artifacts.ts
@@ -2,7 +2,7 @@ import { and, eq, desc, isNull, sql as dsql } from "drizzle-orm";
 import { createHash } from "node:crypto";
 import { db } from "../db/index.js";
 import { taskArtifacts, members, users, agents, type TaskArtifact } from "../db/schema.js";
-import { putObject, publicUrl, readObject } from "./storage.js";
+import { putObject, publicUrl, readObject, deleteObject } from "./storage.js";
 import { id as makeId } from "./ids.js";
 import type { Attachment } from "../db/schema.js";
 
@@ -227,6 +227,21 @@ export async function softDeleteArtifact(artifactId: string): Promise<void> {
     .update(taskArtifacts)
     .set({ deletedAt: new Date() })
     .where(eq(taskArtifacts.id, artifactId));
+}
+
+// Hard-delete every artifact row for these tasks AND unlink their blobs.
+// Called when a task is hard-deleted (deleteTask) — without it the rows + the
+// t/<task>/… objects on disk are orphaned. Includes soft-deleted rows since the
+// whole task is going away. deleteObject is idempotent, so missing blobs are fine.
+export async function purgeArtifactsForTasks(taskIds: string[]): Promise<void> {
+  if (!taskIds.length) return;
+  const { inArray } = await import("drizzle-orm");
+  const rows = await db
+    .select({ storageKey: taskArtifacts.storageKey })
+    .from(taskArtifacts)
+    .where(inArray(taskArtifacts.taskId, taskIds));
+  for (const r of rows) await deleteObject(r.storageKey);
+  await db.delete(taskArtifacts).where(inArray(taskArtifacts.taskId, taskIds));
 }
 
 export async function artifactCount(taskId: string): Promise<number> {

--- a/api/src/lib/tasks-core.ts
+++ b/api/src/lib/tasks-core.ts
@@ -13,7 +13,7 @@ import { id } from "./ids.js";
 import { publishToWorkspace } from "./events.js";
 import { enqueueAgentEvent } from "../agents/enqueue.js";
 import { notify } from "./notifications.js";
-import { liveArtifactRows, isSubstantiveArtifact } from "./task-artifacts.js";
+import { liveArtifactRows, isSubstantiveArtifact, purgeArtifactsForTasks } from "./task-artifacts.js";
 
 export const STATUSES = ["backlog", "in_progress", "review", "done"] as const;
 export type Status = (typeof STATUSES)[number];
@@ -338,6 +338,7 @@ export async function deleteTask(taskId: string, workspaceId: string) {
     .delete(taskLinks)
     .where(or(inArray(taskLinks.taskId, allIds), inArray(taskLinks.linkedTaskId, allIds)));
   await db.delete(taskActivity).where(inArray(taskActivity.taskId, allIds));
+  await purgeArtifactsForTasks(allIds); // rows + their object-store blobs
   await db.delete(tasks).where(inArray(tasks.id, allIds));
   await publishToWorkspace(workspaceId, {
     type: "task.deleted",


### PR DESCRIPTION
deleteTask left task_artifacts rows and their `t/<task>/…` blobs orphaned on hard-delete. Adds `purgeArtifactsForTasks(allIds)` (unlink blobs + delete rows) and calls it from deleteTask alongside the other cascades. Backend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)