### PR TITLE
Auto-plan goals (remove the manual Plan button)

### DIFF
--- a/api/migrations/0016_auto_plan.sql
+++ b/api/migrations/0016_auto_plan.sql
@@ -1,0 +1,9 @@
+-- Automatic planning: goals decompose themselves instead of waiting for a
+-- manual "Plan" click. `workspaces.auto_plan` is the policy ('auto' | 'off');
+-- `goals.plan_attempts` + `last_plan_error` let the sweeper retry-with-backoff
+-- and give up after a cap rather than loop. Idempotent.
+ALTER TABLE "workspaces" ADD COLUMN IF NOT EXISTS "auto_plan" varchar(10) NOT NULL DEFAULT 'auto';
+--> statement-breakpoint
+ALTER TABLE "goals" ADD COLUMN IF NOT EXISTS "plan_attempts" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "goals" ADD COLUMN IF NOT EXISTS "last_plan_error" text;

--- a/api/migrations/meta/_journal.json
+++ b/api/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1777180000000,
       "tag": "0015_goals",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1777190000000,
+      "tag": "0016_auto_plan",
+      "breakpoints": true
     }
   ]
 }

--- a/api/scripts/autoplan-e2e.mjs
+++ b/api/scripts/autoplan-e2e.mjs
@@ -1,0 +1,87 @@
+// End-to-end test of AUTOMATIC planning: creating a goal in an 'auto' workspace
+// decomposes + starts it with no manual plan call, driven by the background
+// goal-plan worker. Also exercises the sweeper picking up an unplanned goal.
+//   createdb cc_autoplan && node scripts/autoplan-e2e.mjs ; dropdb cc_autoplan
+import http from "node:http";
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+
+const DB = "postgres://postgres:circlechat@localhost:5432/cc_autoplan";
+process.env.DATABASE_URL = DB;
+process.env.HERMES_HOMES_DIR = "/tmp/cc-autoplan-homes";
+process.env.GOAL_PLAN_DEBOUNCE_MS = "0"; // plan immediately in the test
+
+// Mock LLM → fixed 3-task plan.
+const PLAN = {
+  tasks: [
+    { key: "a", title: "Research the market", assignee: "remy", dependsOn: [], rationale: "remy researches" },
+    { key: "b", title: "Design the page", assignee: "dara", dependsOn: ["a"], rationale: "dara designs" },
+    { key: "c", title: "Build the page", assignee: "dara", dependsOn: ["b"], rationale: "dara builds" },
+  ],
+};
+const mock = http.createServer((req, res) => {
+  let body = ""; req.on("data", (c) => (body += c));
+  req.on("end", () => { res.setHeader("content-type", "application/json"); res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify(PLAN) } }] })); });
+});
+await new Promise((r) => mock.listen(0, r));
+process.env.PLANNER_BASE_URL = `http://127.0.0.1:${mock.address().port}/v1`;
+process.env.PLANNER_MODEL = "mock";
+
+const postgres = (await import("postgres")).default;
+const { drizzle } = await import("drizzle-orm/postgres-js");
+const { migrate } = await import("drizzle-orm/postgres-js/migrator");
+{ const m = postgres(DB, { max: 1 }); await migrate(drizzle(m), { migrationsFolder: "./migrations" }); await m.end(); }
+
+const { db } = await import("../dist/db/index.js");
+const schema = await import("../dist/db/schema.js");
+const { eq } = await import("drizzle-orm");
+const wsId = "ws_ap01";
+await db.insert(schema.workspaces).values({ id: wsId, name: "AP", handle: "ap", createdBy: "u_o", mission: "Ship things" }); // auto_plan defaults to 'auto'
+await db.insert(schema.users).values({ id: "u_o", email: "o@x.com", name: "O", handle: "owner", passwordHash: "x" });
+await db.insert(schema.members).values({ id: "m_o", workspaceId: wsId, kind: "user", refId: "u_o" });
+async function agent(id, handle, title, skills) {
+  await db.insert(schema.agents).values({ id, workspaceId: wsId, handle, name: handle, kind: "openclaw", adapter: "webhook", title, capabilities: [], botToken: `cc_${id}`, createdBy: "m_o" });
+  await db.insert(schema.members).values({ id: `m_${handle}`, workspaceId: wsId, kind: "agent", refId: id, reportsTo: "m_o" });
+  const root = join(process.env.HERMES_HOMES_DIR, `.openclaw-${handle}`, "skills");
+  for (const [n, d] of Object.entries(skills)) { await fs.mkdir(join(root, n), { recursive: true }); await fs.writeFile(join(root, n, "DESCRIPTION.md"), `---\nname: ${n}\ndescription: ${d}\n---\n`); }
+}
+await fs.rm(process.env.HERMES_HOMES_DIR, { recursive: true, force: true });
+await agent("a_remy", "remy", "Researcher", { research: "Market research." });
+await agent("a_dara", "dara", "Designer", { design: "Design and build pages." });
+
+const { startGoalPlanWorker } = await import("../dist/agents/goal-planner-worker.js");
+const { goalQueue } = await import("../dist/lib/goal-queue.js");
+const { createGoal } = await import("../dist/lib/goals-core.js");
+const worker = startGoalPlanWorker();
+
+let ok = true;
+const assert = (c, m) => { if (!c) { ok = false; console.error("✗ " + m); } else console.log("✓ " + m); };
+const tasksFor = async (gid) => db.select().from(schema.tasks).where(eq(schema.tasks.goalId, gid));
+async function waitForTasks(gid, label, timeoutMs = 20000) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeoutMs) { const r = await tasksFor(gid); if (r.length) return r; await new Promise((r) => setTimeout(r, 400)); }
+  return [];
+}
+
+// 1. Plan-on-create: createGoal enqueues; the worker plans it automatically.
+console.log("=== plan-on-create ===");
+const g1 = await createGoal({ title: "Launch the landing page" }, "m_o", wsId);
+const t1 = await waitForTasks(g1.goal.id, "create");
+assert(t1.length === 3, `goal auto-planned on create → ${t1.length} tasks (no manual plan call)`);
+const [g1row] = await db.select().from(schema.goals).where(eq(schema.goals.id, g1.goal.id));
+assert(g1row.status === "in_progress", "goal moved to in_progress automatically");
+assert(t1.some((t) => t.status === "in_progress"), "a root task auto-started");
+
+// 2. Sweeper: insert a raw open goal (no enqueue), fire a sweep, it gets planned.
+console.log("=== sweeper backstop ===");
+const g2id = "goal_sweeptest01";
+await db.insert(schema.goals).values({ id: g2id, workspaceId: wsId, title: "Second goal", status: "open", ownerMemberId: "m_o", createdBy: "m_o" });
+await goalQueue.add("sweep", { kind: "sweep" });
+const t2 = await waitForTasks(g2id, "sweep");
+assert(t2.length === 3, `sweeper picked up the unplanned goal → ${t2.length} tasks`);
+
+await worker.close();
+await goalQueue.close();
+mock.close();
+console.log(ok ? "\nALL PASS ✅" : "\nFAILURES ❌");
+process.exit(ok ? 0 : 1);

