### PR TITLE
Raise agent heartbeat cap 1h -> 24h

### DIFF
--- a/api/src/routes/agent-install.ts
+++ b/api/src/routes/agent-install.ts
@@ -55,7 +55,7 @@ const InstallOpenClawBody = z.object({
   apiKey: z.string().min(10).max(400),
   apiBaseUrl: z.string().url().max(400).optional(),
   model: z.string().max(120).optional(),
-  heartbeatIntervalSec: z.number().int().min(15).max(3600).optional(),
+  heartbeatIntervalSec: z.number().int().min(15).max(86400).optional(),
   channelIds: z.array(z.string()).optional(),
   // Optional member id the new agent should report to in the org chart —
   // wired by the "+ Add report" PLUS block on /org.
@@ -80,7 +80,7 @@ const InstallHermesBody = z.object({
   // FreeLLMAPI endpoint, stored in HERMES_HOME/config.yaml:custom_providers.
   apiBaseUrl: z.string().url().max(400).optional(),
   model: z.string().max(120).optional(),
-  heartbeatIntervalSec: z.number().int().min(15).max(3600).optional(),
+  heartbeatIntervalSec: z.number().int().min(15).max(86400).optional(),
   channelIds: z.array(z.string()).optional(),
   reportsTo: z.string().max(32).nullable().optional(),
 });

--- a/api/src/routes/agents.ts
+++ b/api/src/routes/agents.ts
@@ -29,7 +29,7 @@ const CreateBody = z.object({
   brief: z.string().max(2000).optional(),
   scopes: z.array(z.string()).optional(),
   callbackUrl: z.string().url().optional(),
-  heartbeatIntervalSec: z.number().int().min(5).max(3600).optional(),
+  heartbeatIntervalSec: z.number().int().min(5).max(86400).optional(),
   channelIds: z.array(z.string()).optional(),
   config: z.record(z.string(), z.unknown()).optional(),
 });
@@ -40,7 +40,7 @@ const PatchBody = z.object({
   brief: z.string().max(2000).optional(),
   scopes: z.array(z.string()).optional(),
   callbackUrl: z.string().url().optional(),
-  heartbeatIntervalSec: z.number().int().min(5).max(3600).optional(),
+  heartbeatIntervalSec: z.number().int().min(5).max(86400).optional(),
   model: z.string().max(80).optional(),
   config: z.record(z.string(), z.unknown()).optional(),
 });


### PR DESCRIPTION
The 3600s cap blocked long heartbeats; low-frequency beats are the main cost lever for paid models (e.g. a 3-hour heartbeat). Raises the zod max to 86400s on the install + update agent routes. Backend only.