### PR TITLE
Open files same-origin + serve inline (fix local-file Save prompt)

### DIFF
--- a/api/src/routes/files.ts
+++ b/api/src/routes/files.ts
@@ -172,6 +172,12 @@ export async function fileServeRoutes(app: FastifyInstance): Promise<void> {
     reply.header("content-type", ct);
     reply.header("content-length", String(st.size));
     reply.header("cache-control", "private, max-age=60");
+    // Display in the browser rather than force-downloading. Without this,
+    // navigating to e.g. a text/markdown URL pops a Save dialog. The web
+    // viewer's explicit Download button uses the <a download> attribute, which
+    // overrides this, so "download" still works.
+    const fname = (key.split("/").pop() || "file").replace(/[\r\n"]/g, "_");
+    reply.header("content-disposition", `inline; filename="${fname}"`);
     return reply.send(streamObject(key));
   });
 }

--- a/web/src/components/Attachments.tsx
+++ b/web/src/components/Attachments.tsx
@@ -1,3 +1,4 @@
+import { fileUrl } from "../lib/fileUrl";
 import { ArrowUpRight } from "lucide-react";
 import { useBus } from "../state/store";
 import { kindFor, ICON_FOR, STYLE_FOR, formatSize } from "../lib/fileKind";
@@ -31,7 +32,7 @@ export default function Attachments({ files }: { files: Attachment[] }) {
               className="att-image"
               title={`${f.name} · ${formatSize(f.size)}`}
             >
-              <img src={f.url} alt={f.name} loading="lazy" />
+              <img src={fileUrl(f.url)} alt={f.name} loading="lazy" />
               <span className="att-image-meta">
                 <span className="att-image-name">{f.name}</span>
                 {f.size > 0 && <span className="att-image-size">{formatSize(f.size)}</span>}

--- a/web/src/components/FileViewer.tsx
+++ b/web/src/components/FileViewer.tsx
@@ -3,6 +3,7 @@ import { X, Download, ExternalLink, ChevronLeft, ChevronRight, Loader2 } from "l
 import DOMPurify from "dompurify";
 import { useBus, type ViewerFile } from "../state/store";
 import { renderMarkdown } from "../lib/md";
+import { fileUrl } from "../lib/fileUrl";
 
 type Kind =
   | "image"
@@ -116,7 +117,7 @@ export default function FileViewer() {
           <div className="fv-actions">
             <a
               className="fv-btn"
-              href={file.url}
+              href={fileUrl(file.url)}
               target="_blank"
               rel="noopener noreferrer"
               title="Open in new tab"
@@ -125,7 +126,7 @@ export default function FileViewer() {
             </a>
             <a
               className="fv-btn"
-              href={file.url}
+              href={fileUrl(file.url)}
               download={file.name}
               title="Download"
             >
@@ -167,28 +168,28 @@ function Preview({ file }: { file: ViewerFile }) {
   if (kind === "image") {
     return (
       <div className="fv-center">
-        <img src={file.url} alt={file.name} className="fv-image" />
+        <img src={fileUrl(file.url)} alt={file.name} className="fv-image" />
       </div>
     );
   }
   if (kind === "video") {
     return (
       <div className="fv-center">
-        <video src={file.url} controls className="fv-video" />
+        <video src={fileUrl(file.url)} controls className="fv-video" />
       </div>
     );
   }
   if (kind === "audio") {
     return (
       <div className="fv-center">
-        <audio src={file.url} controls className="fv-audio" />
+        <audio src={fileUrl(file.url)} controls className="fv-audio" />
       </div>
     );
   }
   if (kind === "pdf") {
     return (
       <iframe
-        src={file.url}
+        src={fileUrl(file.url)}
         title={file.name}
         className="fv-iframe"
       />
@@ -250,7 +251,7 @@ function ErrorPane({ err }: { err: string }) {
 }
 
 function MarkdownPreview({ file }: { file: ViewerFile }) {
-  const { text, err, loading } = useTextContent(file.url);
+  const { text, err, loading } = useTextContent(fileUrl(file.url));
   if (loading) return <Spinner />;
   if (err) return <ErrorPane err={err} />;
   const html = DOMPurify.sanitize(renderMarkdown(text ?? ""));
@@ -262,7 +263,7 @@ function MarkdownPreview({ file }: { file: ViewerFile }) {
 }
 
 function HtmlPreview({ file }: { file: ViewerFile }) {
-  const { text, err, loading } = useTextContent(file.url);
+  const { text, err, loading } = useTextContent(fileUrl(file.url));
   if (loading) return <Spinner />;
   if (err) return <ErrorPane err={err} />;
   // Sandboxed srcdoc: scripts disabled, no same-origin, no forms or popups.
@@ -279,7 +280,7 @@ function HtmlPreview({ file }: { file: ViewerFile }) {
 }
 
 function TextPreview({ file }: { file: ViewerFile }) {
-  const { text, err, loading } = useTextContent(file.url);
+  const { text, err, loading } = useTextContent(fileUrl(file.url));
   if (loading) return <Spinner />;
   if (err) return <ErrorPane err={err} />;
   return (
@@ -297,7 +298,7 @@ function Unsupported({ file }: { file: ViewerFile }) {
         This file type ({file.contentType || "unknown"}) can't be previewed in
         the browser. Download it to open locally.
       </div>
-      <a className="btn primary sm" href={file.url} download={file.name}>
+      <a className="btn primary sm" href={fileUrl(file.url)} download={file.name}>
         <Download size={14} /> Download
       </a>
     </div>

--- a/web/src/lib/fileUrl.ts
+++ b/web/src/lib/fileUrl.ts
@@ -1,0 +1,15 @@
+// Always fetch/open the file-serve route on the SAME origin the app is served
+// from, regardless of the absolute host the API stamped into the descriptor
+// (PUBLIC_BASE_URL is for agents, which curl with a bearer token). Keeping it
+// same-origin means the browser sends the `cc_session` cookie (the cookie is
+// Secure + SameSite, so a cross-origin request drops it → 401 → the browser
+// gives up and offers a local Save dialog instead of showing the file).
+export function fileUrl(url: string | undefined | null): string {
+  if (!url) return "";
+  try {
+    const u = new URL(url, window.location.origin);
+    return u.pathname + u.search;
+  } catch {
+    return url;
+  }
+}

--- a/web/src/pages/Files.tsx
+++ b/web/src/pages/Files.tsx
@@ -1,3 +1,4 @@
+import { fileUrl } from "../lib/fileUrl";
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -170,7 +171,7 @@ export default function FilesPage() {
                     title={f.name}
                   >
                     <img
-                      src={f.url}
+                      src={fileUrl(f.url)}
                       alt={f.name}
                       loading="lazy"
                       className="w-full h-full object-cover"


### PR DESCRIPTION
Opening a deliverable popped Chrome's "wants to access files on your computer" Save dialog instead of showing the file.

**Causes & fixes:**
1. The web used the API's absolute `PUBLIC_BASE_URL` url (meant for agents). On any other origin, `/files` is cross-origin → the Secure+SameSite `cc_session` cookie drops → 401 → browser offers a local Save dialog. Added `fileUrl()` to rewrite descriptor urls to same-origin `/files/<key>` everywhere (FileViewer src/fetch/anchors, Attachments + Files thumbnails).
2. `/files` sent no `Content-Disposition`, so navigating to e.g. `text/markdown` force-downloaded it. Now serves `inline; filename`; the viewer's Download button still downloads via `<a download>`.

api + web.