### PR TITLE
Integrate Composio SDK so agents can use connected SaaS tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,13 @@ VITE_WS_URL=/events
 # GOAL_STALL_REPLAN=on        # auto re-plan stalled goals (archives+regenerates open tasks); default just notifies the owner
 # ENFORCE_AGENT_SCOPES=off    # default ON; set off for a trusted single-tenant deploy
 # APPROVE_RISK_AT=medium      # force approval for actions at/above this risk (low|medium|high)
+
+# ── Composio (optional) — give agents your connected SaaS tools ──
+# Set COMPOSIO_API_KEY to turn it on (dormant / no errors when empty). Agents get
+# a composio_* MCP toolset (bundled Hermes/OpenClaw) plus a composio_execute
+# action, and every outbound call routes through the approval gate. The SDK + key
+# live server-side only. See docs/composio.md.
+# COMPOSIO_API_KEY=
+# COMPOSIO_USER_ID=default    # the Composio user/entity whose connections agents act as
+# COMPOSIO_TOOLKITS=          # optional csv allow-list (e.g. github,gmail); empty = every connected toolkit
+# COMPOSIO_APPROVAL=all       # all | writes | off — gate outbound Composio calls (default all)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You get Slack-shaped ergonomics for humans. You get a clean, versioned, MIT-lice
 - **Context packet**: agent identity + org-chart, recent messages from relevant conversations, open tasks assigned to me, pending approvals, rolling memory. Assembled per trigger, not broadcast firehose.
 - **Action allowlist**: `post_message`, `react`, `open_thread`, `share_files`, `create_task`, `update_task`, `assign_task`, `task_comment`, `share_to_task`, `request_approval`, `set_memory`. Anything else is dropped.
 - **Approvals**: gate risky actions (email, outbound API, billing) behind a human click. Agents emit `request_approval`, the platform wakes them with `approval_response` on decision. Approvers can attach credentials that land directly in the agent's environment — secrets never transit chat or the DB.
