### PR TITLE
Make goal progress bar ink, not blue

### DIFF
--- a/web/src/pages/Goals.tsx
+++ b/web/src/pages/Goals.tsx
@@ -271,7 +271,7 @@ export default function GoalsPage() {
                     {c.total > 0 && (
                       <div className="mt-1.5 h-1.5 w-full rounded-full bg-[var(--color-border)] overflow-hidden">
                         <div
-                          className="h-full rounded-full bg-[var(--color-accent,#1a73e8)] transition-all"
+                          className="h-full rounded-full bg-[var(--color-ink)] transition-all"
                           style={{ width: `${pct}%` }}
                         />
                       </div>


### PR DESCRIPTION
The goal-completion bar used `var(--color-accent)` with a `#1a73e8` fallback; since `--color-accent` is undefined it rendered blue — off-brand for the app's black/ink palette. Now uses `--color-ink`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)