### PR TITLE
Render markdown tables; give tasks URLs; rework task-modal chrome

### DIFF
--- a/web/src/components/Board.tsx
+++ b/web/src/components/Board.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Plus, MessageSquare, GitBranch, Link2, Calendar, Lock } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -24,26 +24,23 @@ export default function Board() {
   const qc = useQueryClient();
   const me = useMe();
   const dir = useMembersDirectory();
-  const [openTaskId, setOpenTaskId] = useState<string | null>(null);
-  // Deep-link support: notifications (e.g. "a workflow task is ready for you")
-  // and the Goals page navigate here as `/board?task=<id>`. Open that task's
-  // modal on arrival so the link actually lands on the task instead of a bare
-  // board. Without this the param is silently ignored.
+  // The open task lives in the URL as `/board?task=<id>`, so every task has its
+  // own unique, shareable, back-button-friendly address. Opening a card (or a
+  // deep-link from a notification / the Goals page) is just a URL change; the
+  // param is the single source of truth for which modal is open.
   const [searchParams, setSearchParams] = useSearchParams();
-  const taskParam = searchParams.get("task");
-  useEffect(() => {
-    if (taskParam) setOpenTaskId(taskParam);
-  }, [taskParam]);
-  // Closing the modal clears the param too, so the task doesn't re-open on the
-  // next render (the effect above would otherwise keep firing) and a refresh
-  // lands on a clean board.
+  const openTaskId = searchParams.get("task");
+  function openTask(id: string) {
+    const next = new URLSearchParams(searchParams);
+    next.set("task", id);
+    setSearchParams(next); // push, so browser Back closes the task
+  }
+  // Closing clears the param (replace, so we don't pile up history) and lands
+  // on a clean board on refresh.
   function closeTask() {
-    setOpenTaskId(null);
-    if (searchParams.has("task")) {
-      const next = new URLSearchParams(searchParams);
-      next.delete("task");
-      setSearchParams(next, { replace: true });
-    }
+    const next = new URLSearchParams(searchParams);
+    next.delete("task");
+    setSearchParams(next, { replace: true });
   }
   const [addingIn, setAddingIn] = useState<TaskStatus | null>(null);
   const [newTitle, setNewTitle] = useState("");
@@ -249,7 +246,7 @@ export default function Board() {
                       setDragId(null);
                       moveTask(id, col.id, c.id);
                     }}
-                    onClick={() => setOpenTaskId(c.id)}
+                    onClick={() => openTask(c.id)}
                     title={c.id}
                   >
                     <div className="kc-title">{c.title}</div>

