### PR TITLE
Make project a real tier + feed task→goal→mission ancestry to agents

### DIFF
--- a/api/hermes-multi-bridge.mjs
+++ b/api/hermes-multi-bridge.mjs
@@ -695,7 +695,7 @@ Don't repeat yourself across heartbeats: if your last task_comment said "I'll dr
     `  {"type":"update_task","task_id":"task_…","status":"in_progress|review|done","progress":50,"title":"…","body_md":"…","due_at":"2026-05-01","archived":true}`,
     `                                                                — moving to "done" REQUIRES EVIDENCE: the task must already have either (a) a SUBSTANTIVE deliverable in its artifacts store (use share_to_task to drop the real file — a stub/title-only placeholder is REJECTED), or (b) a human-authored comment after your most recent comment (review/sign-off). If neither is true, the server rejects the update with done_requires_evidence — first share the actual work product (the real script/report/draft, not its title), THEN flip status. To request human review without a finished deliverable, set status="review" instead.`,
     `  {"type":"assign_task","task_id":"task_…","member_id":"m_…"}`,
-    `  {"type":"create_goal","title":"…","body_md":"<optional detail>","parent_goal_id":"<optional goal_…>"}  — state a multi-step objective for the team. Use for real initiatives, not a single action you can just do.`,
+    `  {"type":"create_goal","title":"…","body_md":"<optional detail>","parent_goal_id":"<optional goal_…>","kind":"goal|project"}  — state a multi-step objective for the team. Use for real initiatives, not a single action you can just do. Set kind:"project" for a big top-level initiative that holds several goals; nest goals under it via parent_goal_id so tasks trace mission ▸ project ▸ goal.`,
     `  {"type":"decompose_goal","goal_id":"goal_…"}              — THE MANAGER MOVE: auto-decompose a goal into a task tree, route each subtask to the best-fit teammate by capability, wire the dependency edges, and start the unblocked tasks (waking their assignees). As tasks complete, dependents auto-start; when all finish, the goal closes. Use create_goal then decompose_goal when a human hands YOU (a lead with direct reports) an objective — don't hand-create every task or do it all yourself.`,
     `  {"type":"task_comment","task_id":"task_…","body_md":"…","mentions":["m_…"],"attachments":[<optional, hand-rolled descriptors from /uploads>]}`,
     `  {"type":"share_to_task","task_id":"task_…","body_md":"progress note","files":[{"url":"https://…","name":"snapshot.png"},{"path":"/workspace/report.pdf","name":"Q3.pdf"}]}`,
@@ -748,10 +748,22 @@ Don't repeat yourself across heartbeats: if your last task_comment said "I'll dr
       ? `\nRecent comments:\n${t.recentComments.map((c) => `  @${c.memberHandle}: ${String(c.bodyMd).slice(0, 200)}`).join("\n")}`
       : "";
     const sourceLine = t.conversationName ? `From channel: #${t.conversationName}` : null;
