### PR TITLE
Add segmented toggle component; fix squished Goal/Project switch

### DIFF
--- a/web/src/components/Segmented.tsx
+++ b/web/src/components/Segmented.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+
+export type SegmentedOption<T extends string> = {
+  value: T;
+  label: string;
+  icon?: ReactNode;
+};
+
+// A small iOS-style segmented toggle. The active segment lifts onto a paper
+// "pill" inside a tinted track, so the choice reads clearly instead of two
+// cramped buttons. Generic over the value union so callers stay type-safe.
+export default function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  size = "md",
+  ariaLabel,
+}: {
+  options: SegmentedOption<T>[];
+  value: T;
+  onChange: (v: T) => void;
+  size?: "sm" | "md";
+  ariaLabel?: string;
+}) {
+  return (
+    <div className={`seg seg--${size}`} role="tablist" aria-label={ariaLabel}>
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          role="tab"
+          aria-selected={value === o.value}
+          className={`seg-opt${value === o.value ? " active" : ""}`}
+          onClick={() => onChange(o.value)}
+        >
+          {o.icon && <span className="seg-opt-icon">{o.icon}</span>}
+          <span>{o.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/pages/Goals.tsx
+++ b/web/src/pages/Goals.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Target, Plus, Wand2, ChevronRight, ChevronDown } from "lucide-react";
+import { Target, Plus, Wand2, ChevronRight, ChevronDown, FolderKanban } from "lucide-react";
 import { api, type Goal, type Task, type PlanResult } from "../api/client";
 import { humanizeError } from "../api/errors";
 import { useGoals, useTasks, useMembersDirectory } from "../lib/hooks";
+import Segmented from "../components/Segmented";
 
 const STATUS_LABEL: Record<string, string> = {
   open: "Open",
@@ -163,18 +164,15 @@ export default function GoalsPage() {
             <div className="mt-3 flex flex-wrap items-center gap-2">
               {/* Kind toggle — a project is a top-level container; a goal is a
                   unit of intent the planner decomposes (and can nest under a project). */}
-              <div className="inline-flex rounded-md border border-[var(--color-border)] overflow-hidden text-[12px]">
-                {(["goal", "project"] as const).map((k) => (
-                  <button
-                    key={k}
-                    className={`px-2.5 py-1 ${newKind === k ? "bg-[var(--color-accent,#1a73e8)] text-white" : "text-[var(--color-muted)]"}`}
-                    onClick={() => setNewKind(k)}
-                    type="button"
-                  >
-                    {k === "project" ? "Project" : "Goal"}
-                  </button>
-                ))}
-              </div>
+              <Segmented
+                ariaLabel="Goal or project"
+                value={newKind}
+                onChange={setNewKind}
+                options={[
+                  { value: "goal", label: "Goal", icon: <Target size={13} strokeWidth={2} /> },
+                  { value: "project", label: "Project", icon: <FolderKanban size={13} strokeWidth={2} /> },
+                ]}
+              />
               {newKind === "goal" && (
                 <select
                   className="text-[12px] bg-transparent border border-[var(--color-border)] rounded-md px-2 py-1 outline-none"

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1660,6 +1660,43 @@ input, textarea { font: inherit; color: inherit; }
 .btn.xs { padding: 1px 6px; font-size: 11px; font-family: var(--font-mono); }
 .btn:disabled { opacity: 0.45; cursor: default; }
 
+/* Segmented toggle (components/Segmented.tsx) — a tinted track with the
+   active option lifted onto a paper pill. Used for Goal/Project and any
+   small either/or choice. */
+.seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  background: var(--color-hi);
+  border: 1px solid var(--color-hair);
+  border-radius: 9px;
+}
+.seg-opt {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  color: var(--color-muted);
+  border: 1px solid transparent;
+  border-radius: 7px;
+  transition: background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+}
+.seg--sm .seg-opt { padding: 3px 10px; font-size: 12px; gap: 5px; }
+.seg-opt:hover { color: var(--color-ink); }
+.seg-opt.active {
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border-color: var(--color-hair-2);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+.seg-opt-icon { display: inline-flex; }
+@media (prefers-reduced-motion: reduce) {
+  .seg-opt { transition: none; }
+}
+
 /* Action toolbar on the agent detail header — groups the run/pause/export
    controls into one segmented bar so they read as buttons, not links. */
 .agent-toolbar {


### PR DESCRIPTION
## Problem
The Goal/Project switch on the new-goal form was two cramped buttons in a tiny bordered box with a hardcoded `#1a73e8` accent that didn't match the app — it read as squished rather than a real control.

## Changes
- **New `components/Segmented.tsx`** — a reusable, generic, type-safe iOS-style segmented toggle (tinted track, active option lifted onto a paper pill, optional icons, `sm`/`md` sizes, reduced-motion aware).
- **Goals** — use it for the Goal/Project toggle (Target / FolderKanban icons).
- **styles** — `.seg` / `.seg-opt` built from the app's own ink/paper/hairline tokens, not a one-off blue.

`tsc --noEmit` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)