--- a/web/src/components/TaskModal.tsx
+++ b/web/src/components/TaskModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { X, Plus, Trash2, Paperclip, Bold, Italic, Code, ChevronDown, Upload } from "lucide-react";
+import { X, Plus, Trash2, Paperclip, Bold, Italic, Code, ChevronDown, Upload, Maximize2, Minimize2 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useTaskDetail,
@@ -57,6 +57,7 @@ export default function TaskModal({
   const [busy, setBusy] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
   const [statusMenuOpen, setStatusMenuOpen] = useState(false);
+  const [maximized, setMaximized] = useState(false);
   const composerTaRef = useRef<HTMLTextAreaElement>(null);
   const bodyTouched = useRef(false);
   const titleTouched = useRef(false);
@@ -273,12 +274,19 @@ export default function TaskModal({
 
   return (
     <div className="modal-bg" onClick={onClose}>
-      <div className="modal task-modal" onClick={(e) => e.stopPropagation()}>
+      <div
+        className={`modal task-modal${maximized ? " task-modal--max" : ""}`}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="task-modal-head">
           <span className="mono text-[11px] text-[var(--color-muted)]">{t.id}</span>
           <span className="tm-head-spacer" />
-          <button className="tb-btn" onClick={deleteTask} title="Delete task">
-            <Trash2 size={14} />
+          <button
+            className="tb-btn"
+            onClick={() => setMaximized((m) => !m)}
+            title={maximized ? "Restore size" : "Maximize"}
+          >
+            {maximized ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
           </button>
           <button className="tb-btn" onClick={onClose} title="Close">
             <X size={14} />
@@ -722,6 +730,9 @@ export default function TaskModal({
                   day: "numeric",
                 })}
               </div>
+              <button className="tm-delete-btn" onClick={deleteTask} title="Delete task">
+                <Trash2 size={13} strokeWidth={2} /> Delete task
+              </button>
             </div>
           </aside>
         </div>

--- a/web/src/lib/md.ts
+++ b/web/src/lib/md.ts
@@ -42,6 +42,9 @@ export function renderMarkdown(
   );
   return DOMPurify.sanitize(withMentions, {
     ADD_ATTR: ["target", "rel"],
-    ALLOWED_ATTR: ["class", "href", "title", "target", "rel"],
+    // `style` is allowed so GFM table column alignment (markdown-it emits
+    // `style="text-align:…"` on th/td) survives — DOMPurify sanitizes the
+    // CSS value, so this stays safe.
+    ALLOWED_ATTR: ["class", "href", "title", "target", "rel", "style"],
   });
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1278,6 +1278,32 @@ input, textarea { font: inherit; color: inherit; }
   text-decoration-color: rgba(35, 131, 226, 0.4);
   text-underline-offset: 3px;
 }
+/* GFM tables — markdown-it parses them by default, but with no styling they
+   collapse into run-together text. Give them borders, padding, and a header
+   tint so they read as tables in messages, threads, comments, and cards. */
+.msg-body table {
+  border-collapse: collapse;
+  width: auto;
+  max-width: 100%;
+  margin: 6px 0;
+  font-size: 13px;
+  display: block;
+  overflow-x: auto;
+}
+.msg-body th,
+.msg-body td {
+  border: 1px solid var(--color-hair-2);
+  padding: 5px 10px;
+  text-align: left;
+  vertical-align: top;
+  line-height: 1.45;
+}
+.msg-body th {
+  background: var(--color-hi);
+  font-weight: 600;
+  color: var(--color-ink);
+}
+.msg-body tbody tr:nth-child(even) td { background: var(--color-hi-2); }
 
 /* reactions */
 .reactions { display: flex; gap: 4px; margin-top: 6px; flex-wrap: wrap; }
@@ -1954,6 +1980,13 @@ input, textarea { font: inherit; color: inherit; }
   display: flex; flex-direction: column;
   overflow: hidden;
 }
+/* Maximized: take over the viewport (minus the backdrop padding). */
+.modal.task-modal--max {
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  max-height: none;
+}
 .task-modal-head {
   display: flex; align-items: center; gap: 8px;
   padding: 10px 14px;
@@ -2040,6 +2073,24 @@ input, textarea { font: inherit; color: inherit; }
   text-align: right;
 }
 .tm-rail-meta { border-top: 1px solid var(--color-hair); padding-top: 12px; }
+/* Small delete button tucked under Created in the rail (moved out of the
+   header, which now holds maximize). Quiet by default, red on hover. */
+.tm-delete-btn {
+  margin-top: 4px;
+  align-self: flex-start;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 9px;
+  font-size: 12px;
+  border-radius: 6px;
+  border: 1px solid var(--color-hair-2);
+  background: var(--color-paper);
+  color: var(--color-muted);
+}
+.tm-delete-btn:hover {
+  border-color: var(--color-err);
+  color: var(--color-err);
+  background: var(--color-hi);
+}
 @media (max-width: 780px) {
   .modal.task-modal { width: 96vw; }
   .task-modal-body.tm-split {


### PR DESCRIPTION
Four UI fixes across markdown rendering and the board task modal.

## Changes
- **Markdown tables** — tables were parsed by markdown-it but rendered as unstyled, run-together text everywhere markdown shows (messages, threads, comments, task cards). Added `.msg-body` table CSS (borders, header tint, zebra rows, overflow scroll) and allowed `style` through DOMPurify so GFM column alignment survives (the value is still sanitized).
- **Unique task URLs** — opening a board card now drives the URL as `/board?task=<id>`, so every task has its own shareable, back-button-friendly address. The param is the single source of truth (push on open, replace on close).
- **Maximize button** — the task modal header's delete button (next to close, easy to mis-click) is replaced with a maximize/restore toggle that expands the modal to fill the viewport.
- **Delete relocated** — delete moved into the right rail under **Created**, as a small quiet button that turns red on hover.

`tsc --noEmit` and `npm run build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)