### PR TITLE
Single-admin platform: signup is a one-time bootstrap

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -59,9 +59,24 @@ const AcceptInviteBody = z.object({
 });
 
 export default async function authRoutes(app: FastifyInstance): Promise<void> {
+  // Public: is organic signup still allowed? True only while the platform has
+  // zero users — this is a single-admin platform, so signup is a one-time
+  // bootstrap. The frontend uses this to decide signup vs login.
+  app.get("/auth/registration-open", async () => {
+    const [u] = await db.select({ id: users.id }).from(users).limit(1);
+    return { open: !u };
+  });
+
   // ─────────── signup: creates a user + a brand-new workspace ───────────
   app.post("/auth/signup", async (req, reply) => {
     const body = SignupBody.parse(req.body);
+
+    // Single-admin platform: only the very first user may sign up (the admin).
+    // After that, registration is closed — additional people join only via an
+    // admin invite and cannot create their own workspaces. Enforced server-side
+    // so a stale client or a direct API call can't bypass it.
+    const [anyUser] = await db.select({ id: users.id }).from(users).limit(1);
+    if (anyUser) return reply.code(403).send({ error: "registration_closed" });
 
     const [existUser] = await db
       .select({ id: users.id })

--- a/api/src/routes/workspaces.ts
+++ b/api/src/routes/workspaces.ts
@@ -90,6 +90,15 @@ export default async function workspaceRoutes(app: FastifyInstance): Promise<voi
     const sid = req.cookies[COOKIE_NAME];
     if (!sid) return reply.code(401).send({ error: "unauthenticated" });
 
+    // Single-admin platform: only an existing admin may create workspaces.
+    // Invited users join as `member` and cannot spin up their own workspace.
+    const [adminOf] = await db
+      .select({ workspaceId: workspaceMembers.workspaceId })
+      .from(workspaceMembers)
+      .where(and(eq(workspaceMembers.userId, user.id), eq(workspaceMembers.role, "admin")))
+      .limit(1);
+    if (!adminOf) return reply.code(403).send({ error: "workspace_creation_disabled" });
+
     const handle = await deriveUniqueWorkspaceHandle(body.name);
 
     const wsId = id("w");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { BrowserRouter, Route, Routes, Navigate, useLocation, useNavigate } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { bus } from "./ws/client";
-import { useMe, usePresenceBus } from "./lib/hooks";
+import { useMe, usePresenceBus, useRegistrationOpen } from "./lib/hooks";
 import AppShell from "./components/AppShell";
 import SignupPage from "./pages/Signup";
 import LoginPage from "./pages/Login";
@@ -35,6 +35,7 @@ export default function App() {
 
 function Shell() {
   const me = useMe();
+  const reg = useRegistrationOpen();
   const location = useLocation();
   const nav = useNavigate();
   usePresenceBus();
@@ -65,7 +66,15 @@ function Shell() {
   // Kicking the user off /signup at that moment skips the agent step entirely.
   const redirectAwayFromAuth = location.pathname === "/login";
 
-  if (!me.data && !isStandalone) return <Navigate to="/login" replace />;
+  // Single-admin platform: signup is open only on a fresh, zero-user install.
+  // Once closed, an unauthenticated visitor only ever sees /login, and a direct
+  // hit to /signup bounces to /login. While the status is still loading we don't
+  // redirect (avoids a flicker) — the backend rejects a closed signup anyway.
+  const regOpen = reg.data?.open === true;
+  const regClosed = reg.data?.open === false;
+  if (!me.data && location.pathname === "/signup" && regClosed)
+    return <Navigate to="/login" replace />;
+  if (!me.data && !isStandalone) return <Navigate to={regOpen ? "/signup" : "/login"} replace />;
   if (me.data && redirectAwayFromAuth) {
     void nav;
     return <Navigate to="/" replace />;

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -35,6 +35,18 @@ export function useMe() {
   });
 }
 
+// Whether organic signup is still allowed (true only on a brand-new, zero-user
+// platform). Single-admin model: once the admin exists, signup is closed and
+// the UI shows login only. Backend is the real gate; this just drives the UI.
+export function useRegistrationOpen() {
+  return useQuery<{ open: boolean }>({
+    queryKey: ["registration-open"],
+    queryFn: () => api.get("/auth/registration-open"),
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+}
+
 export function useConversations() {
   const qc = useQueryClient();
   const q = useQuery<{ conversations: Conversation[] }>({

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { api } from "../api/client";
 import { humanizeError } from "../api/errors";
 import { useQueryClient } from "@tanstack/react-query";
+import { useRegistrationOpen } from "../lib/hooks";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -10,6 +11,7 @@ export default function LoginPage() {
   const [err, setErr] = useState<string | null>(null);
   const nav = useNavigate();
   const qc = useQueryClient();
+  const reg = useRegistrationOpen();
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -59,9 +61,11 @@ export default function LoginPage() {
             Sign in
           </button>
         </form>
-        <p className="text-[12px] text-[var(--color-muted)] mt-5 text-center">
-          No workspace yet? <Link to="/signup" className="text-[var(--color-accent-blue)]">Create one</Link>
-        </p>
+        {reg.data?.open && (
+          <p className="text-[12px] text-[var(--color-muted)] mt-5 text-center">
+            No workspace yet? <Link to="/signup" className="text-[var(--color-accent-blue)]">Create one</Link>
+          </p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
The platform is for one admin who invites others; nobody else should sign up organically or create their own workspace.

- `/auth/signup` → 403 `registration_closed` once any user exists (only the first/admin signs up). Server-enforced.
- New public `GET /auth/registration-open` ({open} = zero users) drives the UI.
- `POST /workspaces` gated to admins → invited `member` users get 403 `workspace_creation_disabled`.
- Frontend: unauth lands on /signup only on a fresh install, else /login; /signup bounces to /login when closed; Login hides the 'Create one' link unless open.

api + web.