### PR TITLE
Polish agent toolbar, run-list scroll, and DM profile access

### DIFF
--- a/web/src/components/MemberDetailsPanel.tsx
+++ b/web/src/components/MemberDetailsPanel.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { X, MessageSquare, ExternalLink, Pencil } from "lucide-react";
+import { X, Pencil } from "lucide-react";
 import { useBus } from "../state/store";
 import { api } from "../api/client";
 import Avatar from "./Avatar";
@@ -87,12 +87,12 @@ export default function MemberDetailsPanel() {
         </div>
 
         <div className="details-actions">
-          <button onClick={() => { nav(`/d/${memberId}`); close(); }} className="btn sm inline-flex items-center gap-1.5 flex-1 justify-center">
-            <MessageSquare size={13} strokeWidth={2} /> Message
+          <button onClick={() => { nav(`/d/${memberId}`); close(); }} className="btn sm flex-1 justify-center">
+            Message
           </button>
           {isAgent && agentId && (
-            <button onClick={() => { nav(`/agents/${agentId}`); close(); }} className="btn sm ghost inline-flex items-center gap-1.5 flex-1 justify-center">
-              <ExternalLink size={13} strokeWidth={2} /> Agent page
+            <button onClick={() => { nav(`/agents/${agentId}`); close(); }} className="btn sm ghost flex-1 justify-center">
+              Agent page
             </button>
           )}
         </div>

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -1,7 +1,8 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { FlaskConical, HeartPulse, Pause, Play, Download } from "lucide-react";
 import { useAgent } from "../lib/hooks";
-import { api } from "../api/client";
+import { api, type AgentRun } from "../api/client";
 import Avatar from "../components/Avatar";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -100,36 +101,45 @@ export default function AgentDetailPage() {
               {agent.kind} · {agent.adapter} · {agent.model || "unspecified model"}
             </div>
           </div>
-          <div className="flex gap-2">
+          <div className="agent-toolbar">
             <button
               onClick={runTest}
               disabled={!!pending}
               title="Synthetic test trigger — smoke-tests the bridge and prompt pipeline"
-              className="text-[12px] border border-[var(--color-hair-2)] rounded px-3 py-1.5 hover:bg-[var(--color-hi)]"
+              className="btn sm btn-scale"
             >
-              Test heartbeat
+              <FlaskConical size={13} strokeWidth={2} /> Test heartbeat
             </button>
             <button
               onClick={runHeartbeat}
               disabled={!!pending}
               title="Fire a real scheduled beat right now — same trigger the cron uses"
-              className="text-[12px] border border-[var(--color-hair-2)] rounded px-3 py-1.5 hover:bg-[var(--color-hi)]"
+              className="btn sm btn-scale"
             >
-              Run heartbeat
+              <HeartPulse size={13} strokeWidth={2} /> Run heartbeat
             </button>
             <button
               onClick={togglePause}
               disabled={!!pending}
-              className="text-[12px] border border-[var(--color-hair-2)] rounded px-3 py-1.5 hover:bg-[var(--color-hi)]"
+              title={agent.status === "paused" ? "Resume scheduled heartbeats" : "Pause scheduled heartbeats"}
+              className="btn sm btn-scale"
             >
-              {agent.status === "paused" ? "Resume" : "Pause"}
+              {agent.status === "paused" ? (
+                <>
+                  <Play size={13} strokeWidth={2} /> Resume
+                </>
+              ) : (
+                <>
+                  <Pause size={13} strokeWidth={2} /> Pause
+                </>
+              )}
             </button>
             <button
               onClick={exportYaml}
               title="Download this agent's definition as reviewable YAML (agent-as-code)"
-              className="text-[12px] border border-[var(--color-hair-2)] rounded px-3 py-1.5 hover:bg-[var(--color-hi)]"
+              className="btn sm btn-scale"
             >
-              Export YAML
+              <Download size={13} strokeWidth={2} /> Export YAML
             </button>
           </div>
         </div>
@@ -213,41 +223,78 @@ export default function AgentDetailPage() {
 
         <section className="mt-8">
           <h2 className="text-[11px] uppercase tracking-wider text-[var(--color-muted)] font-mono">Recent runs</h2>
-          <div className="mt-2 space-y-2">
-            {recentRuns.length === 0 && (
-              <p className="text-[13px] text-[var(--color-muted-2)] italic">no runs yet</p>
-            )}
-            {recentRuns.map((r) => (
-              <div
-                key={r.id}
-                className="border border-[var(--color-hair)] rounded p-3 flex items-start gap-3 text-[12px]"
-              >
-                <span
-                  className={`chip ${
-                    r.status === "ok" ? "text-[var(--color-ok)]" : r.status === "failed" ? "text-[var(--color-err)]" : ""
-                  }`}
-                >
-                  {r.status}
-                </span>
-                <span className="font-mono text-[var(--color-muted)]">{r.trigger}</span>
-                <span className="flex-1">
-                  {r.errorText ? (
-                    <span className="text-[var(--color-err)]">{r.errorText}</span>
-                  ) : (
-                    <>
-                      {(r.traceJson ?? []).slice(0, 4).join(" · ")}
-                    </>
-                  )}
-                </span>
-                <span className="text-[var(--color-muted)] font-mono">
-                  {new Date(r.startedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-                </span>
-              </div>
-            ))}
-          </div>
+          <RecentRuns runs={recentRuns} />
         </section>
       </div>
     </main>
+  );
+}
+
+// Recent runs can pile up (the API returns the latest batch), which made the
+// page scroll forever. Cap the visible list and reveal more as the user
+// scrolls a sentinel into view at the bottom of a fixed-height pane.
+const RUNS_PAGE = 8;
+
+function RecentRuns({ runs }: { runs: AgentRun[] }) {
+  const [visible, setVisible] = useState(RUNS_PAGE);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // Reset the window whenever the underlying run list changes (e.g. a refresh
+  // after firing a heartbeat) so we don't strand the user deep in a stale list.
+  useEffect(() => setVisible(RUNS_PAGE), [runs]);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || visible >= runs.length) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setVisible((v) => Math.min(v + RUNS_PAGE, runs.length));
+        }
+      },
+      { rootMargin: "80px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [visible, runs.length]);
+
+  if (runs.length === 0) {
+    return <p className="text-[13px] text-[var(--color-muted-2)] italic mt-2">no runs yet</p>;
+  }
+
+  return (
+    <div className="mt-2 max-h-[420px] overflow-auto space-y-2 pr-1">
+      {runs.slice(0, visible).map((r) => (
+        <div
+          key={r.id}
+          className="border border-[var(--color-hair)] rounded p-3 flex items-start gap-3 text-[12px]"
+        >
+          <span
+            className={`chip ${
+              r.status === "ok" ? "text-[var(--color-ok)]" : r.status === "failed" ? "text-[var(--color-err)]" : ""
+            }`}
+          >
+            {r.status}
+          </span>
+          <span className="font-mono text-[var(--color-muted)]">{r.trigger}</span>
+          <span className="flex-1">
+            {r.errorText ? (
+              <span className="text-[var(--color-err)]">{r.errorText}</span>
+            ) : (
+              <>{(r.traceJson ?? []).slice(0, 4).join(" · ")}</>
+            )}
+          </span>
+          <span className="text-[var(--color-muted)] font-mono">
+            {new Date(r.startedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+          </span>
+        </div>
+      ))}
+      {visible < runs.length && (
+        <div ref={sentinelRef} className="py-2 text-center text-[11px] text-[var(--color-muted-2)] font-mono">
+          scroll for more · {runs.length - visible} older
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/web/src/pages/DM.tsx
+++ b/web/src/pages/DM.tsx
@@ -22,6 +22,7 @@ export default function DMPage() {
   const threadRootId = useBus((s) => s.threadRootId);
   const openThread = useBus((s) => s.openThread);
   const closeThread = useBus((s) => s.closeThread);
+  const openDetails = useBus((s) => s.openDetails);
   const [convId, setConvId] = useState<string | null>(null);
   const creatingRef = useRef<string | null>(null);
 
@@ -97,11 +98,19 @@ export default function DMPage() {
     <main className="flex h-full min-w-0 min-h-0 flex-1 bg-paper overflow-hidden">
       <div className="workspace flex-1 min-w-0">
         <header className="chan-head">
-          <Avatar name={otherName} color="" agent={otherAgent} size="sm" status={otherStatus} />
-          <div className="ch-title">{otherName}</div>
-          <div className="ch-meta">
-            <span className="font-mono text-[12px]">@{otherHandle}</span>
-          </div>
+          <button
+            type="button"
+            className="dm-head-id"
+            onClick={() => otherMemberId && openDetails(otherMemberId)}
+            disabled={!otherMemberId}
+            title={`View ${otherName}'s profile`}
+          >
+            <Avatar name={otherName} color="" agent={otherAgent} size="sm" status={otherStatus} />
+            <span className="ch-title">{otherName}</span>
+            <span className="ch-meta">
+              <span className="font-mono text-[12px]">@{otherHandle}</span>
+            </span>
+          </button>
           <div className="ch-right">
             <button
               className="ch-btn"

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1101,6 +1101,19 @@ input, textarea { font: inherit; color: inherit; }
   font-weight: 600; font-size: 16px;
   letter-spacing: -0.01em; color: var(--color-ink);
 }
+/* DM header identity — the avatar + name act as one button that opens the
+   member profile panel. Keeps the inner gap matching the bare header layout. */
+.dm-head-id {
+  display: inline-flex; align-items: center; gap: 14px;
+  padding: 3px 8px; margin: -3px -4px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  text-align: left;
+  cursor: pointer;
+}
+.dm-head-id:hover { background: var(--color-hi); }
+.dm-head-id:disabled { cursor: default; }
+.dm-head-id:disabled:hover { background: transparent; }
 .chan-head .ch-meta {
   display: flex; align-items: center; gap: 10px;
   color: var(--color-muted); font-size: 13px;
@@ -1619,6 +1632,19 @@ input, textarea { font: inherit; color: inherit; }
 .btn.ghost:hover { color: var(--color-ink); background: var(--color-hi); }
 .btn.sm { padding: 3px 9px; font-size: 12px; }
 .btn.xs { padding: 1px 6px; font-size: 11px; font-family: var(--font-mono); }
+.btn:disabled { opacity: 0.45; cursor: default; }
+
+/* Action toolbar on the agent detail header — groups the run/pause/export
+   controls into one segmented bar so they read as buttons, not links. */
+.agent-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px;
+  border: 1px solid var(--color-hair);
+  border-radius: 10px;
+  background: var(--color-hi);
+}
 
 /* approval row */
 .approve-row {


### PR DESCRIPTION
Four small UI affordance fixes on the agents and DM surfaces.

## Changes
- **Agent toolbar** — the Test heartbeat / Run heartbeat / Pause / Export YAML actions were borderless and read as links. Grouped them into a segmented `.agent-toolbar` of real buttons with icons.
- **Recent runs scroll** — the run list rendered the whole batch and grew without bound. Now a fixed-height pane revealing 8 more at a time via an `IntersectionObserver` sentinel as you scroll.
- **DM profile access** — the DM header avatar + name is now a button that opens the member profile panel (same panel used from message rows / org / members).
- **Profile panel buttons** — removed the icons from the Message / Agent page buttons.

All four files are under `web/src/`; `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)