--- a/api/src/agents/goal-planner-worker.ts
+++ b/api/src/agents/goal-planner-worker.ts
@@ -1,0 +1,97 @@
+import { Worker } from "bullmq";
+import { and, eq, lt, inArray } from "drizzle-orm";
+import { redis } from "../lib/redis.js";
+import { db } from "../db/index.js";
+import { goals, tasks, workspaces } from "../db/schema.js";
+import { GOAL_QUEUE, type GoalPlanJob, enqueueGoalPlan } from "../lib/goal-queue.js";
+import { planGoal } from "../lib/planner.js";
+import { notify } from "../lib/notifications.js";
+
+// Give up after this many failed planning attempts (the sweeper is the retry
+// driver, so each attempt is one sweep tick apart — backoff for free).
+const MAX_PLAN_ATTEMPTS = Number(process.env.GOAL_MAX_PLAN_ATTEMPTS ?? 3);
+// A goal stuck in `planning` longer than this had its worker die mid-plan —
+// reset it to `open` so the sweeper re-plans it.
+const STUCK_PLANNING_MS = Number(process.env.GOAL_STUCK_PLANNING_MS ?? 300_000); // 5 min
+// Cap goals planned per sweep tick — a coarse rate limit until real budgets land.
+const SWEEP_BATCH = Number(process.env.GOAL_SWEEP_BATCH ?? 20);
+
+// Errors that mean "stop, don't count an attempt" (nothing to retry).
+const TERMINAL_NO_COUNT = new Set(["already_planned", "goal_not_found", "wrong_workspace"]);
+
+async function handlePlan(goalId: string): Promise<void> {
+  const [goal] = await db.select().from(goals).where(eq(goals.id, goalId)).limit(1);
+  if (!goal) return;
+  // Only plan goals that are genuinely open and unplanned, in auto workspaces.
+  // (status guard + planGoal's own 0-tasks guard prevent double-planning.)
+  if (goal.status !== "open") return;
+  if (goal.planAttempts >= MAX_PLAN_ATTEMPTS) return;
+  const [ws] = await db.select({ autoPlan: workspaces.autoPlan }).from(workspaces).where(eq(workspaces.id, goal.workspaceId)).limit(1);
+  if (ws?.autoPlan !== "auto") return;
+
+  const r = await planGoal({ goalId, workspaceId: goal.workspaceId, actorMemberId: goal.ownerMemberId ?? goal.createdBy });
+  if (!("error" in r)) {
+    if (goal.lastPlanError) await db.update(goals).set({ lastPlanError: null }).where(eq(goals.id, goalId));
+    return;
+  }
+  if (TERMINAL_NO_COUNT.has(r.error)) return;
+
+  // Count the failed attempt; give up + notify the owner once we hit the cap.
+  const attempts = goal.planAttempts + 1;
+  await db.update(goals).set({ planAttempts: attempts, lastPlanError: r.error, updatedAt: new Date() }).where(eq(goals.id, goalId));
+  if (attempts >= MAX_PLAN_ATTEMPTS && goal.ownerMemberId) {
+    await notify({
+      workspaceId: goal.workspaceId,
+      memberId: goal.ownerMemberId,
+      kind: "system",
+      title: "Couldn't auto-plan a goal",
+      body: `${goal.title} — ${r.error}. Add detail or plan it manually.`,
+      link: `/goals`,
+    }).catch(() => {});
+  }
+}
+
+async function handleSweep(): Promise<void> {
+  // 1. Un-stick goals whose planning crashed mid-flight.
+  await db
+    .update(goals)
+    .set({ status: "open", updatedAt: new Date() })
+    .where(and(eq(goals.status, "planning"), lt(goals.updatedAt, new Date(Date.now() - STUCK_PLANNING_MS))));
+
+  // 2. Find open, under-attempt goals in auto workspaces; enqueue any with no
+  //    tasks yet. Bounded per tick as a coarse rate limit.
+  const candidates = await db
+    .select({ id: goals.id, workspaceId: goals.workspaceId })
+    .from(goals)
+    .innerJoin(workspaces, eq(workspaces.id, goals.workspaceId))
+    .where(and(eq(goals.status, "open"), lt(goals.planAttempts, MAX_PLAN_ATTEMPTS), eq(workspaces.autoPlan, "auto")))
+    .limit(SWEEP_BATCH);
+  if (!candidates.length) return;
+
+  const ids = candidates.map((c) => c.id);
+  const withTasks = new Set(
+    (await db.select({ goalId: tasks.goalId }).from(tasks).where(and(inArray(tasks.goalId, ids), eq(tasks.archived, false)))).map(
+      (t) => t.goalId,
+    ),
+  );
+  for (const c of candidates) {
+    if (withTasks.has(c.id)) continue; // already planned
+    await enqueueGoalPlan(c.id, c.workspaceId, true);
+  }
+}
+
+// Start the goal-planning worker. Called from the worker process boot.
+export function startGoalPlanWorker(): Worker<GoalPlanJob> {
+  const w = new Worker<GoalPlanJob>(
+    GOAL_QUEUE,
+    async (job) => {
+      if (job.data.kind === "sweep") return handleSweep();
+      if (job.data.kind === "plan" && job.data.goalId) return handlePlan(job.data.goalId);
+    },
+    { connection: redis, concurrency: 3 },
+  );
+  w.on("error", (e) => console.error("[goal-planner] error", e));
+  w.on("failed", (job, err) => console.error("[goal-planner] job failed", job?.id, err?.message));
+  console.log("[goal-planner] worker up, concurrency=3");
+  return w;
+}

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -24,6 +24,9 @@ export const workspaces = pgTable(
     // Workspace-level "what we build" prose, inherited by every agent's
     // runtime prompt. Set once per workspace; new agents auto-pick it up.
     mission: text("mission").notNull().default(""),
+    // Auto-planning policy: 'auto' = a new goal is decomposed + started
+    // automatically (no manual Plan button); 'off' = manual planning only.
+    autoPlan: varchar("auto_plan", { length: 10 }).notNull().default("auto"),
   },
   (t) => ({
     handleIdx: uniqueIndex("workspaces_handle_key").on(t.handle),
@@ -364,6 +367,11 @@ export const goals = pgTable(
     // The member accountable for the goal — usually a manager agent or the human
     // who set it. Gets the roll-up notification when the goal completes.
     ownerMemberId: varchar("owner_member_id", { length: 32 }),
+    // Auto-planning bookkeeping: how many times the planner has tried this goal
+    // and the last failure code, so the sweeper can retry-with-backoff and give
+    // up after a cap instead of looping (a cost bomb).
+    planAttempts: integer("plan_attempts").notNull().default(0),
+    lastPlanError: text("last_plan_error"),
     createdBy: varchar("created_by", { length: 32 }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),

--- a/api/src/lib/goal-queue.ts
+++ b/api/src/lib/goal-queue.ts
@@ -1,0 +1,55 @@
+import { Queue } from "bullmq";
+import { redis } from "./redis.js";
+
+// Queue that drives automatic goal planning. Two job shapes:
+//   { kind: "plan", goalId, workspaceId } — decompose one goal (debounced on create)
+//   { kind: "sweep" }                      — periodic reconcile of all goals
+export const GOAL_QUEUE = "goal-plans";
+
+export interface GoalPlanJob {
+  kind: "plan" | "sweep";
+  goalId?: string;
+  workspaceId?: string;
+}
+
+export const goalQueue = new Queue<GoalPlanJob>(GOAL_QUEUE, {
+  connection: redis,
+  defaultJobOptions: {
+    // The sweeper is the retry mechanism (it re-enqueues open goals), so a
+    // single plan job doesn't need BullMQ-level retries.
+    attempts: 1,
+    removeOnComplete: 200,
+    removeOnFail: 200,
+  },
+});
+
+// Debounce window before a freshly-created goal is planned, so a human editing
+// in the UI (or an agent that creates-then-fills) settles first.
+const PLAN_DEBOUNCE_MS = Number(process.env.GOAL_PLAN_DEBOUNCE_MS ?? 20_000);
+
+// Enqueue (or re-enqueue) a plan for one goal. jobId = goalId dedupes: a goal
+// already waiting to be planned won't pile up duplicate jobs.
+export async function enqueueGoalPlan(goalId: string, workspaceId: string, immediate = false): Promise<void> {
+  await goalQueue.add(
+    "plan",
+    { kind: "plan", goalId, workspaceId },
+    // BullMQ custom job ids must not contain ':'. jobId = one pending plan/goal.
+    { jobId: `plan_${goalId}`, delay: immediate ? 0 : PLAN_DEBOUNCE_MS },
+  );
+}
+
+const SWEEP_KEY = "goal-sweep";
+const SWEEP_EVERY_MS = Number(process.env.GOAL_SWEEP_EVERY_MS ?? 180_000); // 3 min
+
+// Install the repeatable sweeper job. Called once at worker boot.
+export async function scheduleGoalSweep(): Promise<void> {
+  // Clear any stale repeatable first so the interval can't double up.
+  for (const r of await goalQueue.getRepeatableJobs()) {
+    if (r.name === SWEEP_KEY) await goalQueue.removeRepeatableByKey(r.key);
+  }
+  await goalQueue.add(
+    SWEEP_KEY,
+    { kind: "sweep" },
+    { repeat: { every: SWEEP_EVERY_MS }, jobId: SWEEP_KEY },
+  );
+}

--- a/api/src/lib/goals-core.ts
+++ b/api/src/lib/goals-core.ts
@@ -1,9 +1,10 @@
 import { and, eq, inArray, desc, asc, sql as dsql } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { goals, tasks, members } from "../db/schema.js";
+import { goals, tasks, members, workspaces } from "../db/schema.js";
 import { id } from "./ids.js";
 import { publishToWorkspace } from "./events.js";
 import { hydrateTasks } from "./tasks-core.js";
+import { enqueueGoalPlan } from "./goal-queue.js";
 
 export const GOAL_STATUSES = ["open", "planning", "in_progress", "done", "archived"] as const;
 export type GoalStatus = (typeof GOAL_STATUSES)[number];
@@ -95,7 +96,24 @@ export async function createGoal(
   const [row] = await db.select().from(goals).where(eq(goals.id, goalId));
   const [hydrated] = await withCounts([row]);
   await publishToWorkspace(workspaceId, { type: "goal.new", workspaceId, goal: hydrated });
+
+  // Auto-planning: in an 'auto' workspace, a brand-new open goal decomposes
+  // itself (debounced, off the request path). No manual Plan click. The
+  // sweeper backstops anything missed. Fire-and-forget — never blocks create.
+  if ((row.status ?? "open") === "open") {
+    const [ws] = await db.select({ autoPlan: workspaces.autoPlan }).from(workspaces).where(eq(workspaces.id, workspaceId)).limit(1);
+    if (ws?.autoPlan === "auto") {
+      enqueueGoalPlan(goalId, workspaceId).catch(() => {});
+    }
+  }
   return { goal: hydrated };
+}
+
+// The workspace's auto-planning policy ('auto' | 'off'), so the UI knows
+// whether to show a manual Plan button.
+export async function workspaceAutoPlan(workspaceId: string): Promise<string> {
+  const [ws] = await db.select({ autoPlan: workspaces.autoPlan }).from(workspaces).where(eq(workspaces.id, workspaceId)).limit(1);
+  return ws?.autoPlan ?? "auto";
 }
 
 export async function listGoals(workspaceId: string) {
@@ -104,7 +122,7 @@ export async function listGoals(workspaceId: string) {
     .from(goals)
     .where(eq(goals.workspaceId, workspaceId))
     .orderBy(desc(goals.createdAt));
-  return { goals: await withCounts(rows) };
+  return { goals: await withCounts(rows), autoPlan: await workspaceAutoPlan(workspaceId) };
 }
 
 export async function getGoalDetail(goalId: string, workspaceId: string) {

--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -19,6 +19,8 @@ import { applyActions, type AgentAction } from "./agents/executor.js";
 import { materialiseScheduledRun, cancelAgentHeartbeat } from "./agents/scheduler.js";
 import { publishToConversation, publishGlobal } from "./lib/events.js";
 import { exportRunTrace } from "./lib/tracing.js";
+import { startGoalPlanWorker } from "./agents/goal-planner-worker.js";
+import { scheduleGoalSweep } from "./lib/goal-queue.js";
 
 const worker = new Worker<AgentJobPayload>(
   AGENT_QUEUE,
@@ -287,3 +289,8 @@ worker.on("error", (e) => console.error("[worker] error", e));
 worker.on("failed", (job, err) => console.error("[worker] job failed", job?.id, err?.message));
 
 console.log(`[worker] circlechat agent-runs worker up, concurrency=10`);
+
+// Automatic goal planning: a worker that decomposes goals off the HTTP path,
+// plus a repeatable sweeper that reconciles unplanned/stuck goals.
+startGoalPlanWorker();
+scheduleGoalSweep().catch((e) => console.error("[goal-planner] sweep schedule failed", e));

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -192,6 +192,8 @@ export interface Goal {
   bodyMd: string;
   status: GoalStatus;
   ownerMemberId: string | null;
+  planAttempts?: number;
+  lastPlanError?: string | null;
   createdBy: string;
   createdAt: string;
   updatedAt: string;

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -275,7 +275,7 @@ export function usePostMessage(convId: string | undefined, parentId?: string | n
 
 export function useGoals() {
   const qc = useQueryClient();
-  const q = useQuery<{ goals: Goal[] }>({
+  const q = useQuery<{ goals: Goal[]; autoPlan?: string }>({
     queryKey: ["goals"],
     queryFn: () => api.get("/goals"),
     staleTime: 15_000,
@@ -283,27 +283,28 @@ export function useGoals() {
   useEffect(() => {
     return bus.on((ev) => {
       if (typeof ev.type !== "string" || !String(ev.type).startsWith("goal.")) return;
+      type GoalsData = { goals: Goal[]; autoPlan?: string };
       if (ev.type === "goal.new") {
         const g = ev.goal as Goal;
-        qc.setQueryData<{ goals: Goal[] }>(["goals"], (old) => {
+        qc.setQueryData<GoalsData>(["goals"], (old) => {
           if (!old) return { goals: [g] };
           if (old.goals.some((x) => x.id === g.id)) return old;
-          return { goals: [g, ...old.goals] };
+          return { ...old, goals: [g, ...old.goals] };
         });
       } else if (ev.type === "goal.updated") {
         // The event may carry the full goal (with counts) or just a status —
         // refetch to stay authoritative on the task tally either way.
         if (ev.goal) {
           const g = ev.goal as Goal;
-          qc.setQueryData<{ goals: Goal[] }>(["goals"], (old) =>
-            old ? { goals: old.goals.map((x) => (x.id === g.id ? g : x)) } : old,
+          qc.setQueryData<GoalsData>(["goals"], (old) =>
+            old ? { ...old, goals: old.goals.map((x) => (x.id === g.id ? g : x)) } : old,
           );
         } else {
           qc.invalidateQueries({ queryKey: ["goals"] });
         }
       } else if (ev.type === "goal.deleted") {
-        qc.setQueryData<{ goals: Goal[] }>(["goals"], (old) =>
-          old ? { goals: old.goals.filter((x) => x.id !== ev.goalId) } : old,
+        qc.setQueryData<GoalsData>(["goals"], (old) =>
+          old ? { ...old, goals: old.goals.filter((x) => x.id !== ev.goalId) } : old,
         );
       }
     });

--- a/web/src/pages/Goals.tsx
+++ b/web/src/pages/Goals.tsx
@@ -37,6 +37,7 @@ export default function GoalsPage() {
   const [toast, setToast] = useState<{ kind: "ok" | "err"; msg: string } | null>(null);
 
   const goals = goalsQ.data?.goals ?? [];
+  const autoPlan = (goalsQ.data?.autoPlan ?? "auto") === "auto";
   const tasksByGoal = useMemo(() => {
     const m = new Map<string, Task[]>();
     for (const t of tasksQ.data?.tasks ?? []) {
@@ -158,8 +159,12 @@ export default function GoalsPage() {
         {goalsQ.isLoading && <div className="text-[13px] text-[var(--color-muted)]">Loading…</div>}
         {!goalsQ.isLoading && active.length === 0 && (
           <div className="text-[13px] text-[var(--color-muted)]">
-            No goals yet. A goal is an objective the team drives toward — create one, then{" "}
-            <strong>Plan</strong> it to auto-decompose it into a task tree routed across your agents.
+            No goals yet. A goal is an objective the team drives toward — create one and{" "}
+            {autoPlan ? (
+              <>it <strong>plans itself</strong>: auto-decomposed into a task tree and routed across your agents.</>
+            ) : (
+              <>hit <strong>Plan</strong> to decompose it into a task tree routed across your agents.</>
+            )}
           </div>
         )}
 
@@ -170,6 +175,11 @@ export default function GoalsPage() {
             const isOpen = expanded.has(g.id);
             const gTasks = tasksByGoal.get(g.id) ?? [];
             const unplanned = c.total === 0 && g.status !== "planning";
+            const failed = unplanned && !!g.lastPlanError;
+            // In an auto workspace the planner runs itself — no button. We only
+            // show a manual control when planning is OFF, or to retry a goal the
+            // planner gave up on.
+            const showPlanBtn = unplanned && (!autoPlan || failed);
             return (
               <div key={g.id} className="rounded-lg border border-[var(--color-border)]">
                 <div className="flex items-center gap-3 p-3">
@@ -185,6 +195,8 @@ export default function GoalsPage() {
                           · {c.done}/{c.total} tasks done
                         </span>
                       )}
+                      {unplanned && autoPlan && !failed && <span>· auto-planning…</span>}
+                      {failed && <span className="text-[#c0392b]">· couldn't plan ({g.lastPlanError})</span>}
                     </div>
                     {c.total > 0 && (
                       <div className="mt-1.5 h-1.5 w-full rounded-full bg-[var(--color-border)] overflow-hidden">
@@ -195,15 +207,17 @@ export default function GoalsPage() {
                       </div>
                     )}
                   </div>
-                  <button
-                    className="btn sm primary inline-flex items-center gap-1 whitespace-nowrap"
-                    disabled={!unplanned || planning === g.id}
-                    onClick={() => planGoal(g)}
-                    title={unplanned ? "Decompose into a task tree and start it" : "Already planned"}
-                  >
-                    <Wand2 size={14} />
-                    {planning === g.id ? "Planning…" : unplanned ? "Plan" : "Planned"}
-                  </button>
+                  {showPlanBtn && (
+                    <button
+                      className="btn sm primary inline-flex items-center gap-1 whitespace-nowrap"
+                      disabled={planning === g.id}
+                      onClick={() => planGoal(g)}
+                      title={failed ? "Try planning this goal again" : "Decompose into a task tree and start it"}
+                    >
+                      <Wand2 size={14} />
+                      {planning === g.id ? "Planning…" : failed ? "Retry" : "Plan"}
+                    </button>
+                  )}
                 </div>
 
                 {isOpen && (
@@ -213,7 +227,8 @@ export default function GoalsPage() {
                     )}
                     {gTasks.length === 0 ? (
                       <div className="text-[12px] text-[var(--color-muted)] py-1">
-                        No tasks yet. {unplanned && "Hit Plan to fan this goal out across the team."}
+                        No tasks yet.{" "}
+                        {unplanned && (autoPlan && !failed ? "Auto-planning — tasks will appear shortly." : "Plan this goal to fan it out across the team.")}
                       </div>
                     ) : (
                       <ul className="flex flex-col gap-1">


### PR DESCRIPTION
Goals now decompose themselves: `createGoal` enqueues a debounced background plan job, a repeatable sweeper reconciles unplanned/stuck goals and drives retries (give up after a cap → notify owner), and per-workspace `auto_plan` policy ('auto' default | 'off') controls whether the manual button shows. Verified end-to-end (plan-on-create + sweeper). Goals-only scope; budgets deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)