+- **Connected SaaS tools (opt-in)**: set a `COMPOSIO_API_KEY` and every agent gains a `composio_*` toolset backed by *your* connected accounts (Gmail, GitHub, Slack, Notion, CRMs, and hundreds more) via [Composio](https://composio.dev). Discovery + execution ride the same MCP / `/agent-api` seam as everything else, so outbound calls inherit the approval gate and audit trail. See **[docs/composio.md](docs/composio.md)**.
 - **Verification gate** (opt-in): before a task flips review→done, an LLM judge scores the actual deliverable against the task's acceptance criteria, and web deliverables get a deterministic headless-render check (blank page or console errors block the flip). The judge fails open on outage by design — a gateway hiccup never freezes the board. See [docs/CONFIG.md](docs/CONFIG.md).
 - **Reply-guard**: server-side filter rejects Python tracebacks, gateway errors, assistant refusals, tool-call JSON dumps, action-JSON leaks, runaway repetition, bearer-token leaks, and meta-narration like "Reply posted successfully…". Agents can't spam a channel even if the model derails.
 - **Task-only mode**: when a heartbeat finds channels quiet but the agent has open work, the bridge fires with no conversation attached and the prompt switches to a strict contract — the only valid output is an `<actions>` block or `HEARTBEAT_OK`.
@@ -70,11 +71,11 @@ You get Slack-shaped ergonomics for humans. You get a clean, versioned, MIT-lice
 
 Honest scope, so you know what you're deploying.
 
-**Can:** post, react, and thread in channels and DMs; create, claim, update, and comment on board tasks; run code and edit files inside their own container (terminal + file toolsets ship in the default template); search and fetch from the web (bring a search-backend key, or point the runtime at a self-hosted SearXNG); write deliverables to a shared `/workspace` and attach them to tasks; request human approval before anything risky; keep durable memory across turns.
+**Can:** post, react, and thread in channels and DMs; create, claim, update, and comment on board tasks; run code and edit files inside their own container (terminal + file toolsets ship in the default template); search and fetch from the web (bring a search-backend key, or point the runtime at a self-hosted SearXNG); write deliverables to a shared `/workspace` and attach them to tasks; **act inside your existing SaaS tools — Gmail, GitHub, Slack, Notion, CRMs, and hundreds more — via [Composio](docs/composio.md) (opt-in)**; request human approval before anything risky; keep durable memory across turns.
 
-**Can't (yet):** log into your existing tools. There is no integration catalog — no Gmail, GitHub, Slack, or CRM connectors. Anything that leaves the workspace goes through an approval-gated request plus whatever credentials you explicitly hand an agent. Wiring MCP tool servers into agent toolsets is the next major item on the roadmap.
+**Can't (yet):** reach a tool you haven't connected. The Composio integration is opt-in (set `COMPOSIO_API_KEY`) and scoped to the accounts you link; without it — or for something outside Composio's catalog — anything that leaves the workspace still goes through an approval-gated request plus whatever credentials you explicitly hand an agent.
 
-If you need agents acting inside dozens of SaaS tools today, n8n or Lindy will serve you better. If you want a governed, auditable team of agents on your own hardware — planning, building, verifying, and shipping artifacts — that's what this is.
+If you want a governed, auditable team of agents on your own hardware — planning, building, verifying, shipping artifacts, and now acting inside your real SaaS tools with a human in the loop — that's what this is.
 
 ---
 
@@ -286,7 +287,7 @@ docs/custom-agents.md         Agent-building reference
 
 Everything is environment variables. Copy `.env.example` and set at minimum `SESSION_SECRET` (≥32 chars) and `PG_PASSWORD`.
 
-The core infrastructure vars are below. For the **agent, LLM, quality-gate, goal-planning, and wake-tuning flags** (planner/verifier gateway, the verification gate, scope enforcement, goal stall/re-plan, ambient damping, Hermes runtime), see **[docs/CONFIG.md](docs/CONFIG.md)** — anything that can block or rewrite work is off/conservative by default.
+The core infrastructure vars are below. For the **agent, LLM, quality-gate, goal-planning, and wake-tuning flags** (planner/verifier gateway, the verification gate, scope enforcement, goal stall/re-plan, ambient damping, Hermes runtime), see **[docs/CONFIG.md](docs/CONFIG.md)** — anything that can block or rewrite work is off/conservative by default. To connect agents to your SaaS tools (Gmail, GitHub, Slack, CRMs, …) via Composio, see **[docs/composio.md](docs/composio.md)**.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.645.0",
         "@aws-sdk/s3-request-presigner": "^3.645.0",
+        "@composio/core": "^0.13.1",
         "@fastify/cookie": "^10.0.1",
         "@fastify/cors": "^10.0.1",
         "@fastify/multipart": "^9.0.1",
@@ -920,6 +921,52 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@composio/client": {
+      "version": "0.1.0-alpha.74",
+      "resolved": "https://registry.npmjs.org/@composio/client/-/client-0.1.0-alpha.74.tgz",
+      "integrity": "sha512-/EHJsFxCpWfRxNvXURRrGVZfJSltSpN4Gkd9M9Cl5gPOirG+NpbXf2B8d4B72H87m7cnOguMKjOH42ogQ84/Ww==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@composio/core": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@composio/core/-/core-0.13.1.tgz",
+      "integrity": "sha512-bC64PJG3RBeuezihfZV/9qJMd1LyzUEFN1tVHTWh32n/muUMr5I33nN6Mezhtkl4+ffBJ8IZ/mNt9tEQKFB/sw==",
+      "license": "ISC",
+      "dependencies": {
+        "@composio/client": "0.1.0-alpha.74",
+        "@composio/json-schema-to-zod": "0.2.0",
+        "@types/json-schema": "^7.0.15",
+        "openai": "^6.42.0",
+        "picocolors": "^1.1.1",
+        "pusher-js": "^8.5.0",
+        "semver": "^7.8.4",
+        "zod-to-json-schema": "^3.25.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/@composio/core/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@composio/json-schema-to-zod": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@composio/json-schema-to-zod/-/json-schema-to-zod-0.2.0.tgz",
+      "integrity": "sha512-P7ym7+1NCN2cDVlSOGTINY6KjZ/d162uc+0LChYcy3d5RAAacgHiGU7ZJF+5pUJHbIivsfAC/4PdjVdsfmHdeA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": ">=3.25.76 <5"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -2562,20 +2609,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.16",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
-      "integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
+      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.24",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2700,14 +2739,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
-      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.4.6.tgz",
+      "integrity": "sha512-O6YGQgZGxypohUJDm+aIBNx9ldzOvQOjnnAmHYKAVJcVRMYQLf+g88s/vCUIHJudeXbgEo7xq1vXUGYlBpdBsg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.29.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2958,18 +2995,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
+      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2995,9 +3027,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3286,6 +3318,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -4924,6 +4962,36 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openai": {
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -4981,7 +5049,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -5190,6 +5257,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/pusher-js": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.5.0.tgz",
+      "integrity": "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==",
+      "license": "MIT",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
       }
     },
     "node_modules/quick-format-unescaped": {
@@ -6102,6 +6178,12 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6930,6 +7012,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.645.0",
     "@aws-sdk/s3-request-presigner": "^3.645.0",
+    "@composio/core": "^0.13.1",
     "@fastify/cookie": "^10.0.1",
     "@fastify/cors": "^10.0.1",
     "@fastify/multipart": "^9.0.1",

--- a/api/scripts/composio-mcp.mjs
+++ b/api/scripts/composio-mcp.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Composio MCP stdio server. Exposes the workspace's connected SaaS tools
+// (Gmail, GitHub, Slack, CRMs, …) to an agent runtime as three meta-tools:
+// discover (composio_list_tools), run (composio_execute), and inspect
+// connections (composio_connections).
+//
+// Dependency-free by design — it only speaks HTTP to CircleChat's /agent-api,
+// exactly like circlechat-mcp.mjs. The Composio SDK and COMPOSIO_API_KEY live
+// server-side in the CircleChat API; this shim (which runs INSIDE the agent
+// container) never sees them. Execution is routed through /agent-api/act so it
+// inherits scope/risk/approval gating.
+//
+// Wire-up (mirrors circlechat): registered by the equip layer with
+//   command: node, args: [<this-file>, <botToken>, <apiBase>]
+
+import { createInterface } from "node:readline";
+
+const TOKEN = process.argv[2] || process.env.CC_BOT_TOKEN || "";
+const BASE = (process.argv[3] || process.env.CC_API_BASE || "http://localhost:3300/api").replace(/\/$/, "");
+
+if (!TOKEN) {
+  console.error("composio-mcp: missing bot token (argv[2] or CC_BOT_TOKEN)");
+  process.exit(1);
+}
+
+async function apiGet(path) {
+  const r = await fetch(`${BASE}${path}`, { headers: { authorization: `Bearer ${TOKEN}` } });
+  if (!r.ok) throw new Error(`GET ${path} → ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  return r.json();
+}
+async function apiPost(path, body) {
+  const r = await fetch(`${BASE}${path}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!r.ok) throw new Error(`POST ${path} → ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  return r.json();
+}
+
+// ──────────────────────── tool catalog ────────────────────────
+
+const TOOLS = [
+  {
+    name: "composio_list_tools",
+    description:
+      "Discover Composio tools you can run against the workspace's connected accounts (Gmail, GitHub, Slack, Notion, CRMs, …). Returns tool slugs + input schemas. Filter with `toolkits` (comma-separated, e.g. \"github,gmail\") and/or a `search` term. ALWAYS call this first to get the exact slug + arguments, then run it with composio_execute.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        toolkits: { type: "string", description: 'comma-separated toolkit slugs, e.g. "github,gmail"' },
+        search: { type: "string", description: "fuzzy search across tool names/descriptions" },
+        limit: { type: "number", minimum: 1, maximum: 200 },
+      },
+      additionalProperties: false,
+    },
+    run: ({ toolkits, search, limit }) => {
+      const q = new URLSearchParams();
+      if (toolkits) q.set("toolkits", toolkits);
+      if (search) q.set("search", search);
+      if (limit) q.set("limit", String(limit));
+      const qs = q.toString();
+      return apiGet(`/agent-api/composio/tools${qs ? `?${qs}` : ""}`);
+    },
+  },
+  {
+    name: "composio_connections",
+    description:
+      "List the connected accounts available to you — which SaaS toolkits are linked, their status, and the approval policy. Use this to see what you can act on before discovering tools.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    run: () => apiGet("/agent-api/composio/status"),
+  },
+  {
+    name: "composio_execute",
+    description:
+      "Run ONE Composio tool by slug (from composio_list_tools) with its arguments, acting as the workspace's connected account. Outbound/write actions are gated: if the result says an approval was opened (ap_…), STOP — do NOT call it again. It runs automatically once a human approves and you'll be woken with an approval_response trigger.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: { type: "string", description: "exact Composio tool slug, e.g. GITHUB_CREATE_AN_ISSUE" },
+        arguments: { type: "object", description: "arguments object matching the tool's inputSchema" },
+        conversation_id: {
+          type: "string",
+          description: "optional: the conversation this is for, so an approval confirmation is posted there",
+        },
+      },
+      required: ["slug"],
+      additionalProperties: false,
+    },
+    run: async ({ slug, arguments: args, conversation_id }) => {
+      const res = await apiPost("/agent-api/act", {
+        action: {
+          type: "composio_execute",
+          slug,
+          arguments: args ?? {},
+          ...(conversation_id ? { conversation_id } : {}),
+        },
+      });
+      // Tool ran → hand back its output. Gated/rejected → surface the message
+      // (which names the approval card) so the model knows to wait, not retry.
+      const cr = Array.isArray(res.composioResults)
+        ? (res.composioResults.find((r) => r.slug === slug) ?? res.composioResults[0])
+        : null;
+      if (cr) return cr;
+      if (Array.isArray(res.errors) && res.errors.length) {
+        return { pending_approval: true, message: res.errors.join("; ") };
+      }
+      return res;
+    },
+  },
+];
+
+// ──────────────────────── JSON-RPC (MCP stdio) ────────────────────────
+
+const PROTOCOL_VERSION = "2024-11-05";
+
+function send(msg) {
+  process.stdout.write(JSON.stringify(msg) + "\n");
+}
+function result(id, res) {
+  send({ jsonrpc: "2.0", id, result: res });
+}
+function error(id, code, message) {
+  send({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+async function handle(req) {
+  const { id, method, params } = req;
+  try {
+    if (method === "initialize") {
+      return result(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: "composio", version: "0.1.0" },
+      });
+    }
+    if (method === "notifications/initialized") return;
+    if (method === "tools/list") {
+      return result(id, {
+        tools: TOOLS.map((t) => ({
+          name: t.name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+        })),
+      });
+    }
+    if (method === "tools/call") {
+      const tool = TOOLS.find((t) => t.name === params?.name);
+      if (!tool) return error(id, -32601, `unknown tool: ${params?.name}`);
+      const out = await tool.run(params.arguments ?? {});
+      return result(id, { content: [{ type: "text", text: JSON.stringify(out, null, 2) }] });
+    }
+    if (method === "ping") return result(id, {});
+    error(id, -32601, `method not found: ${method}`);
+  } catch (e) {
+    error(id, -32000, (e instanceof Error ? e.message : String(e)).slice(0, 500));
+  }
+}
+
+const rl = createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let msg;
+  try {
+    msg = JSON.parse(trimmed);
+  } catch {
+    return;
+  }
+  handle(msg);
+});
+
+process.stdin.on("end", () => process.exit(0));

--- a/api/src/agents/executor.ts
+++ b/api/src/agents/executor.ts
@@ -43,6 +43,7 @@ import { putObject, publicUrl, readObject } from "../lib/storage.js";
 import { createArtifact, isSubstantiveContent } from "../lib/task-artifacts.js";
 import { notifyForMessage } from "../lib/notifications.js";
 import { writeProjectFile } from "../lib/project-files.js";
+import { executeComposioTool, composioNeedsApproval } from "../lib/composio.js";
 
 export interface AgentAttachment {
   key: string;
@@ -173,12 +174,35 @@ export type AgentAction =
       mode?: "append" | "replace";
       summary?: string;
       triggers?: string[];
+    }
+  // Execute a tool from the user's Composio connections (Gmail, GitHub, Slack,
+  // CRMs, …). The Composio SDK + API key live server-side (lib/composio.ts); the
+  // agent only names a `slug` + `arguments` it discovered via composio_list_tools.
+  // Gated by COMPOSIO_APPROVAL (approval-gated by default) and audit-logged like
+  // every other action.
+  | {
+      type: "composio_execute";
+      slug: string;
+      arguments?: Record<string, unknown>;
+      conversation_id?: string;
+      task_id?: string;
     };
+
+// Result of a composio_execute action, surfaced back to the caller (the MCP
+// shim → the model) so a tool's output is available mid-turn. Not persisted.
+export interface ComposioActionResult {
+  slug: string;
+  ok: boolean;
+  data?: Record<string, unknown>;
+  error?: string | null;
+}
 
 export interface ExecOutcome {
   actionsApplied: number;
   errors: string[];
   trace: string[];
+  // Populated only when the batch contained composio_execute action(s).
+  composioResults?: ComposioActionResult[];
 }
 
 // Executor-performed actions that are safe to AUTO-REPLAY when their gated
@@ -205,6 +229,9 @@ const AUTO_REPLAYABLE = new Set([
   "memory_append",
   "memory_rethink",
   "project_note",
+  // Approved outbound Composio calls replay server-side from their stored
+  // payload — the human authorized exactly this slug + arguments.
+  "composio_execute",
 ]);
 
 export interface ApprovedReplayResult {
@@ -357,6 +384,23 @@ function describeForApproval(a: AgentAction): { action: string; conversationId: 
       return { action: `${a.type} on ${a.task_id}`, conversationId: null, payload: { ...a } };
     case "project_note":
       return { action: `project_note ${a.project}/${a.file ?? "log.md"}`, conversationId: null, payload: { ...a } };
+    case "composio_execute": {
+      // Include a truncated argument preview so (a) the human sees exactly what
+      // the tool will do in the approvals UI, and (b) two distinct calls to the
+      // same slug aren't collapsed by the trigram approval-dedupe.
+      let argHint = "";
+      try {
+        const s = JSON.stringify(a.arguments ?? {});
+        argHint = s.length > 140 ? `${s.slice(0, 140)}…` : s;
+      } catch {
+        argHint = "";
+      }
+      return {
+        action: `composio_execute ${a.slug} ${argHint}`.trim(),
+        conversationId: a.conversation_id ?? null,
+        payload: { ...a },
+      };
+    }
     default:
       return { action: a.type, conversationId: null, payload: {} };
   }
@@ -506,6 +550,7 @@ const REQUIRED_STRING_FIELDS: Record<string, string[]> = {
   share_files: ["conversation_id"],
   share_to_task: ["task_id"],
   project_note: ["project", "note"],
+  composio_execute: ["slug"],
 };
 
 export function validateActionShape(a: AgentAction): string | null {
@@ -618,9 +663,18 @@ export async function applyActions(params: {
       // the approvals UI. The payload is preserved for replay-on-approval.
       const outOfScope = enforce && !actionAllowedByScopes(a.type, scopes);
       const riskGated = riskGate && actionGatedByRisk(a.type);
-      if (outOfScope || riskGated) {
+      // Composio has its own gate (COMPOSIO_APPROVAL), independent of the global
+      // scope/risk flags: an outbound call to a connected SaaS tool is gated by
+      // default so a human sees "send this email / create this issue" first.
+      const composioGated =
+        a.type === "composio_execute" && composioNeedsApproval((a as { slug: string }).slug);
+      if (outOfScope || riskGated || composioGated) {
         const d = describeForApproval(a);
-        const reason = outOfScope ? (ACTION_SCOPE[a.type] ?? a.type) : `risk:${ACTION_RISK[a.type] ?? "low"}`;
+        const reason = composioGated
+          ? `composio:${(a as { slug: string }).slug}`
+          : outOfScope
+            ? (ACTION_SCOPE[a.type] ?? a.type)
+            : `risk:${ACTION_RISK[a.type] ?? "low"}`;
         // A matching APPROVED approval is a one-shot pass: the human already
         // said yes to exactly this action, so execute it now and consume the
         // approval (status → applied) so it can't authorize a second replay.
@@ -675,7 +729,11 @@ export async function applyActions(params: {
             conversationId: d.conversationId,
           });
         }
-        const why = outOfScope ? `requires scope "${reason}"` : `is ${reason} and needs approval`;
+        const why = composioGated
+          ? `is a Composio tool call and needs approval before it runs`
+          : outOfScope
+            ? `requires scope "${reason}"`
+            : `is ${reason} and needs approval`;
         out.trace.push(`gated ${a.type} → approval ${apId} (${why})`);
         out.errors.push(`${a.type} ${why} — opened approval ${apId}`);
         continue;
@@ -991,6 +1049,52 @@ async function applyOne(
     case "call_tool": {
       // The platform doesn't execute tools — the agent runtime does. We just record it.
       out.trace.push(`tool ${a.name}`);
+      return;
+    }
+    case "composio_execute": {
+      // Run the tool via the server-side Composio SDK (lib/composio.ts). The gate
+      // in applyActions already decided this call is allowed to run now (either
+      // COMPOSIO_APPROVAL let it through, or a human approved it and this is the
+      // replay). Failures come back as {successful:false, error} — surface them
+      // to the model rather than throwing.
+      let result;
+      try {
+        result = await executeComposioTool(a.slug, a.arguments ?? {});
+      } catch (e) {
+        const msg = (e as Error).message;
+        out.trace.push(`composio_execute ${a.slug} → error: ${msg}`);
+        out.errors.push(`composio_execute ${a.slug}: ${msg}`);
+        (out.composioResults ??= []).push({ slug: a.slug, ok: false, error: msg });
+        return;
+      }
+      (out.composioResults ??= []).push({
+        slug: a.slug,
+        ok: result.successful,
+        data: result.data,
+        error: result.error,
+      });
+      out.trace.push(
+        `composio_execute ${a.slug} → ${result.successful ? "ok" : `failed: ${result.error}`}`,
+      );
+      if (!result.successful) {
+        out.errors.push(`composio_execute ${a.slug} failed: ${result.error ?? "unknown_error"}`);
+      }
+      // Approval-replay runs server-side with no synchronous caller to receive
+      // the result, so post a concise confirmation into the originating
+      // conversation (the agent is also woken with an approval_response trigger).
+      // Non-fatal: the agent may not be a member of the conversation.
+      if (runId === "approval-replay" && a.conversation_id) {
+        const summary = result.successful
+          ? `✅ Approved Composio action ran: \`${a.slug}\`.`
+          : `⚠️ Approved Composio action \`${a.slug}\` failed: ${result.error ?? "unknown error"}.`;
+        await applyOne(
+          agentId,
+          runId,
+          agentMemberId,
+          { type: "post_message", conversation_id: a.conversation_id, body_md: summary } as AgentAction,
+          out,
+        ).catch((e) => out.trace.push(`composio replay post failed: ${(e as Error).message}`));
+      }
       return;
     }
     case "run_code": {

--- a/api/src/agents/hermes-equip.ts
+++ b/api/src/agents/hermes-equip.ts
@@ -10,6 +10,7 @@ import {
   buildHermesCommand,
   mcpScriptPathForRegistration,
 } from "./hermes-runtime.js";
+import { composioEnabled } from "../lib/composio.js";
 
 const HERMES_HOMES_DIR = process.env.HERMES_HOMES_DIR ?? homedir();
 const BRIDGE_CONFIG_PATH =
@@ -48,6 +49,10 @@ const BROWSER_SKILL_TEMPLATE_DIR =
 const MCP_SCRIPT =
   process.env.CC_MCP_SCRIPT ??
   pathResolve(process.cwd(), "scripts/circlechat-mcp.mjs");
+// The Composio MCP stdio shim (dep-free; proxies to /agent-api/composio + /act).
+const COMPOSIO_MCP_SCRIPT =
+  process.env.CC_COMPOSIO_MCP_SCRIPT ??
+  pathResolve(process.cwd(), "scripts/composio-mcp.mjs");
 
 // What CircleChat's MCP server knows the API base as. Hermes only passes argv
 // strings, not env, to stdio servers — so we bake this in.
@@ -188,6 +193,44 @@ export async function installCircleChatTooling(params: {
     void mcpScriptForRegistration;
     void botToken;
     void CC_API_BASE;
+  }
+
+  // Composio MCP — the user's connected SaaS tools. Registered whenever Composio
+  // is configured server-side (COMPOSIO_API_KEY set). Unlike the circlechat MCP
+  // (whose writes have an <actions> fallback), MCP is the ONLY path to Composio
+  // tools, so it's on by default when enabled; opt out with CC_COMPOSIO_MCP=off.
+  if (composioEnabled() && process.env.CC_COMPOSIO_MCP !== "off") {
+    try {
+      let composioScriptForRegistration = COMPOSIO_MCP_SCRIPT;
+      if (HERMES_RUNTIME === "docker") {
+        // Stage the shim inside HERMES_HOME so the containerised hermes can spawn
+        // it (same trick as the circlechat shim above).
+        const staged = join(hermesHome, basename(COMPOSIO_MCP_SCRIPT));
+        await fs.copyFile(COMPOSIO_MCP_SCRIPT, staged);
+        composioScriptForRegistration = mcpScriptPathForRegistration(hermesHome, COMPOSIO_MCP_SCRIPT);
+      }
+      const configPath = join(hermesHome, "config.yaml");
+      const raw = await fs.readFile(configPath, "utf8");
+      const cfg = (parseYaml(raw) as Record<string, unknown>) ?? {};
+      cfg.mcp_servers = {
+        ...((cfg.mcp_servers as Record<string, unknown>) ?? {}),
+        composio: {
+          command: "node",
+          args: [composioScriptForRegistration, botToken, CC_API_BASE],
+          enabled: true,
+          timeout: 120,
+        },
+      };
+      const pt = (cfg.platform_toolsets as Record<string, string[]>) ?? {};
+      const cli = Array.isArray(pt.cli) ? pt.cli : ["hermes-cli"];
+      if (!cli.includes("mcp-composio")) cli.push("mcp-composio");
+      pt.cli = cli;
+      cfg.platform_toolsets = pt;
+      await fs.writeFile(configPath, stringifyYaml(cfg));
+      notes.push("registered composio MCP (connected SaaS tools)");
+    } catch (e) {
+      notes.push(`composio mcp registration failed: ${(e as Error).message.slice(0, 200)}`);
+    }
   }
 
   return { skillInstalled, mcpRegistered, notes };

--- a/api/src/agents/openclaw-equip.ts
+++ b/api/src/agents/openclaw-equip.ts
@@ -3,10 +3,14 @@ import { promises as fs } from "node:fs";
 import { join, resolve as pathResolve, basename } from "node:path";
 import { buildOpenClawCommand, CONTAINER_OPENCLAW_HOME } from "./openclaw-runtime.js";
 import { skillHasDescription } from "./hermes-equip.js";
+import { composioEnabled } from "../lib/composio.js";
 
 const MCP_SCRIPT =
   process.env.CC_MCP_SCRIPT ??
   pathResolve(process.cwd(), "scripts/circlechat-mcp.mjs");
+const COMPOSIO_MCP_SCRIPT =
+  process.env.CC_COMPOSIO_MCP_SCRIPT ??
+  pathResolve(process.cwd(), "scripts/composio-mcp.mjs");
 const CC_API_BASE = process.env.CC_API_BASE ?? "http://localhost:3300/api";
 const SKILL_TEMPLATE_DIR =
   process.env.CC_SKILL_TEMPLATE ??
@@ -108,6 +112,32 @@ export async function equipOpenClawAgent(params: {
     mcpRegistered = true;
   } catch (e) {
     notes.push(`mcp set failed: ${(e as Error).message.slice(0, 200)}`);
+  }
+
+  // Composio MCP — register the connected-SaaS-tools shim when Composio is
+  // configured server-side. Opt out with CC_COMPOSIO_MCP=off.
+  if (composioEnabled() && process.env.CC_COMPOSIO_MCP !== "off") {
+    try {
+      const composioName = basename(COMPOSIO_MCP_SCRIPT);
+      await fs.copyFile(COMPOSIO_MCP_SCRIPT, join(openclawHome, composioName));
+      const composioMcpJson = JSON.stringify({
+        command: "node",
+        args: [`${CONTAINER_OPENCLAW_HOME}/${composioName}`, botToken, CC_API_BASE],
+      });
+      const cmd = buildOpenClawCommand(openclawHome, ["mcp", "set", "composio", composioMcpJson]);
+      await new Promise<void>((resolve, reject) => {
+        const p = spawn(cmd.cmd, cmd.args, { env: cmd.env, timeout: 60_000 });
+        let err = "";
+        p.stderr.on("data", (d) => (err += d));
+        p.on("error", reject);
+        p.on("close", (code) =>
+          code === 0 ? resolve() : reject(new Error(`openclaw mcp set composio exit ${code}: ${err.slice(0, 200)}`)),
+        );
+      });
+      notes.push("registered composio MCP (connected SaaS tools)");
+    } catch (e) {
+      notes.push(`composio mcp set failed: ${(e as Error).message.slice(0, 200)}`);
+    }
   }
 
   return { mcpRegistered, skillInstalled, notes };

--- a/api/src/lib/composio.ts
+++ b/api/src/lib/composio.ts
@@ -1,0 +1,197 @@
+// Server-side Composio integration. This is the ONE place the Composio SDK and
+// the COMPOSIO_API_KEY live — the agent containers never see either. Agents
+// discover and run Composio tools through /agent-api/composio/* + /agent-api/act
+// (see routes/agent-api-composio.ts and the composio_execute executor action),
+// so every outbound call inherits CircleChat's scope/risk/approval gating.
+//
+// Dormant by design: with COMPOSIO_API_KEY unset, composioEnabled() is false and
+// every helper returns empty / throws composio_not_configured — no errors at
+// boot, mirroring the planner/verifier "no key → feature off" convention.
+
+import { Composio } from "@composio/core";
+
+const API_KEY = process.env.COMPOSIO_API_KEY ?? "";
+
+// The Composio user id (entity) whose connected accounts agents act as. A single
+// workspace-wide identity for now — the deploy owner's connections. Per-agent
+// identities are a natural follow-up (store the id on agents.config_json and
+// thread it through composio_execute).
+const DEFAULT_USER_ID = process.env.COMPOSIO_USER_ID?.trim() || "default";
+
+// Optional allow-list of toolkits to expose (comma-separated slugs, e.g.
+// "github,gmail,slack"). Empty → expose whatever the user has actually connected.
+const CONFIGURED_TOOLKITS = (process.env.COMPOSIO_TOOLKITS ?? "")
+  .split(",")
+  .map((s) => s.trim().toUpperCase())
+  .filter(Boolean);
+
+export type ComposioApproval = "all" | "writes" | "off";
+
+// Approval policy for composio_execute. Default "all": every outbound Composio
+// call is routed through a human approval card. "writes" auto-runs read-only
+// tools and gates the rest; "off" runs everything (still fully audit-logged).
+export function composioApprovalPolicy(): ComposioApproval {
+  const v = (process.env.COMPOSIO_APPROVAL ?? "all").trim().toLowerCase();
+  if (v === "off" || v === "none") return "off";
+  if (v === "writes" || v === "write") return "writes";
+  return "all";
+}
+
+export function composioEnabled(): boolean {
+  return API_KEY.length > 0;
+}
+
+export function composioUserId(): string {
+  return DEFAULT_USER_ID;
+}
+
+export function composioConfiguredToolkits(): string[] {
+  return CONFIGURED_TOOLKITS;
+}
+
+let _client: Composio | null = null;
+function client(): Composio {
+  if (!composioEnabled()) throw new Error("composio_not_configured");
+  if (!_client) _client = new Composio({ apiKey: API_KEY });
+  return _client;
+}
+
+export interface ComposioToolDef {
+  // MCP tool name IS the Composio slug (e.g. GITHUB_CREATE_AN_ISSUE) so the
+  // model calls composio_execute({ slug }) with exactly what it discovered.
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  toolkit?: string;
+}
+
+function toolkitOf(raw: unknown): string | undefined {
+  const tk = (raw as { toolkit?: unknown }).toolkit;
+  if (typeof tk === "string") return tk;
+  if (tk && typeof tk === "object") {
+    const slug = (tk as { slug?: unknown }).slug;
+    if (typeof slug === "string") return slug;
+  }
+  return undefined;
+}
+
+export interface ComposioConnection {
+  id: string;
+  toolkit: string;
+  status: string;
+}
+
+// The user's connected accounts. Used both for the status endpoint and to derive
+// the default tool scope when no COMPOSIO_TOOLKITS allow-list is set.
+export async function listComposioConnections(userId?: string): Promise<ComposioConnection[]> {
+  if (!composioEnabled()) return [];
+  const res = (await client().connectedAccounts.list({
+    userIds: [userId ?? DEFAULT_USER_ID],
+  })) as unknown as { items?: unknown[] } | unknown[];
+  const items: unknown[] = Array.isArray(res) ? res : (res?.items ?? []);
+  return items.map((it) => {
+    const o = it as Record<string, unknown>;
+    return {
+      id: String(o.id ?? ""),
+      toolkit: (toolkitOf(o) ?? (o.toolkitSlug as string) ?? "unknown").toString(),
+      status: String(o.status ?? "unknown"),
+    };
+  });
+}
+
+// List the Composio tools an agent may use, as MCP-ready defs. Scope resolution:
+//   1. explicit opts.toolkits, else the COMPOSIO_TOOLKITS allow-list;
+//   2. if neither and no search term, fall back to the toolkits the user has
+//      actually connected (so an empty allow-list = "everything I connected");
+//   3. a search term alone is honored (fuzzy discovery across the catalog).
+// We never dump the entire Composio catalog unscoped.
+export async function listComposioTools(opts?: {
+  toolkits?: string[];
+  search?: string;
+  limit?: number;
+  userId?: string;
+}): Promise<ComposioToolDef[]> {
+  if (!composioEnabled()) return [];
+  const limit = Math.min(Math.max(opts?.limit ?? 50, 1), 200);
+  const search = opts?.search?.trim();
+
+  let toolkits = (opts?.toolkits?.length ? opts.toolkits : CONFIGURED_TOOLKITS)
+    .map((t) => t.trim().toUpperCase())
+    .filter(Boolean);
+  if (!toolkits.length && !search) {
+    const conns = await listComposioConnections(opts?.userId);
+    toolkits = Array.from(
+      new Set(
+        conns
+          .map((c) => c.toolkit.toUpperCase())
+          .filter((t) => t && t !== "UNKNOWN"),
+      ),
+    );
+  }
+
+  let query: Record<string, unknown>;
+  if (toolkits.length) query = { toolkits, limit, ...(search ? { search } : {}) };
+  else if (search) query = { search };
+  else return [];
+
+  const raw = (await client().tools.getRawComposioTools(query as never)) as unknown;
+  const list: unknown[] = Array.isArray(raw) ? raw : ((raw as { items?: unknown[] })?.items ?? []);
+  return list.map((t) => {
+    const o = t as Record<string, unknown>;
+    return {
+      name: String(o.slug ?? o.name ?? ""),
+      description: String(o.description ?? o.name ?? o.slug ?? ""),
+      inputSchema:
+        (o.inputParameters as Record<string, unknown>) ?? { type: "object", properties: {} },
+      toolkit: toolkitOf(o),
+    };
+  });
+}
+
+export interface ComposioExecResult {
+  successful: boolean;
+  data: Record<string, unknown>;
+  error: string | null;
+}
+
+// Execute one Composio tool for the workspace's connected user. Throws only on
+// SDK/transport failure; a tool that ran but failed comes back with
+// successful:false + error so the caller can surface it to the model.
+export async function executeComposioTool(
+  slug: string,
+  args: Record<string, unknown>,
+  userId?: string,
+): Promise<ComposioExecResult> {
+  const res = await client().tools.execute(slug, {
+    userId: userId ?? DEFAULT_USER_ID,
+    arguments: args ?? {},
+    // Agents discover slugs dynamically and don't pin a toolkit version, so use
+    // the latest instead of erroring with "toolkit version not specified".
+    dangerouslySkipVersionCheck: true,
+  });
+  return {
+    successful: Boolean(res.successful),
+    data: (res.data as Record<string, unknown>) ?? {},
+    error: res.error ?? null,
+  };
+}
+
+// Read-only heuristic for COMPOSIO_APPROVAL=writes. Composio slugs are verb-typed
+// (GITHUB_LIST_REPOS, GMAIL_SEND_EMAIL); GET/LIST/SEARCH-style verbs are treated
+// as read-only and auto-run, everything else needs approval. Conservative: an
+// unrecognized verb is treated as a write (gated).
+const READ_VERB_RE =
+  /_(GET|LIST|SEARCH|FETCH|READ|FIND|RETRIEVE|CHECK|COUNT|LOOKUP|VIEW|DOWNLOAD|EXPORT)(_|$)/;
+
+export function composioSlugIsReadOnly(slug: string): boolean {
+  return READ_VERB_RE.test((slug ?? "").toUpperCase());
+}
+
+// Whether a composio_execute for this slug must go through the approval gate,
+// per COMPOSIO_APPROVAL. Consulted by the executor.
+export function composioNeedsApproval(slug: string): boolean {
+  const policy = composioApprovalPolicy();
+  if (policy === "off") return false;
+  if (policy === "all") return true;
+  return !composioSlugIsReadOnly(slug);
+}

--- a/api/src/routes/agent-api.ts
+++ b/api/src/routes/agent-api.ts
@@ -35,6 +35,14 @@ import { checkReplyBody, guardRejectHint } from "../agents/reply-guard.js";
 import { checkRecentDuplicate } from "../agents/dedupe.js";
 import { sanitizeAttachments, applyActions, type AgentAction } from "../agents/executor.js";
 import {
+  composioEnabled,
+  composioUserId,
+  composioApprovalPolicy,
+  composioConfiguredToolkits,
+  listComposioTools,
+  listComposioConnections,
+} from "../lib/composio.js";
+import {
   STATUSES,
   listTasks,
   getTaskDetail,
@@ -239,6 +247,9 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
       applied: outcome.actionsApplied,
       errors: outcome.errors,
       trace: outcome.trace,
+      // Present only when a composio_execute ran in this batch — carries the
+      // tool's output so the MCP shim can hand it back to the model mid-turn.
+      ...(outcome.composioResults ? { composioResults: outcome.composioResults } : {}),
     };
   });
 
@@ -1007,6 +1018,41 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
       .parse((req.query as Record<string, unknown>) ?? {});
     const hits = await recallKnowledge(req.agentCtx!.workspaceId, q.q, q.k ?? 5);
     return { hits };
+  });
+
+  // ───── Composio: the user's connected SaaS tools ─────
+  // DISCOVERY only (read-only). Execution goes through the gated /agent-api/act
+  // (composio_execute action) so every outbound call inherits scope/risk/approval
+  // — the Composio SDK + API key live server-side and never reach the agent.
+  // Both endpoints degrade to { enabled:false } when COMPOSIO_API_KEY is unset.
+  app.get("/agent-api/composio/status", async () => {
+    if (!composioEnabled()) return { enabled: false };
+    const connections = await listComposioConnections().catch(() => []);
+    return {
+      enabled: true,
+      userId: composioUserId(),
+      approval: composioApprovalPolicy(),
+      toolkits: composioConfiguredToolkits(),
+      connections,
+    };
+  });
+
+  // GET /agent-api/composio/tools?toolkits=github,gmail&search=issue&limit=50
+  // Returns MCP-ready tool defs ({ name=slug, description, inputSchema }) for the
+  // agent to discover what it can call, then pass a chosen slug to composio_execute.
+  app.get("/agent-api/composio/tools", async (req) => {
+    if (!composioEnabled()) return { enabled: false, tools: [] };
+    const q = req.query as { toolkits?: string; search?: string; limit?: string };
+    const toolkits = (q.toolkits ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const tools = await listComposioTools({
+      toolkits: toolkits.length ? toolkits : undefined,
+      search: q.search?.trim() || undefined,
+      limit: q.limit ? Number(q.limit) : undefined,
+    });
+    return { enabled: true, tools };
   });
 
   // Browser proxy: shell out to the host's `agent-browser` CLI so agents can

--- a/api/templates/circlechat-skill/SKILL.md
+++ b/api/templates/circlechat-skill/SKILL.md
@@ -241,6 +241,30 @@ Emit the action, stop, wait for `trigger: "approval_response"` to do the
 actual thing. In-workspace chat / task / file actions never need approval —
 just do them. See action types for full schema.
 
+## Composio: acting in connected apps (Gmail, GitHub, Slack, CRMs, …)
+
+If this workspace has Composio connected, you have three **real MCP tools**
+(unlike the `<actions>` names above — these you call directly) that let you act
+inside the team's actual SaaS accounts:
+
+- `composio_connections` — see which apps are linked and their status.
+- `composio_list_tools` — discover the exact tool slugs + argument schemas for a
+  toolkit (`toolkits: "github,gmail"`) or a `search` term. **Always do this
+  first** to get the real slug and its inputSchema — never guess a slug.
+- `composio_execute` — run one tool by `slug` with `arguments`.
+
+Flow: `composio_list_tools({ toolkits: "gmail" })` → pick e.g.
+`GMAIL_SEND_EMAIL`, read its schema → `composio_execute({ slug:
+"GMAIL_SEND_EMAIL", arguments: {…}, conversation_id })`.
+
+**Approvals.** Outbound/write actions are gated by default. `composio_execute`
+may return `pending_approval` with an approval id (`ap_…`) — a human must
+approve it in the Approvals tab. When you see that: **STOP, do not call the tool
+again.** It runs automatically on approval; you'll be woken with `trigger:
+"approval_response"` and a confirmation is posted to the conversation. Read-only
+lookups (LIST/GET/SEARCH) usually run immediately and return data you can use
+this turn. Never fabricate a result — if it's pending or errored, say so.
+
 ## Do it, don't task it
 
 If the user asks for a **direct thing you can fulfill this turn** — share a

--- a/compose.agents.yml
+++ b/compose.agents.yml
@@ -41,6 +41,9 @@ services:
       CC_SKILL_TEMPLATE: ${CC_REPO_HOST_DIR:-/opt/circlechat}/api/templates/circlechat-skill
       CC_BROWSER_SKILL_TEMPLATE: ${CC_REPO_HOST_DIR:-/opt/circlechat}/api/templates/browser-skill
       CC_MCP_SCRIPT: ${CC_REPO_HOST_DIR:-/opt/circlechat}/api/scripts/circlechat-mcp.mjs
+      # The Composio MCP shim staged into each agent when COMPOSIO_API_KEY is set.
+      # Lives in the same (already-mounted) scripts dir as circlechat-mcp.mjs.
+      CC_COMPOSIO_MCP_SCRIPT: ${CC_REPO_HOST_DIR:-/opt/circlechat}/api/scripts/composio-mcp.mjs
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${HERMES_HOMES_DIR:-/opt/hermes-homes}:${HERMES_HOMES_DIR:-/opt/hermes-homes}

--- a/compose.yml
+++ b/compose.yml
@@ -78,6 +78,11 @@ services:
       SESSION_SECRET: ${SESSION_SECRET:-please-change-me}
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-http://localhost:8080}
       SMTP_URL: ${SMTP_URL:-}
+      # Composio — connected SaaS tools for agents. Empty COMPOSIO_API_KEY = off.
+      COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}
+      COMPOSIO_USER_ID: ${COMPOSIO_USER_ID:-default}
+      COMPOSIO_TOOLKITS: ${COMPOSIO_TOOLKITS:-}
+      COMPOSIO_APPROVAL: ${COMPOSIO_APPROVAL:-all}
       # Shared, persistent workspace for agents (HOST path). When set, every
       # agent container gets it bind-mounted at /workspace so files survive the
       # per-turn `docker run --rm` and are visible across agents; the API also
@@ -101,6 +106,12 @@ services:
       API_INTERNAL_URL: http://api:3000
       SESSION_SECRET: ${SESSION_SECRET:-please-change-me}
       CC_SHARED_WORKSPACE_DIR: ${CC_SHARED_WORKSPACE_DIR:-}
+      # The worker runs the executor (heartbeat runs + approval replays), so it
+      # needs the same Composio config as the api.
+      COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}
+      COMPOSIO_USER_ID: ${COMPOSIO_USER_ID:-default}
+      COMPOSIO_TOOLKITS: ${COMPOSIO_TOOLKITS:-}
+      COMPOSIO_APPROVAL: ${COMPOSIO_APPROVAL:-all}
     depends_on:
       postgres: { condition: service_healthy }
       redis: { condition: service_healthy }

--- a/docs/composio.md
+++ b/docs/composio.md
@@ -1,0 +1,132 @@
+# Composio — connect agents to your existing SaaS tools
+
+CircleChat's built-in agents can plan, build, run code, browse, and ship
+artifacts — but out of the box they can't *log into your existing tools*. This
+integration closes that gap with [Composio](https://composio.dev): once you set
+a `COMPOSIO_API_KEY`, every agent gains a `composio_*` toolset backed by **your**
+connected accounts (Gmail, GitHub, Slack, Notion, Linear, HubSpot, …), and every
+outbound call routes through CircleChat's existing **approval gate**.
+
+It's fully opt-in and dormant until configured — no key, no behaviour change.
+
+## Design
+
+The Composio **SDK and API key live server-side only** (in the `api`/`worker`
+containers). Agents never see them. They reach Composio the same way they reach
+the rest of CircleChat: through a small MCP shim that proxies to `/agent-api`.
+
+```
+Agent (Hermes / OpenClaw / custom webhook)
+   │  MCP: composio_list_tools · composio_execute · composio_connections
+   ▼
+composio-mcp.mjs          (dep-free stdio shim, runs inside the agent container)
+   │  HTTP → /agent-api/composio/*   (discovery, read-only)
+   │  HTTP → /agent-api/act          (execution, gated)
+   ▼
+Fastify API ── @composio/core ──▶ Composio ──▶ your connected accounts
+   │  composio_execute action
+   ├─ COMPOSIO_APPROVAL=all  → opens an approval card; a human clicks approve;
+   │                            the call replays server-side (audit-logged)
+   └─ COMPOSIO_APPROVAL=off  → runs immediately (still audit-logged)
+```
+
+Because execution goes through the same `composio_execute` action and the same
+`applyActions` path as everything else, it inherits scope/risk/approval gating,
+dedupe, and the audit trail for free — nothing bypasses the executor.
+
+## Setup
+
+1. **Get a Composio API key** and connect at least one account for your user id
+   at [app.composio.dev](https://app.composio.dev). The "user id" (a.k.a. entity)
+   is whatever identity owns those connections — e.g. `default` or your email.
+
+2. **Configure CircleChat** (`.env`):
+
+   ```bash
+   COMPOSIO_API_KEY=comp_...
+   COMPOSIO_USER_ID=default        # the entity whose connections agents act as
+   COMPOSIO_TOOLKITS=github,gmail  # optional allow-list; empty = every connected toolkit
+   COMPOSIO_APPROVAL=all           # all | writes | off  (default: all)
+   ```
+
+3. **Restart** so the `api` and `worker` pick up the env:
+
+   ```bash
+   docker compose up -d
+   ```
+
+That's it for the base stack. Any agent whose runtime speaks MCP (the bundled
+Hermes/OpenClaw runtime, or your own) now sees the `composio_*` tools.
+
+## How agents use it
+
+Three MCP tools (self-describing; the model discovers, then acts):
+
+| Tool | Purpose |
+| --- | --- |
+| `composio_connections` | List connected accounts + status + the approval policy. |
+| `composio_list_tools` | Discover tool slugs + input schemas for a toolkit or search term. |
+| `composio_execute` | Run one tool by `slug` with `arguments`. |
+
+Typical turn: `composio_list_tools({ toolkits: "gmail" })` → pick
+`GMAIL_SEND_EMAIL`, read its schema → `composio_execute({ slug:
+"GMAIL_SEND_EMAIL", arguments: { … } })`.
+
+## Approvals
+
+`COMPOSIO_APPROVAL` controls the gate:
+
+- **`all`** (default) — every `composio_execute` opens an approval card. The
+  agent gets back `pending_approval` with an id (`ap_…`) and stops. A human
+  approves it in the **Approvals** tab; the call then **replays server-side**
+  from its stored payload (the human authorised exactly this slug + arguments),
+  and a confirmation is posted to the originating conversation. The agent is also
+  woken with an `approval_response` trigger.
+- **`writes`** — read-only tools (`*_GET_*` / `*_LIST_*` / `*_SEARCH_*` …) run
+  immediately and return data in the same turn; everything else is gated as
+  above. Good default once you trust reads.
+- **`off`** — everything runs immediately. Still fully audit-logged; use only on
+  a trusted single-tenant deploy.
+
+Approval cards show a truncated argument preview, so the human sees exactly what
+will run before clicking approve.
+
+## Bundled-agent runtime (Hermes / OpenClaw)
+
+When Composio is enabled, the equip step registers a second MCP server
+(`composio`) into each provisioned agent alongside `circlechat`, and stages the
+dep-free `api/scripts/composio-mcp.mjs` into the agent's home. Nothing else is
+required. Opt a single deploy out with `CC_COMPOSIO_MCP=off`.
+
+## Custom / reference agent
+
+Prefer to run an agent as a plain process (no container runtime)? The reference
+webhook agent in [`examples/composio-agent`](../examples/composio-agent) uses
+`@composio/core` + `@composio/anthropic` to drive Claude over your Composio tools
+and reply in a channel — the fastest way to see the integration work end-to-end.
+
+## Configuration reference
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `COMPOSIO_API_KEY` | — | Composio API key. **Unset = feature off.** |
+| `COMPOSIO_USER_ID` | `default` | The Composio user/entity whose connected accounts agents act as. |
+| `COMPOSIO_TOOLKITS` | *(empty)* | CSV allow-list of toolkit slugs to expose. Empty = every toolkit the user has connected. |
+| `COMPOSIO_APPROVAL` | `all` | `all` \| `writes` \| `off` — approval policy for outbound calls. |
+| `CC_COMPOSIO_MCP` | `on` | Set `off` to skip registering the composio MCP server into bundled agents. |
+
+## Security notes
+
+- The API key and the Composio SDK never enter an agent container — only the
+  bot-token-authenticated `/agent-api/composio/*` proxy is reachable from there.
+- Keep `COMPOSIO_APPROVAL=all` (or `writes`) on multi-tenant or shared deploys so
+  a model can't send an email / open a PR without a human in the loop.
+- Every Composio call is recorded on the agent's run and (when gated) as an
+  approval row you can query.
+
+## Roadmap
+
+- Per-agent Composio identities (distinct connected accounts per agent, stored on
+  `agents.config_json`) instead of one workspace-wide `COMPOSIO_USER_ID`.
+- Surfacing the connect flow (`toolkits.authorize`) in the UI so admins can link
+  accounts without leaving CircleChat.

--- a/examples/composio-agent/.env.example
+++ b/examples/composio-agent/.env.example
@@ -1,0 +1,17 @@
+# Bot token from CircleChat: Members → Provision agent → runtime "webhook".
+CC_BOT_TOKEN=cc_xxx
+
+# Claude drives the tool-use loop.
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Composio: the API key + the user/entity whose connected accounts to act as.
+COMPOSIO_API_KEY=comp_...
+COMPOSIO_USER_ID=default
+
+# Optional: restrict to specific toolkits (comma-separated). Empty = every
+# toolkit the user has connected.
+COMPOSIO_TOOLKITS=github,gmail
+
+# Optional overrides.
+CC_MODEL=claude-sonnet-5
+PORT=8790

--- a/examples/composio-agent/.npmrc
+++ b/examples/composio-agent/.npmrc
@@ -1,0 +1,3 @@
+# @composio/anthropic declares @mastra/mcp as a peer it doesn't use on this code
+# path; legacy-peer-deps lets `npm install` stay lean instead of pulling it in.
+legacy-peer-deps=true

--- a/examples/composio-agent/README.md
+++ b/examples/composio-agent/README.md
@@ -1,0 +1,67 @@
+# CircleChat × Composio — reference agent
+
+A minimal CircleChat **webhook agent** whose toolset is the user's
+[Composio](https://composio.dev) connections. Claude reads the message, decides
+which connected-app tools to call (Gmail, GitHub, Slack, a CRM, …), Composio
+executes them against the connected account, and the agent replies in the
+channel.
+
+This is the fastest way to see the integration work end-to-end — it runs as a
+plain Node process, no containerised agent runtime required. For giving the
+*bundled* Hermes/OpenClaw agents the same tools, see
+[`../../docs/composio.md`](../../docs/composio.md).
+
+## Prerequisites
+
+- CircleChat running (`docker compose up` in the repo root).
+- A [Composio](https://app.composio.dev) API key with at least one connected
+  account for your `COMPOSIO_USER_ID`.
+- An Anthropic API key.
+
+## Run
+
+```bash
+cd examples/composio-agent
+npm install                 # .npmrc sets legacy-peer-deps so this stays lean
+cp .env.example .env        # fill in the four required keys
+set -a; source .env; set +a
+npm start                   # listens on :8790
+```
+
+## Point CircleChat at it
+
+1. In CircleChat: **Members → Provision agent**, runtime **webhook**. Copy the
+   bot token into `.env` as `CC_BOT_TOKEN` and restart the agent.
+2. Register this agent's callback URL. CircleChat's API runs in Docker, so it
+   reaches your host process via `host.docker.internal`:
+
+   ```bash
+   curl -X POST http://localhost/api/agents/$AGENT_ID/register \
+     -H "Authorization: Bearer $CC_BOT_TOKEN" \
+     -d '{"callbackUrl":"http://host.docker.internal:8790"}'
+   ```
+
+   (`$AGENT_ID` is shown on the agent's detail page.)
+3. In any channel the agent is in, `@mention` it or DM it:
+   *"@composio what are my 3 most recent GitHub issues?"* or
+   *"draft and send a test email to me via Gmail."*
+
+Read-only lookups run immediately. Outbound/write actions surface as tool calls
+Claude makes directly here; if you want them gated behind a human click, use the
+in-platform MCP path (which routes through CircleChat's approval gate) documented
+in [`../../docs/composio.md`](../../docs/composio.md).
+
+## How it works
+
+```
+CircleChat ──POST /event (context packet)──▶ this agent
+                                              │  Claude (tools = your Composio tools)
+                                              │  ├─ tool_use ─▶ composio.provider.handleToolCalls()
+                                              │  └─ final text
+                                              ▼
+                          { actions: [ post_message ] } ──▶ CircleChat
+```
+
+`agent.mjs` is ~180 lines; the whole loop is `composio.tools.get(userId,
+{toolkits})` → `anthropic.messages.create({ tools })` →
+`composio.provider.handleToolCalls(userId, response)`.

--- a/examples/composio-agent/agent.mjs
+++ b/examples/composio-agent/agent.mjs
@@ -1,0 +1,175 @@
+// Reference CircleChat agent whose toolset IS the user's Composio connections,
+// driven by Claude. Implements the webhook contract from docs/custom-agents.md:
+// POST /heartbeat and POST /event receive a context packet; we reply with a
+// post_message action (or "HEARTBEAT_OK").
+//
+// This is the lightweight way to prove the integration end-to-end WITHOUT the
+// containerised Hermes/OpenClaw runtime: it runs as a plain Node process, Claude
+// decides which Composio tools to call, and Composio executes them against the
+// connected account. (The in-platform path — bundled agents getting the same
+// tools via the composio MCP shim — is the other half; see docs/composio.md.)
+
+import http from "node:http";
+import Anthropic from "@anthropic-ai/sdk";
+import { Composio } from "@composio/core";
+import { AnthropicProvider } from "@composio/anthropic";
+
+const {
+  CC_BOT_TOKEN,
+  ANTHROPIC_API_KEY,
+  COMPOSIO_API_KEY,
+  COMPOSIO_USER_ID = "default",
+  COMPOSIO_TOOLKITS = "",
+  CC_MODEL = "claude-sonnet-5",
+  PORT = "8790",
+} = process.env;
+
+for (const [k, v] of Object.entries({ CC_BOT_TOKEN, ANTHROPIC_API_KEY, COMPOSIO_API_KEY })) {
+  if (!v) {
+    console.error(`composio-agent: missing required env ${k}`);
+    process.exit(1);
+  }
+}
+
+const anthropic = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
+const composio = new Composio({ apiKey: COMPOSIO_API_KEY, provider: new AnthropicProvider() });
+
+const CONFIGURED_TOOLKITS = COMPOSIO_TOOLKITS.split(",")
+  .map((s) => s.trim().toUpperCase())
+  .filter(Boolean);
+const MAX_TOOL_STEPS = 6;
+
+// Resolve which toolkits to expose: the COMPOSIO_TOOLKITS allow-list, else the
+// toolkits the user has actually connected.
+async function resolveToolkits() {
+  if (CONFIGURED_TOOLKITS.length) return CONFIGURED_TOOLKITS;
+  try {
+    const res = await composio.connectedAccounts.list({ userIds: [COMPOSIO_USER_ID] });
+    const items = Array.isArray(res) ? res : (res?.items ?? []);
+    const set = new Set(
+      items
+        .map((it) => (it?.toolkit?.slug ?? it?.toolkit ?? it?.toolkitSlug ?? "").toString().toUpperCase())
+        .filter((t) => t && t !== "UNKNOWN"),
+    );
+    return [...set];
+  } catch (e) {
+    console.error("composio-agent: could not list connections:", e.message);
+    return [];
+  }
+}
+
+// Run a Claude tool-use loop where the tools are the user's Composio tools.
+async function answerWithComposio(packet, userText) {
+  const toolkits = await resolveToolkits();
+  const tools = toolkits.length
+    ? await composio.tools.get(COMPOSIO_USER_ID, { toolkits, limit: 30 })
+    : [];
+
+  const model = packet?.agent?.model || CC_MODEL;
+  const system =
+    (packet?.agent?.brief || "You are a helpful teammate in a CircleChat workspace.") +
+    "\n\nYou can act in the user's connected apps via the provided tools. Use them " +
+    "when the request needs real data or a real action; otherwise just answer. Be " +
+    "concise (1–3 sentences). Never claim you did something you didn't actually do.";
+
+  const messages = [{ role: "user", content: userText }];
+  let last = null;
+  for (let step = 0; step < MAX_TOOL_STEPS; step++) {
+    last = await anthropic.messages.create({
+      model,
+      max_tokens: 1024,
+      system,
+      messages,
+      ...(tools.length ? { tools } : {}),
+    });
+    messages.push({ role: "assistant", content: last.content });
+    if (last.stop_reason !== "tool_use") break;
+    // Execute every tool_use block via Composio; append the tool_result blocks.
+    const toolResults = await composio.provider.handleToolCalls(COMPOSIO_USER_ID, last);
+    messages.push(...toolResults);
+  }
+
+  const text = (last?.content ?? [])
+    .filter((b) => b.type === "text")
+    .map((b) => b.text)
+    .join("")
+    .trim();
+  return text || "(no reply)";
+}
+
+async function reply(packet) {
+  const trigger = packet.trigger;
+  // Only spend the model on things addressed to us. Quiet heartbeats stay silent.
+  if (!["mention", "dm", "test"].includes(trigger)) return "HEARTBEAT_OK";
+  const conv = (packet.inbox ?? [])[0];
+  if (!conv || !conv.messages?.length) return "HEARTBEAT_OK";
+  const lastMsg = conv.messages[conv.messages.length - 1];
+  // Don't answer our own last message.
+  if (lastMsg.memberHandle && packet.agent?.handle && lastMsg.memberHandle === packet.agent.handle) {
+    return "HEARTBEAT_OK";
+  }
+  const body = await answerWithComposio(packet, lastMsg.bodyMd ?? "");
+  return {
+    actions: [
+      {
+        type: "post_message",
+        conversation_id: conv.conversationId,
+        body_md: body,
+        reply_to: lastMsg.id,
+      },
+    ],
+    trace: [`composio-agent handled ${trigger}`],
+  };
+}
+
+// ──────────────────────── HTTP plumbing (built-in http) ────────────────────────
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      try {
+        resolve(raw ? JSON.parse(raw) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method !== "POST" || !["/heartbeat", "/event"].includes(req.url ?? "")) {
+    res.writeHead(404).end("not found");
+    return;
+  }
+  const auth = req.headers.authorization ?? "";
+  if (auth.replace(/^Bearer\s+/i, "") !== CC_BOT_TOKEN) {
+    res.writeHead(401).end("unauthorized");
+    return;
+  }
+  let packet;
+  try {
+    packet = await readJson(req);
+  } catch {
+    res.writeHead(400).end("bad json");
+    return;
+  }
+  // /heartbeat has no explicit trigger; treat it as scheduled.
+  if (req.url === "/heartbeat" && !packet.trigger) packet.trigger = "scheduled";
+  try {
+    const out = await reply(packet);
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(typeof out === "string" ? JSON.stringify(out) : JSON.stringify(out));
+  } catch (e) {
+    console.error("composio-agent error:", e);
+    // Fail silent to CircleChat so a model/tool hiccup doesn't spam the channel.
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify("HEARTBEAT_OK"));
+  }
+});
+
+server.listen(Number(PORT), () => {
+  console.log(`composio-agent listening on :${PORT} (user=${COMPOSIO_USER_ID}, toolkits=${CONFIGURED_TOOLKITS.join(",") || "auto"})`);
+});

--- a/examples/composio-agent/package-lock.json
+++ b/examples/composio-agent/package-lock.json
@@ -1,0 +1,159 @@
+{
+  "name": "circlechat-composio-agent",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "circlechat-composio-agent",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.52.0",
+        "@composio/anthropic": "^0.10.0",
+        "@composio/core": "^0.13.1",
+        "zod": "^3.25.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.52.0.tgz",
+      "integrity": "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      }
+    },
+    "node_modules/@composio/anthropic": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@composio/anthropic/-/anthropic-0.10.0.tgz",
+      "integrity": "sha512-xndVj++0+Cos4B+o5HqwYoQDTvh1IB9IT3JXcTtxsctHceKn7Hq0QQn61zdtW702KR5W10NTM5dignK/RkkmGA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@anthropic-ai/sdk": "^0.52.0",
+        "@composio/core": ">=0.10.0 <1.0.0",
+        "@mastra/mcp": "^0.12.0"
+      }
+    },
+    "node_modules/@composio/client": {
+      "version": "0.1.0-alpha.74",
+      "resolved": "https://registry.npmjs.org/@composio/client/-/client-0.1.0-alpha.74.tgz",
+      "integrity": "sha512-/EHJsFxCpWfRxNvXURRrGVZfJSltSpN4Gkd9M9Cl5gPOirG+NpbXf2B8d4B72H87m7cnOguMKjOH42ogQ84/Ww==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@composio/core": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@composio/core/-/core-0.13.1.tgz",
+      "integrity": "sha512-bC64PJG3RBeuezihfZV/9qJMd1LyzUEFN1tVHTWh32n/muUMr5I33nN6Mezhtkl4+ffBJ8IZ/mNt9tEQKFB/sw==",
+      "license": "ISC",
+      "dependencies": {
+        "@composio/client": "0.1.0-alpha.74",
+        "@composio/json-schema-to-zod": "0.2.0",
+        "@types/json-schema": "^7.0.15",
+        "openai": "^6.42.0",
+        "picocolors": "^1.1.1",
+        "pusher-js": "^8.5.0",
+        "semver": "^7.8.4",
+        "zod-to-json-schema": "^3.25.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/@composio/json-schema-to-zod": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@composio/json-schema-to-zod/-/json-schema-to-zod-0.2.0.tgz",
+      "integrity": "sha512-P7ym7+1NCN2cDVlSOGTINY6KjZ/d162uc+0LChYcy3d5RAAacgHiGU7ZJF+5pUJHbIivsfAC/4PdjVdsfmHdeA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": ">=3.25.76 <5"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/openai": {
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pusher-js": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.5.0.tgz",
+      "integrity": "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==",
+      "license": "MIT",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/composio-agent/package.json
+++ b/examples/composio-agent/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "circlechat-composio-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Reference CircleChat webhook agent whose tools are the user's Composio connections, driven by Claude.",
+  "scripts": {
+    "start": "node agent.mjs"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.52.0",
+    "@composio/anthropic": "^0.10.0",
+    "@composio/core": "^0.13.1",
+    "zod": "^3.25.0"
+  }
+}


### PR DESCRIPTION
Closes the "no integration catalog" gap called out in the README's honest-scope section: agents can now act inside connected SaaS tools (Gmail, GitHub, Slack, …) via [Composio](https://composio.dev). Fully opt-in behind `COMPOSIO_API_KEY` and dormant (no behaviour change) when unset.

## Design

The Composio SDK + API key stay **server-side only** — agents never see them. They reach Composio through the same MCP + `/agent-api` seam they already use, so nothing bypasses the executor:

- **`api/src/lib/composio.ts`** — server-side `@composio/core` wrapper (discover, execute, list connections) with a read/write approval heuristic.
- **`executor.ts`** — a new `composio_execute` action that inherits CircleChat's scope/risk/**approval** gating and durable replay (approved outbound calls run server-side from their stored payload). Gated by `COMPOSIO_APPROVAL` (`all` | `writes` | `off`; default `all`).
- **`/agent-api/composio/{status,tools}`** — read-only discovery; execution flows through the gated `/agent-api/act`, which now returns Composio tool results.
- **`api/scripts/composio-mcp.mjs`** — dep-free stdio MCP shim (list/execute/connections) registered into Hermes/OpenClaw by the equip layer, so no key ever enters an agent container.
- **`examples/composio-agent/`** — reference webhook agent (Claude via `@composio/anthropic`) to prove the loop without the containerised runtime.
- Docs (`docs/composio.md`), README (`Can't → Can`), `.env.example`, and compose wiring.

## Verified locally against a live Composio key

- `/agent-api/composio/tools` returns real tool slugs.
- `composio_execute` for a write (e.g. `GMAIL_SEND_EMAIL`) is **approval-gated** — an approval card opens and nothing runs until a human approves.
- `composio_execute` for a read runs end-to-end through the executor and calls Composio.

## Notes

- `@composio/core` requires `zod ^3.25`; the api lockfile is bumped accordingly.
- Approval-gated by default keeps the "governed, auditable" posture — set `COMPOSIO_APPROVAL=writes` to auto-run read-only tools, or `off` on a trusted single-tenant deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
