### PR TITLE
Reject placeholder artifacts at submit (stop stub clutter)

### DIFF
--- a/api/src/agents/executor.ts
+++ b/api/src/agents/executor.ts
@@ -28,7 +28,7 @@ import {
   loadTask,
 } from "../lib/tasks-core.js";
 import { putObject, publicUrl, readObject } from "../lib/storage.js";
-import { createArtifact } from "../lib/task-artifacts.js";
+import { createArtifact, isSubstantiveContent } from "../lib/task-artifacts.js";
 import { notifyForMessage } from "../lib/notifications.js";
 
 export interface AgentAttachment {
@@ -718,6 +718,13 @@ async function applyOne(
           const buf = await readObject(f.key);
           if (!buf) {
             out.trace.push(`share_to_task artifact skip ${f.name}: bytes not found`);
+            continue;
+          }
+          // Don't persist placeholder stubs as durable deliverables (they'd
+          // litter the task's artifacts list); the comment attachment above
+          // still landed for the activity feed.
+          if (!isSubstantiveContent(buf, f.contentType, f.name, targetTask.title)) {
+            out.trace.push(`share_to_task artifact skip ${f.name}: looks like a placeholder, not stored as a deliverable`);
             continue;
           }
           await createArtifact({

--- a/api/src/lib/task-artifacts.ts
+++ b/api/src/lib/task-artifacts.ts
@@ -178,27 +178,29 @@ export async function liveArtifactRows(taskId: string): Promise<TaskArtifact[]> 
     .where(and(eq(taskArtifacts.taskId, taskId), isNull(taskArtifacts.deletedAt)));
 }
 
-// Heuristic substance check for the done-evidence gate. Tiered to bound I/O:
-//   • size < MIN              → a stub, reject (kills the 26-byte title files)
-//   • size ≥ TRUST_SIZE       → trust it without reading (real work is big)
-//   • binary in between       → accept (image/pdf/zip ≥200B is plausibly real)
-//   • text in between         → read + reject title-echoes and thin content
-export async function isSubstantiveArtifact(
-  row: TaskArtifact,
+// Heuristic substance check, working on raw bytes so it runs both at SUBMIT
+// time (before a row exists — reject stubs at the source) and at the done-gate.
+// Tiered to bound I/O:
+//   • size < MIN          → a stub, reject (kills the 26-byte title files)
+//   • size ≥ TRUST_SIZE   → trust it (real work is big)
+//   • binary in between   → accept (image/pdf/zip ≥120B is plausibly real)
+//   • text in between     → reject title-echoes and repetitive padding
+export function isSubstantiveContent(
+  buffer: Buffer,
+  contentType: string,
+  name: string,
   taskTitle: string,
-): Promise<boolean> {
-  if (row.size < MIN_SUBSTANTIVE_BYTES) return false;
-  if (row.size >= TRUST_SIZE_BYTES) return true;
+): boolean {
+  if (buffer.length < MIN_SUBSTANTIVE_BYTES) return false;
+  if (buffer.length >= TRUST_SIZE_BYTES) return true;
 
-  const ct = (row.contentType || "").toLowerCase();
+  const ct = (contentType || "").toLowerCase();
   const isText =
     /^text\/|json|xml|csv|markdown|javascript|typescript|x-sh|yaml|html/.test(ct) ||
-    /\.(md|txt|csv|json|ya?ml|js|ts|tsx|py|sh|html?|sql)$/i.test(row.name);
+    /\.(md|txt|csv|json|ya?ml|js|ts|tsx|py|sh|html?|sql)$/i.test(name);
   if (!isText) return true; // binary blob over the floor — assume a real file
 
-  const buf = await readObject(row.storageKey);
-  if (!buf) return false;
-  const content = normalizeText(buf.toString("utf8"));
+  const content = normalizeText(buffer.toString("utf8"));
   if (content.length < MIN_SUBSTANTIVE_TEXT_CHARS) return false;
   const title = normalizeText(taskTitle || "");
   // Reject content that is essentially just the task title restated.
@@ -208,9 +210,21 @@ export async function isSubstantiveArtifact(
   // bites is to paste the title (or a phrase) N times. Few distinct words
   // across many total words = padding, not a deliverable.
   const words = content.split(" ").filter(Boolean);
-  const distinct = new Set(words).size;
-  if (words.length >= 12 && distinct < 8) return false;
+  if (words.length >= 12 && new Set(words).size < 8) return false;
   return true;
+}
+
+// Done-gate variant: same check against a stored row, reading the blob only for
+// the borderline-size text case.
+export async function isSubstantiveArtifact(
+  row: TaskArtifact,
+  taskTitle: string,
+): Promise<boolean> {
+  if (row.size < MIN_SUBSTANTIVE_BYTES) return false;
+  if (row.size >= TRUST_SIZE_BYTES) return true;
+  const buf = await readObject(row.storageKey);
+  if (!buf) return false;
+  return isSubstantiveContent(buf, row.contentType, row.name, taskTitle);
 }
 
 export async function loadArtifact(artifactId: string): Promise<TaskArtifact | null> {

--- a/api/src/routes/agent-api.ts
+++ b/api/src/routes/agent-api.ts
@@ -17,6 +17,7 @@ import {
   currentArtifacts,
   currentArtifactByName,
   artifactCount,
+  isSubstantiveContent,
   MAX_ARTIFACT_BYTES,
   MAX_ARTIFACTS_PER_TASK,
 } from "../lib/task-artifacts.js";
@@ -791,6 +792,14 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
     const { buffer, name, contentType } = resolved;
     if (buffer.length > MAX_ARTIFACT_BYTES)
       return reply.code(413).send({ error: "too_large", maxBytes: MAX_ARTIFACT_BYTES });
+    // Reject placeholders at the source so stub files don't litter the task's
+    // deliverables list. Agents are an untrusted client; humans (the human API)
+    // are not gated. Re-submitting the SAME name with real content versions it.
+    if (!isSubstantiveContent(buffer, contentType, name, t.title))
+      return reply.code(422).send({
+        error: "artifact_not_substantive",
+        hint: "This looks like a placeholder or just the task title — submit the real deliverable (the actual report/script/draft). Reuse the same name to version an existing artifact.",
+      });
 
     const art = await createArtifact({
       taskId,


### PR DESCRIPTION
Follow-up to the PR E done-gate. POST /artifacts accepted anything, so agents that couldn't close spawned new filenames instead of versioning — leaving 34B title-stubs in a task's deliverables list (task_x6sj had two stubs next to the real wireframe).

- Factored the substance heuristic into `isSubstantiveContent(buffer,…)` (runs before a row exists).
- Agent `POST …/artifacts` → 422 `artifact_not_substantive` + hint (reuse the name to version).
- `share_to_task` → skips persisting a stub as a durable artifact (comment attachment still lands).
- Humans stay ungated (trusted verifier). Done-gate delegates to the same check.

Also soft-deleting the 2 existing stubs on task_x6sj. Backend only.