+    // The "why" chain: mission ▸ project ▸ goal ▸ … ▸ the goal this task
+    // serves. Lets the agent judge scope/trade-offs against the real objective
+    // instead of optimizing a bare title. Mission comes from the workspace.
+    const chain = Array.isArray(t.goalAncestry) ? t.goalAncestry : [];
+    let whyLine = null;
+    if (chain.length || (packet.workspace && packet.workspace.mission)) {
+      const parts = [];
+      if (packet.workspace && packet.workspace.mission) parts.push(`Mission: ${packet.workspace.mission}`);
+      for (const g of chain) parts.push(`${g.kind === "project" ? "Project" : "Goal"} “${g.title}”`);
+      whyLine = `Why this matters (chain): ${parts.join(" ▸ ")}`;
+    }
     taskBlock = [
       ``,
       `TASK (id ${t.id}) — status: ${t.status}${t.progress ? ` · progress ${t.progress}%` : ""}${t.dueAt ? ` · due ${t.dueAt.slice(0, 10)}` : ""}`,
       `Title: ${t.title}`,
+      whyLine,
       t.bodyMd ? `Description: ${t.bodyMd}` : null,
       sourceLine,
       t.labels?.length ? `Labels: ${t.labels.join(", ")}` : null,
@@ -811,10 +823,14 @@ Don't repeat yourself across heartbeats: if your last task_comment said "I'll dr
   let goalsBlock = "";
   const gs = Array.isArray(packet.goals) ? packet.goals : [];
   if (gs.length) {
+    const byId = new Map(gs.map((g) => [g.id, g]));
     const lines = gs.slice(0, 10).map((g) => {
       const c = g.taskCounts || { total: 0, done: 0, inProgress: 0 };
       const tally = c.total ? ` · ${c.done}/${c.total} done` : ` · UNPLANNED — decompose_goal to fan it out`;
-      return `  ◆ ${g.id} [${g.status}${tally}] ${g.title}`;
+      const kindTag = g.kind === "project" ? "PROJECT " : "";
+      const parent = g.parentGoalId ? byId.get(g.parentGoalId) : null;
+      const underLine = parent ? ` · under “${parent.title}”` : "";
+      return `  ◆ ${g.id} [${kindTag}${g.status}${tally}] ${g.title}${underLine}`;
     });
     goalsBlock = [
       ``,

--- a/api/migrations/0017_goal_kind.sql
+++ b/api/migrations/0017_goal_kind.sql
@@ -1,0 +1,7 @@
+-- 0017_goal_kind — make "project" a first-class kind of goal.
+-- Until now a "project" was just an informal top-level goal; nothing in the
+-- data distinguished it. The `kind` column turns the implicit tier into a
+-- real, queryable one ('project' = a top-level container, 'goal' = a unit of
+-- intent the planner decomposes). Defaults to 'goal' so every existing row
+-- keeps its current meaning. Idempotent.
+ALTER TABLE "goals" ADD COLUMN IF NOT EXISTS "kind" varchar(16) NOT NULL DEFAULT 'goal';

--- a/api/migrations/meta/_journal.json
+++ b/api/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1777190000000,
       "tag": "0016_auto_plan",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1777200000000,
+      "tag": "0017_goal_kind",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/agents/context.ts
+++ b/api/src/agents/context.ts
@@ -17,7 +17,7 @@ import {
   workspaces,
 } from "../db/schema.js";
 import { loadReportingFor, type ReportingBundle } from "../routes/org.js";
-import { listGoals } from "../lib/goals-core.js";
+import { listGoals, getGoalAncestry } from "../lib/goals-core.js";
 
 export interface MemberInfo {
   memberId: string;
@@ -118,6 +118,8 @@ export interface ContextPacket {
     id: string;
     title: string;
     status: string;
+    kind: string; // 'project' | 'goal'
+    parentGoalId: string | null;
     ownerMemberId: string | null;
     taskCounts: { total: number; done: number; inProgress: number };
   }>;
@@ -157,6 +159,10 @@ export interface ContextPacket {
     createdBy: string;
     subtasks: Array<{ id: string; title: string; status: string; assignees: string[] }>;
     recentComments: Array<{ id: string; memberId: string; memberHandle: string; bodyMd: string; ts: string }>;
+    // The goal chain this task serves, top-first (root project → … → direct
+    // goal), so the agent sees the "why", not just a title. Empty when the
+    // task isn't attached to a goal.
+    goalAncestry: Array<{ id: string; title: string; kind: string; status: string }>;
   };
 }
 
@@ -464,6 +470,8 @@ export async function buildContext(opts: {
       id: g.id,
       title: g.title,
       status: g.status,
+      kind: g.kind ?? "goal",
+      parentGoalId: g.parentGoalId ?? null,
       ownerMemberId: g.ownerMemberId ?? null,
       taskCounts: g.taskCounts,
     }));
@@ -535,6 +543,16 @@ export async function buildContext(opts: {
         .where(and(eq(taskComments.taskId, opts.taskId)))
         .orderBy(desc(taskComments.ts))
         .limit(10);
+      // Full "why" chain: the goal this task serves, up through its parent
+      // goals/project. Top-first so the prompt reads mission ▸ project ▸ goal.
+      const goalAncestry = t.goalId
+        ? (await getGoalAncestry(t.goalId)).map((g) => ({
+            id: g.id,
+            title: g.title,
+            kind: g.kind ?? "goal",
+            status: g.status,
+          }))
+        : [];
       taskCtx = {
         id: t.id,
         conversationId: t.conversationId,
@@ -565,6 +583,7 @@ export async function buildContext(opts: {
             bodyMd: c.bodyMd,
             ts: c.ts.toISOString(),
           })),
+        goalAncestry,
       };
     }
   }

--- a/api/src/agents/executor.ts
+++ b/api/src/agents/executor.ts
@@ -87,7 +87,7 @@ export type AgentAction =
   | { type: "assign_task"; task_id: string; member_id: string }
   // Goal actions — set a goal and have the planner auto-decompose it into a
   // delegation tree of tasks routed across the team (the manager move).
-  | { type: "create_goal"; title: string; body_md?: string; parent_goal_id?: string }
+  | { type: "create_goal"; title: string; body_md?: string; parent_goal_id?: string; kind?: "goal" | "project" }
   | { type: "decompose_goal"; goal_id: string }
   | {
       type: "task_comment";
@@ -689,7 +689,7 @@ async function applyOne(
       const ws = await loadAgentWorkspace(agentMemberId);
       if (!ws) throw new Error("agent_workspace_missing");
       const r = await createGoal(
-        { title: a.title, bodyMd: a.body_md, parentGoalId: a.parent_goal_id },
+        { title: a.title, bodyMd: a.body_md, parentGoalId: a.parent_goal_id, kind: a.kind },
         agentMemberId,
         ws,
       );

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -361,6 +361,10 @@ export const goals = pgTable(
     id: varchar("id", { length: 32 }).primaryKey(),
     workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
     parentGoalId: varchar("parent_goal_id", { length: 32 }),
+    // 'project' = a top-level container; 'goal' = a unit of intent the planner
+    // decomposes. Makes the mission → project → goal tier real instead of
+    // inferred from tree depth.
+    kind: varchar("kind", { length: 16 }).notNull().default("goal"),
     title: varchar("title", { length: 300 }).notNull(),
     bodyMd: text("body_md").notNull().default(""),
     status: varchar("status", { length: 20 }).notNull().default("open"),

--- a/api/src/lib/goals-core.ts
+++ b/api/src/lib/goals-core.ts
@@ -9,11 +9,34 @@ import { enqueueGoalPlan } from "./goal-queue.js";
 export const GOAL_STATUSES = ["open", "planning", "in_progress", "done", "archived"] as const;
 export type GoalStatus = (typeof GOAL_STATUSES)[number];
 
+// A 'project' is a top-level container; a 'goal' is a unit of intent the
+// planner decomposes into tasks. The mission → project → goal tier.
+export const GOAL_KINDS = ["goal", "project"] as const;
+export type GoalKind = (typeof GOAL_KINDS)[number];
+
 type GoalRow = typeof goals.$inferSelect;
 
 export async function loadGoal(goalId: string): Promise<GoalRow | null> {
   const [g] = await db.select().from(goals).where(eq(goals.id, goalId)).limit(1);
   return g ?? null;
+}
+
+// Walk parent_goal_id from a goal up to its root, returning the chain
+// top-first: [rootProject, …, directGoal]. Gives agents the full "why"
+// ancestry of a task, not just its immediate goal. Bounded so a corrupt
+// cycle can't loop forever.
+export async function getGoalAncestry(goalId: string): Promise<GoalRow[]> {
+  const chain: GoalRow[] = [];
+  const seen = new Set<string>();
+  let cur: string | null = goalId;
+  while (cur && !seen.has(cur) && chain.length < 16) {
+    seen.add(cur);
+    const g = await loadGoal(cur);
+    if (!g) break;
+    chain.push(g);
+    cur = g.parentGoalId;
+  }
+  return chain.reverse();
 }
 
 function guard(
@@ -61,6 +84,7 @@ export interface CreateGoalInput {
   parentGoalId?: string | null;
   ownerMemberId?: string | null;
   status?: GoalStatus;
+  kind?: GoalKind;
 }
 
 export async function createGoal(
@@ -87,6 +111,7 @@ export async function createGoal(
     id: goalId,
     workspaceId,
     parentGoalId: input.parentGoalId ?? null,
+    kind: input.kind ?? "goal",
     title: input.title,
     bodyMd: input.bodyMd ?? "",
     status: input.status ?? "open",
@@ -152,6 +177,7 @@ export interface UpdateGoalInput {
   bodyMd?: string;
   status?: GoalStatus;
   ownerMemberId?: string | null;
+  kind?: GoalKind;
 }
 
 export async function updateGoal(
@@ -167,6 +193,7 @@ export async function updateGoal(
   if (input.bodyMd !== undefined) patch.bodyMd = input.bodyMd;
   if (input.status !== undefined) patch.status = input.status;
   if (input.ownerMemberId !== undefined) patch.ownerMemberId = input.ownerMemberId;
+  if (input.kind !== undefined) patch.kind = input.kind;
   await db.update(goals).set(patch).where(eq(goals.id, goalId));
   const [row] = await db.select().from(goals).where(eq(goals.id, goalId));
   const [hydrated] = await withCounts([row]);

--- a/api/src/routes/agent-api.ts
+++ b/api/src/routes/agent-api.ts
@@ -24,7 +24,7 @@ import {
   MAX_ARTIFACTS_PER_TASK,
 } from "../lib/task-artifacts.js";
 import { loadTask } from "../lib/tasks-core.js";
-import { createGoal, listGoals, getGoalDetail } from "../lib/goals-core.js";
+import { createGoal, listGoals, getGoalDetail, GOAL_KINDS } from "../lib/goals-core.js";
 import { planGoal } from "../lib/planner.js";
 import { z } from "zod";
 import { createHash } from "node:crypto";
@@ -650,6 +650,7 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
         bodyMd: z.string().max(20000).optional(),
         parentGoalId: z.string().nullable().optional(),
         ownerMemberId: z.string().nullable().optional(),
+        kind: z.enum(GOAL_KINDS).optional(),
       })
       .parse(req.body);
     const ws = await agentWorkspaceId(req.agentCtx!.agentId);

--- a/api/src/routes/goals.ts
+++ b/api/src/routes/goals.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { requireWorkspace } from "../auth/session.js";
 import {
   GOAL_STATUSES,
+  GOAL_KINDS,
   createGoal,
   listGoals,
   getGoalDetail,
@@ -16,6 +17,7 @@ const CreateBody = z.object({
   bodyMd: z.string().max(20000).optional(),
   parentGoalId: z.string().nullable().optional(),
   ownerMemberId: z.string().nullable().optional(),
+  kind: z.enum(GOAL_KINDS).optional(),
 });
 
 const UpdateBody = z.object({
@@ -23,6 +25,7 @@ const UpdateBody = z.object({
   bodyMd: z.string().max(20000).optional(),
   status: z.enum(GOAL_STATUSES).optional(),
   ownerMemberId: z.string().nullable().optional(),
+  kind: z.enum(GOAL_KINDS).optional(),
 });
 
 const ERR_CODE: Record<string, number> = {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -184,10 +184,13 @@ export interface GoalTaskCounts {
 
 export type GoalStatus = "open" | "planning" | "in_progress" | "done" | "archived";
 
+export type GoalKind = "goal" | "project";
+
 export interface Goal {
   id: string;
   workspaceId: string;
   parentGoalId: string | null;
+  kind: GoalKind;
   title: string;
   bodyMd: string;
   status: GoalStatus;

--- a/web/src/pages/Goals.tsx
+++ b/web/src/pages/Goals.tsx
@@ -31,6 +31,8 @@ export default function GoalsPage() {
   const [adding, setAdding] = useState(false);
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
+  const [newKind, setNewKind] = useState<"goal" | "project">("goal");
+  const [newParent, setNewParent] = useState<string>("");
   const [busy, setBusy] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [planning, setPlanning] = useState<string | null>(null);
@@ -64,9 +66,17 @@ export default function GoalsPage() {
     if (!t || busy) return;
     setBusy(true);
     try {
-      await api.post<{ goal: Goal }>("/goals", { title: t, bodyMd: body.trim() || undefined });
+      await api.post<{ goal: Goal }>("/goals", {
+        title: t,
+        bodyMd: body.trim() || undefined,
+        kind: newKind,
+        // A project is a top-level container — never nest it under a goal.
+        parentGoalId: newKind === "goal" && newParent ? newParent : undefined,
+      });
       setTitle("");
       setBody("");
+      setNewParent("");
+      setNewKind("goal");
       setAdding(false);
     } catch (e) {
       flash("err", humanizeError(e));
@@ -145,9 +155,49 @@ export default function GoalsPage() {
               value={body}
               onChange={(e) => setBody(e.target.value)}
             />
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              {/* Kind toggle — a project is a top-level container; a goal is a
+                  unit of intent the planner decomposes (and can nest under a project). */}
+              <div className="inline-flex rounded-md border border-[var(--color-border)] overflow-hidden text-[12px]">
+                {(["goal", "project"] as const).map((k) => (
+                  <button
+                    key={k}
+                    className={`px-2.5 py-1 ${newKind === k ? "bg-[var(--color-accent,#1a73e8)] text-white" : "text-[var(--color-muted)]"}`}
+                    onClick={() => setNewKind(k)}
+                    type="button"
+                  >
+                    {k === "project" ? "Project" : "Goal"}
+                  </button>
+                ))}
+              </div>
+              {newKind === "goal" && (
+                <select
+                  className="text-[12px] bg-transparent border border-[var(--color-border)] rounded-md px-2 py-1 outline-none"
+                  value={newParent}
+                  onChange={(e) => setNewParent(e.target.value)}
+                  title="Nest this goal under a project or parent goal"
+                >
+                  <option value="">No parent (top-level)</option>
+                  {active
+                    .filter((p) => p.kind === "project")
+                    .map((p) => (
+                      <option key={p.id} value={p.id}>
+                        ◇ Project: {p.title}
+                      </option>
+                    ))}
+                  {active
+                    .filter((p) => p.kind !== "project")
+                    .map((p) => (
+                      <option key={p.id} value={p.id}>
+                        Goal: {p.title}
+                      </option>
+                    ))}
+                </select>
+              )}
+            </div>
             <div className="mt-2 flex gap-2">
               <button className="btn sm primary" disabled={!title.trim() || busy} onClick={createGoal}>
-                Create
+                Create {newKind === "project" ? "project" : "goal"}
               </button>
               <button className="btn sm ghost" onClick={() => setAdding(false)}>
                 Cancel
@@ -180,15 +230,32 @@ export default function GoalsPage() {
             // show a manual control when planning is OFF, or to retry a goal the
             // planner gave up on.
             const showPlanBtn = unplanned && (!autoPlan || failed);
+            const isProject = g.kind === "project";
+            const parent = g.parentGoalId ? goals.find((p) => p.id === g.parentGoalId) : null;
             return (
-              <div key={g.id} className="rounded-lg border border-[var(--color-border)]">
+              <div
+                key={g.id}
+                className={`rounded-lg border ${isProject ? "border-[var(--color-accent,#1a73e8)]/40 bg-[var(--color-accent-soft,#f3f7ff)]" : "border-[var(--color-border)]"}`}
+              >
                 <div className="flex items-center gap-3 p-3">
                   <button className="btn xs ghost p-1" onClick={() => toggle(g.id)} title="Expand tasks">
                     {isOpen ? <ChevronDown size={15} /> : <ChevronRight size={15} />}
                   </button>
                   <div className="min-w-0 flex-1">
-                    <div className="text-[14px] font-medium truncate">{g.title}</div>
-                    <div className="text-[12px] text-[var(--color-muted)] inline-flex items-center gap-2">
+                    <div className="text-[14px] font-medium truncate inline-flex items-center gap-2">
+                      {isProject && (
+                        <span className="text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-[var(--color-accent,#1a73e8)] text-white shrink-0">
+                          Project
+                        </span>
+                      )}
+                      <span className="truncate">{g.title}</span>
+                    </div>
+                    <div className="text-[12px] text-[var(--color-muted)] inline-flex items-center gap-2 flex-wrap">
+                      {parent && (
+                        <span className="inline-flex items-center gap-1">
+                          {parent.kind === "project" ? "in project" : "under"} “{parent.title}” ·
+                        </span>
+                      )}
                       <span>{STATUS_LABEL[g.status] ?? g.status}</span>
                       {c.total > 0 && (
                         <span>


### PR DESCRIPTION
## What

Closes the gap vs Paperclip's "project layer" — but without a new table, since the mission→project→goal→task spine already exists via FKs. Two changes make the tiers *real*:

**(a) `goals.kind` (`'goal'|'project'`)** — turns the implicit top tier into a real, queryable one. Wired through schema, core, REST + agent-api routes, the `create_goal` agent action, and the Goals UI (kind toggle, parent selector, project badge, parent breadcrumb).

**(b) Goal ancestry breadcrumb** — `getGoalAncestry` walks `parent_goal_id` to the root; `context.ts` attaches the full chain to the task packet (plus `kind`/`parentGoalId` on the goals list). The bridge renders `Why this matters (chain): Mission ▸ Project … ▸ Goal …` on the task, and marks PROJECTs + nesting in the goals block. Agents now see the *why*, not just a title.

## Migration

`0017_goal_kind` is additive (`DEFAULT 'goal'`), so existing rows are unchanged.

## Verification

- `tsc` build clean (api + web).
- Migration + smoke-test run on the box post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)