### PR TITLE
Remove task storage subtree on delete (no leftover empty dirs)

### DIFF
--- a/api/src/lib/storage.ts
+++ b/api/src/lib/storage.ts
@@ -48,6 +48,17 @@ export async function deleteObject(key: string): Promise<void> {
   }
 }
 
+// Remove a whole key prefix subtree (files + dirs) — e.g. a task's t/<id>/
+// folder when the task is deleted. Best-effort + idempotent; the safeJoin guard
+// keeps it inside the storage root.
+export async function removeStoragePrefix(prefix: string): Promise<void> {
+  try {
+    await fs.rm(safeJoin(prefix), { recursive: true, force: true });
+  } catch {
+    // ignore — best-effort cleanup
+  }
+}
+
 export function publicUrl(key: string): string {
   // Absolute so agents (bearer-auth'd curl) can follow the URL directly.
   return `${config.publicBaseUrl.replace(/\/$/, "")}/files/${key}`;

--- a/api/src/lib/task-artifacts.ts
+++ b/api/src/lib/task-artifacts.ts
@@ -2,7 +2,7 @@ import { and, eq, desc, isNull, sql as dsql } from "drizzle-orm";
 import { createHash } from "node:crypto";
 import { db } from "../db/index.js";
 import { taskArtifacts, members, users, agents, type TaskArtifact } from "../db/schema.js";
-import { putObject, publicUrl, readObject, deleteObject } from "./storage.js";
+import { putObject, publicUrl, readObject, removeStoragePrefix } from "./storage.js";
 import { id as makeId } from "./ids.js";
 import type { Attachment } from "../db/schema.js";
 
@@ -236,12 +236,10 @@ export async function softDeleteArtifact(artifactId: string): Promise<void> {
 export async function purgeArtifactsForTasks(taskIds: string[]): Promise<void> {
   if (!taskIds.length) return;
   const { inArray } = await import("drizzle-orm");
-  const rows = await db
-    .select({ storageKey: taskArtifacts.storageKey })
-    .from(taskArtifacts)
-    .where(inArray(taskArtifacts.taskId, taskIds));
-  for (const r of rows) await deleteObject(r.storageKey);
   await db.delete(taskArtifacts).where(inArray(taskArtifacts.taskId, taskIds));
+  // Every artifact blob for a task lives under t/<taskId>/…, so dropping that
+  // subtree clears the bytes AND the now-empty dirs in one shot.
+  for (const id of taskIds) await removeStoragePrefix(`t/${id}`);
 }
 
 export async function artifactCount(taskId: string): Promise<number> {


### PR DESCRIPTION
Follow-up to #21. The first cut unlinked blob files but left empty `t/<task>/<artifact>/` dirs that accumulate per deleted task. Adds `removeStoragePrefix()` (safeJoin-guarded `fs.rm` recursive) and drops the whole `t/<taskId>/` subtree. Backend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)