### PR TITLE
Fix cancelAgentHeartbeat (duplicate heartbeat schedules)

### DIFF
--- a/api/src/agents/scheduler.ts
+++ b/api/src/agents/scheduler.ts
@@ -21,9 +21,14 @@ export async function scheduleAgentHeartbeat(agentId: string, everySec: number):
 }
 
 export async function cancelAgentHeartbeat(agentId: string): Promise<void> {
+  const key = REPEAT_KEY(agentId);
   const repeats = await agentQueue.getRepeatableJobs();
   for (const r of repeats) {
-    if (r.id === REPEAT_KEY(agentId)) {
+    // The repeatable job is identified by its NAME (set via agentQueue.add(key,…));
+    // getRepeatableJobs() returns id=undefined, so matching on r.id silently
+    // matched nothing and old schedules piled up (duplicate heartbeats). Match
+    // on name (keep id as a fallback).
+    if (r.name === key || r.id === key) {
       await agentQueue.removeRepeatableByKey(r.key);
     }
   }


### PR DESCRIPTION
cancelAgentHeartbeat matched `r.id` but getRepeatableJobs() returns id=undefined — the repeat job is keyed by NAME. So cancel matched nothing and every reschedule piled on a new repeat, leaving an agent firing several heartbeats at once (found Samantha with 3h+1h+3min jobs, plus orphaned jobs from wiped agents). Match on r.name. Backend only.