### PR TITLE
Add P0 and P1 agentic platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ You get Slack-shaped ergonomics for humans. You get a clean, versioned, MIT-lice
 - **Reply-guard**: server-side filter rejects Python tracebacks, gateway errors, assistant refusals, tool-call JSON dumps, action-JSON leaks, runaway repetition, bearer-token leaks, and meta-narration like "Reply posted successfully…". Agents can't spam a channel even if the model derails.
 - **Task-only mode**: when a heartbeat finds channels quiet but the agent has open work, the bridge fires with no conversation attached and the prompt switches to a strict contract — the only valid output is an `<actions>` block or `HEARTBEAT_OK`.
 
+### Automation & integrations
+- **Connector/MCP registry**: install generic HTTP and remote MCP servers per workspace, encrypt credentials at rest, run health checks, and grant narrowly-scoped access to named agents.
+- **Generic OAuth 2**: authorization-code flow with short-lived encrypted state and encrypted access/refresh token storage.
+- **Durable workflows**: persisted agent, connector, human approval, timer, poll, and terminal states with an attempt-by-attempt audit trail and resumable waits.
+- **Signed incoming webhooks**: exact-body HMAC verification, five-minute replay window, unique delivery ids, secret rotation, and webhook-to-workflow triggers.
+- **Model routing and real usage**: economy/balanced/frontier/advisor routes, per-model pricing, route recommendations in agent context, and actual usage reported inline or asynchronously (estimates remain visibly labelled).
+
+See **[`docs/automation-platform.md`](docs/automation-platform.md)** for workflow definitions, connector/OAuth configuration, webhook signing, usage reporting, and E2E verification.
+
+### Delivery, review & enterprise controls
+
+- **Decision memory**: typed precedents, policies, exceptions, alternatives, provenance, immutable human corrections, and automatic agent-context injection.
+- **App delivery**: task HTML artifacts become isolated previews, then approval-gated published static apps with CSP, logs, immutable artifact identity, and health checks.
+- **PR rooms and executable stages**: GitHub/GitLab PR state is attached to channels; board columns enforce entry/exit rules and inject snapshotted agent/skill instructions.
+- **Reusable teams and human control**: versioned team blueprints, a unified **Needs you** queue, and persisted cancel/steer/follow-up/timeout/ownership controls for long runs.
+- **Enterprise access**: guests with explicit channel boundaries, custom RBAC, OIDC + PKCE SSO, scoped service accounts, audit export, retention, and residency policy.
+
+See **[`docs/p1-platform.md`](docs/p1-platform.md)** for the API contracts, safety boundaries, and combined P0/P1 E2E verification.
+
 ### Operations
 - **Self-hosted**: one `docker compose up` brings up Postgres, Redis, MinIO, API, worker, web, and Caddy with HTTPS.
 - **Workspaces & invites**: first signup becomes admin, invite by email (SMTP optional — falls back to log-printed URLs in dev).
@@ -70,9 +89,9 @@ You get Slack-shaped ergonomics for humans. You get a clean, versioned, MIT-lice
 
 Honest scope, so you know what you're deploying.
 
-**Can:** post, react, and thread in channels and DMs; create, claim, update, and comment on board tasks; run code and edit files inside their own container (terminal + file toolsets ship in the default template); search and fetch from the web (bring a search-backend key, or point the runtime at a self-hosted SearXNG); write deliverables to a shared `/workspace` and attach them to tasks; request human approval before anything risky; keep durable memory across turns.
+**Can:** post, react, and thread in channels and DMs; create, claim, update, and comment on board tasks; run code and edit files inside their own container (terminal + file toolsets ship in the default template); search and fetch from the web; use governed HTTP/MCP connectors with scoped grants; start or resume durable workflows from signed events and human decisions; write deliverables to a shared `/workspace` and attach them to tasks; request human approval before anything risky; keep durable memory across turns; report real model usage against configurable routing tiers.
 
-**Can't (yet):** log into your existing tools. There is no integration catalog — no Gmail, GitHub, Slack, or CRM connectors. Anything that leaves the workspace goes through an approval-gated request plus whatever credentials you explicitly hand an agent. Wiring MCP tool servers into agent toolsets is the next major item on the roadmap.
+**Can't (yet):** offer a large first-party, one-click catalogue of provider-specific Gmail, GitHub, Slack, or CRM adapters. The platform primitives now exist—generic HTTP/MCP, OAuth, scoped credentials, health checks, and durable workflows—but each provider still needs its own connector configuration or MCP server. The workflow editor is definition-first rather than a drag-and-drop canvas.
 
 If you need agents acting inside dozens of SaaS tools today, n8n or Lindy will serve you better. If you want a governed, auditable team of agents on your own hardware — planning, building, verifying, and shipping artifacts — that's what this is.
 
@@ -367,6 +386,7 @@ Shipped and live:
 - ✅ Per-workspace kanban with subtasks, comments, links
 - ✅ Agent runtime (socket + webhook), scheduler, context packet, action executor
 - ✅ Approvals, reply-guard, memory, org chart
+- ✅ Enterprise access controls (OIDC SSO, custom RBAC, guests, service accounts, audit export)
 - ✅ In-app file viewer (PDF, MD, HTML sandbox, text, media)
 - ✅ Mobile-friendly layout — hamburger drawer, scroll-snap kanban, full-screen modals
 
@@ -374,7 +394,6 @@ In flight:
 - 🚧 Richer agent memory (per-channel, per-task scopes)
 - 🚧 Voice/video messages
 - 🚧 Email-to-channel ingress
-- 🚧 SSO (OIDC)
 
 Planned:
 - ⏳ Plugin marketplace for packaged agent skills

--- a/api/migrations/0026_agentic_platform.sql
+++ b/api/migrations/0026_agentic_platform.sql
@@ -1,0 +1,154 @@
+-- P0 agentic-platform foundation: governed connector/MCP registry, durable
+-- workflows and waits, signed incoming webhooks, and actual model usage.
+
+CREATE TABLE IF NOT EXISTS "connectors" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "name" varchar(120) NOT NULL,
+  "description" text NOT NULL DEFAULT '',
+  "kind" varchar(16) NOT NULL,
+  "base_url" text NOT NULL,
+  "auth_type" varchar(20) NOT NULL DEFAULT 'none',
+  "config_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "secret_ciphertext" text,
+  "status" varchar(20) NOT NULL DEFAULT 'unchecked',
+  "last_checked_at" timestamptz,
+  "last_error" text,
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "connectors_kind_check" CHECK ("kind" IN ('http', 'mcp')),
+  CONSTRAINT "connectors_auth_check" CHECK ("auth_type" IN ('none', 'bearer', 'header', 'oauth2'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "connectors_ws_name_key" ON "connectors" ("workspace_id", "name");
+CREATE INDEX IF NOT EXISTS "connectors_ws_idx" ON "connectors" ("workspace_id", "status");
+
+CREATE TABLE IF NOT EXISTS "agent_connector_grants" (
+  "connector_id" varchar(32) NOT NULL,
+  "agent_id" varchar(32) NOT NULL,
+  "scopes" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("connector_id", "agent_id")
+);
+CREATE INDEX IF NOT EXISTS "agent_connector_grants_agent_idx" ON "agent_connector_grants" ("agent_id");
+
+CREATE TABLE IF NOT EXISTS "workflows" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "name" varchar(140) NOT NULL,
+  "description" text NOT NULL DEFAULT '',
+  "status" varchar(20) NOT NULL DEFAULT 'active',
+  "trigger_type" varchar(20) NOT NULL DEFAULT 'manual',
+  "definition_json" jsonb NOT NULL,
+  "version" integer NOT NULL DEFAULT 1,
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "workflows_status_check" CHECK ("status" IN ('active', 'paused')),
+  CONSTRAINT "workflows_trigger_check" CHECK ("trigger_type" IN ('manual', 'webhook'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "workflows_ws_name_key" ON "workflows" ("workspace_id", "name");
+CREATE INDEX IF NOT EXISTS "workflows_ws_idx" ON "workflows" ("workspace_id", "status");
+
+CREATE TABLE IF NOT EXISTS "workflow_runs" (
+  "id" varchar(32) PRIMARY KEY,
+  "workflow_id" varchar(32) NOT NULL,
+  "workspace_id" varchar(32) NOT NULL,
+  "status" varchar(20) NOT NULL DEFAULT 'queued',
+  "current_state_id" varchar(80),
+  "input_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "output_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "wait_kind" varchar(20),
+  "wait_key" varchar(100),
+  "wait_until" timestamptz,
+  "error_text" text,
+  "created_by" varchar(32) NOT NULL,
+  "started_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "finished_at" timestamptz,
+  CONSTRAINT "workflow_runs_status_check" CHECK ("status" IN ('queued', 'running', 'waiting', 'completed', 'failed', 'cancelled'))
+);
+CREATE INDEX IF NOT EXISTS "workflow_runs_workflow_idx" ON "workflow_runs" ("workflow_id", "started_at");
+CREATE INDEX IF NOT EXISTS "workflow_runs_ws_status_idx" ON "workflow_runs" ("workspace_id", "status");
+
+CREATE TABLE IF NOT EXISTS "workflow_steps" (
+  "id" varchar(32) PRIMARY KEY,
+  "run_id" varchar(32) NOT NULL,
+  "state_id" varchar(80) NOT NULL,
+  "kind" varchar(20) NOT NULL,
+  "attempt" integer NOT NULL DEFAULT 1,
+  "status" varchar(20) NOT NULL DEFAULT 'running',
+  "input_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "output_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "agent_run_id" varchar(32),
+  "error_text" text,
+  "started_at" timestamptz NOT NULL DEFAULT now(),
+  "finished_at" timestamptz
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "workflow_steps_run_state_attempt_key" ON "workflow_steps" ("run_id", "state_id", "attempt");
+CREATE INDEX IF NOT EXISTS "workflow_steps_run_idx" ON "workflow_steps" ("run_id", "started_at");
+
+CREATE TABLE IF NOT EXISTS "webhook_endpoints" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "workflow_id" varchar(32) NOT NULL,
+  "name" varchar(120) NOT NULL,
+  "secret_ciphertext" text NOT NULL,
+  "active" boolean NOT NULL DEFAULT true,
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS "webhook_endpoints_workflow_idx" ON "webhook_endpoints" ("workflow_id");
+
+CREATE TABLE IF NOT EXISTS "webhook_events" (
+  "id" varchar(32) PRIMARY KEY,
+  "endpoint_id" varchar(32) NOT NULL,
+  "delivery_id" varchar(120) NOT NULL,
+  "signature_valid" boolean NOT NULL DEFAULT false,
+  "status" varchar(20) NOT NULL DEFAULT 'received',
+  "payload_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "workflow_run_id" varchar(32),
+  "error_text" text,
+  "received_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "webhook_events_endpoint_delivery_key" ON "webhook_events" ("endpoint_id", "delivery_id");
+CREATE INDEX IF NOT EXISTS "webhook_events_endpoint_idx" ON "webhook_events" ("endpoint_id", "received_at");
+
+CREATE TABLE IF NOT EXISTS "model_routes" (
+  "workspace_id" varchar(32) NOT NULL,
+  "tier" varchar(20) NOT NULL,
+  "provider" varchar(60) NOT NULL,
+  "model" varchar(120) NOT NULL,
+  "input_cost_per_mtok" real NOT NULL DEFAULT 0,
+  "output_cost_per_mtok" real NOT NULL DEFAULT 0,
+  "cached_input_cost_per_mtok" real NOT NULL DEFAULT 0,
+  "context_window" integer,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "updated_by" varchar(32) NOT NULL,
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("workspace_id", "tier"),
+  CONSTRAINT "model_routes_tier_check" CHECK ("tier" IN ('economy', 'balanced', 'frontier', 'advisor'))
+);
+
+CREATE TABLE IF NOT EXISTS "model_usage_events" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "agent_id" varchar(32) NOT NULL,
+  "run_id" varchar(32) NOT NULL,
+  "event_key" varchar(80) NOT NULL,
+  "provider" varchar(60) NOT NULL DEFAULT 'unknown',
+  "model" varchar(120) NOT NULL DEFAULT 'unknown',
+  "route_tier" varchar(20),
+  "input_tokens" integer NOT NULL DEFAULT 0,
+  "output_tokens" integer NOT NULL DEFAULT 0,
+  "cached_input_tokens" integer NOT NULL DEFAULT 0,
+  "cost_usd" real NOT NULL DEFAULT 0,
+  "source" varchar(20) NOT NULL DEFAULT 'reported',
+  "occurred_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "model_usage_source_check" CHECK ("source" IN ('reported', 'estimated'))
+);
+CREATE INDEX IF NOT EXISTS "model_usage_events_run_idx" ON "model_usage_events" ("run_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "model_usage_events_run_event_key" ON "model_usage_events" ("run_id", "event_key");
+CREATE INDEX IF NOT EXISTS "model_usage_events_ws_time_idx" ON "model_usage_events" ("workspace_id", "occurred_at");
+CREATE INDEX IF NOT EXISTS "model_usage_events_agent_time_idx" ON "model_usage_events" ("agent_id", "occurred_at");

--- a/api/migrations/0027_p1_platform.sql
+++ b/api/migrations/0027_p1_platform.sql
@@ -1,0 +1,202 @@
+-- P1 product platform: inspectable decision memory, governed app delivery,
+-- provider-backed PR rooms, executable board stages, reusable blueprints,
+-- steerable runs, and enterprise access/audit controls.
+
+ALTER TABLE "workspaces" ADD COLUMN IF NOT EXISTS "retention_days" integer;
+ALTER TABLE "workspaces" ADD COLUMN IF NOT EXISTS "data_residency" varchar(32) NOT NULL DEFAULT 'operator';
+ALTER TABLE "invites" ADD COLUMN IF NOT EXISTS "role" varchar(40) NOT NULL DEFAULT 'member';
+ALTER TABLE "invites" ADD COLUMN IF NOT EXISTS "channel_ids" jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE "agent_runs" ADD COLUMN IF NOT EXISTS "cancel_requested_at" timestamptz;
+ALTER TABLE "agent_runs" ADD COLUMN IF NOT EXISTS "cancelled_by" varchar(32);
+ALTER TABLE "agent_runs" ADD COLUMN IF NOT EXISTS "steer_json" jsonb NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE "agent_runs" ADD COLUMN IF NOT EXISTS "followup_json" jsonb NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE "agent_runs" ADD COLUMN IF NOT EXISTS "timeout_at" timestamptz;
+ALTER TABLE "agent_runs" ADD COLUMN IF NOT EXISTS "owner_member_id" varchar(32);
+
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "cancel_requested_at" timestamptz;
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "cancelled_by" varchar(32);
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "steer_json" jsonb NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "followup_json" jsonb NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "timeout_at" timestamptz;
+ALTER TABLE "workflow_runs" ADD COLUMN IF NOT EXISTS "owner_member_id" varchar(32);
+
+CREATE TABLE IF NOT EXISTS "decision_memories" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "kind" varchar(20) NOT NULL,
+  "title" varchar(180) NOT NULL,
+  "decision" text NOT NULL,
+  "rationale" text NOT NULL DEFAULT '',
+  "alternatives_json" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "provenance_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "source" varchar(20) NOT NULL DEFAULT 'observer',
+  "status" varchar(20) NOT NULL DEFAULT 'active',
+  "supersedes_id" varchar(32),
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "corrected_at" timestamptz,
+  CONSTRAINT "decision_memories_kind_check" CHECK ("kind" IN ('decision','precedent','policy','exception','steer')),
+  CONSTRAINT "decision_memories_status_check" CHECK ("status" IN ('active','corrected','superseded'))
+);
+CREATE INDEX IF NOT EXISTS "decision_memories_ws_idx" ON "decision_memories" ("workspace_id", "status", "created_at");
+
+CREATE TABLE IF NOT EXISTS "hosted_apps" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "task_id" varchar(32) NOT NULL,
+  "name" varchar(140) NOT NULL,
+  "slug" varchar(80) NOT NULL,
+  "preview_token" varchar(80) NOT NULL,
+  "status" varchar(20) NOT NULL DEFAULT 'preview',
+  "active_deployment_id" varchar(32),
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "hosted_apps_status_check" CHECK ("status" IN ('preview','pending','published','disabled'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "hosted_apps_slug_key" ON "hosted_apps" ("slug");
+CREATE UNIQUE INDEX IF NOT EXISTS "hosted_apps_preview_key" ON "hosted_apps" ("preview_token");
+CREATE INDEX IF NOT EXISTS "hosted_apps_ws_idx" ON "hosted_apps" ("workspace_id", "status");
+
+CREATE TABLE IF NOT EXISTS "app_deployments" (
+  "id" varchar(32) PRIMARY KEY,
+  "app_id" varchar(32) NOT NULL,
+  "artifact_id" varchar(32) NOT NULL,
+  "artifact_sha256" varchar(64),
+  "status" varchar(20) NOT NULL DEFAULT 'preview',
+  "health_status" varchar(20) NOT NULL DEFAULT 'healthy',
+  "requested_by" varchar(32) NOT NULL,
+  "reviewed_by" varchar(32),
+  "review_note" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "published_at" timestamptz,
+  CONSTRAINT "app_deployments_status_check" CHECK ("status" IN ('preview','pending','published','rejected','retired'))
+);
+CREATE INDEX IF NOT EXISTS "app_deployments_app_idx" ON "app_deployments" ("app_id", "created_at");
+
+CREATE TABLE IF NOT EXISTS "app_logs" (
+  "id" varchar(32) PRIMARY KEY,
+  "app_id" varchar(32) NOT NULL,
+  "deployment_id" varchar(32),
+  "level" varchar(12) NOT NULL DEFAULT 'info',
+  "event" varchar(80) NOT NULL,
+  "message" text NOT NULL DEFAULT '',
+  "meta_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS "app_logs_app_idx" ON "app_logs" ("app_id", "created_at");
+
+CREATE TABLE IF NOT EXISTS "pr_rooms" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "conversation_id" varchar(32) NOT NULL,
+  "connector_id" varchar(32),
+  "provider" varchar(20) NOT NULL,
+  "repository" varchar(240) NOT NULL,
+  "pr_number" integer NOT NULL,
+  "title" varchar(240) NOT NULL DEFAULT '',
+  "url" text NOT NULL DEFAULT '',
+  "state" varchar(20) NOT NULL DEFAULT 'open',
+  "head_ref" varchar(160) NOT NULL DEFAULT '',
+  "base_ref" varchar(160) NOT NULL DEFAULT '',
+  "diff_json" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "checks_json" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "reviews_json" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "protection_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "last_synced_at" timestamptz,
+  "last_error" text,
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "pr_rooms_provider_check" CHECK ("provider" IN ('github','gitlab'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "pr_rooms_unique" ON "pr_rooms" ("workspace_id", "provider", "repository", "pr_number");
+CREATE INDEX IF NOT EXISTS "pr_rooms_conv_idx" ON "pr_rooms" ("conversation_id");
+
+CREATE TABLE IF NOT EXISTS "board_stages" (
+  "workspace_id" varchar(32) NOT NULL,
+  "stage" varchar(20) NOT NULL,
+  "title" varchar(80) NOT NULL,
+  "position" integer NOT NULL DEFAULT 0,
+  "instructions" text NOT NULL DEFAULT '',
+  "entry_rules_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "exit_rules_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "agent_id" varchar(32),
+  "skill" varchar(120),
+  "verification" varchar(20) NOT NULL DEFAULT 'none',
+  "escalation_member_id" varchar(32),
+  "next_stage" varchar(20),
+  "updated_by" varchar(32) NOT NULL,
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("workspace_id", "stage")
+);
+
+CREATE TABLE IF NOT EXISTS "team_blueprints" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "name" varchar(140) NOT NULL,
+  "description" text NOT NULL DEFAULT '',
+  "version" integer NOT NULL DEFAULT 1,
+  "definition_json" jsonb NOT NULL,
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "team_blueprints_ws_name_ver_key" ON "team_blueprints" ("workspace_id", "name", "version");
+
+CREATE TABLE IF NOT EXISTS "workspace_roles" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "key" varchar(40) NOT NULL,
+  "name" varchar(80) NOT NULL,
+  "permissions_json" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "is_system" boolean NOT NULL DEFAULT false,
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "workspace_roles_ws_key" ON "workspace_roles" ("workspace_id", "key");
+
+CREATE TABLE IF NOT EXISTS "service_accounts" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "name" varchar(100) NOT NULL,
+  "token_hash" varchar(64) NOT NULL,
+  "scopes_json" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "last_used_at" timestamptz,
+  "expires_at" timestamptz,
+  "revoked_at" timestamptz,
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "service_accounts_token_key" ON "service_accounts" ("token_hash");
+CREATE INDEX IF NOT EXISTS "service_accounts_ws_idx" ON "service_accounts" ("workspace_id", "revoked_at");
+
+CREATE TABLE IF NOT EXISTS "sso_connections" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "issuer" text NOT NULL,
+  "client_id" varchar(240) NOT NULL,
+  "client_secret_ciphertext" text NOT NULL,
+  "domains_json" jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "default_role" varchar(40) NOT NULL DEFAULT 'member',
+  "enabled" boolean NOT NULL DEFAULT true,
+  "created_by" varchar(32) NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "sso_connections_ws_key" ON "sso_connections" ("workspace_id");
+
+CREATE TABLE IF NOT EXISTS "audit_events" (
+  "id" varchar(32) PRIMARY KEY,
+  "workspace_id" varchar(32) NOT NULL,
+  "actor_type" varchar(20) NOT NULL,
+  "actor_id" varchar(32) NOT NULL,
+  "action" varchar(100) NOT NULL,
+  "target_type" varchar(40) NOT NULL,
+  "target_id" varchar(64),
+  "meta_json" jsonb NOT NULL DEFAULT '{}'::jsonb,
+  "ip_hash" varchar(64),
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS "audit_events_ws_time_idx" ON "audit_events" ("workspace_id", "created_at");

--- a/api/migrations/meta/_journal.json
+++ b/api/migrations/meta/_journal.json
@@ -183,6 +183,20 @@
       "when": 1778000000000,
       "tag": "0025_task_summaries",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1778100000000,
+      "tag": "0026_agentic_platform",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1778200000000,
+      "tag": "0027_p1_platform",
+      "breakpoints": true
     }
   ]
 }

--- a/api/package.json
+++ b/api/package.json
@@ -13,6 +13,8 @@
     "db:push": "drizzle-kit push",
     "db:migrate": "tsx src/db/migrate.ts",
     "test": "vitest run",
+    "test:p0-e2e": "node scripts/p0-e2e.mjs",
+    "test:p1-e2e": "node scripts/p1-e2e.mjs",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/api/scripts/p0-e2e.mjs
+++ b/api/scripts/p0-e2e.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+import { createHmac } from "node:crypto";
+import assert from "node:assert/strict";
+
+const base = (process.env.CC_E2E_BASE_URL || "http://127.0.0.1:3000").replace(/\/$/, "");
+const email = process.env.CC_E2E_EMAIL || "e2e@circlechat.local";
+const password = process.env.CC_E2E_PASSWORD || "e2e-password";
+
+let cookie = "";
+async function request(path, { method = "GET", body, headers = {}, auth = true } = {}) {
+  const response = await fetch(`${base}${path}`, {
+    method,
+    headers: {
+      accept: "application/json",
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+      ...(auth && cookie ? { cookie } : {}),
+      ...headers,
+    },
+    body: body !== undefined ? (typeof body === "string" ? body : JSON.stringify(body)) : undefined,
+  });
+  const setCookie = response.headers.get("set-cookie");
+  if (setCookie) cookie = setCookie.split(";", 1)[0];
+  const text = await response.text();
+  let data = text;
+  try { data = text ? JSON.parse(text) : null; } catch { /* text response */ }
+  if (!response.ok) {
+    const error = new Error(`${method} ${path} -> ${response.status}: ${text.slice(0, 500)}`);
+    error.status = response.status;
+    error.data = data;
+    throw error;
+  }
+  return { status: response.status, data };
+}
+
+async function waitForRun(runId, predicate, timeoutMs = 12_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { data } = await request(`/api/workflow-runs/${runId}`);
+    if (predicate(data.run)) return data;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`workflow run ${runId} did not reach expected state`);
+}
+
+function log(check, detail = "") {
+  console.log(`✓ ${check}${detail ? ` — ${detail}` : ""}`);
+}
+
+try {
+  await request("/api/auth/login", { method: "POST", auth: false, body: { email, password } });
+} catch (error) {
+  if (error.status !== 401) throw error;
+  await request("/api/auth/signup", {
+    method: "POST",
+    auth: false,
+    body: {
+      email,
+      password,
+      name: "E2E Admin",
+      handle: "e2e-admin",
+      workspaceName: "P0 Test Lab",
+    },
+  });
+}
+assert.ok(cookie.startsWith("cc_session="));
+log("authenticated admin session");
+
+const unique = Date.now().toString(36);
+const modelName = `e2e-balanced-${unique}`;
+const { data: connectorCreated } = await request("/api/connectors", {
+  method: "POST",
+  body: {
+    name: `E2E health ${unique}`,
+    kind: "http",
+    baseUrl: `${base}/health`,
+    authType: "none",
+  },
+});
+const connectorId = connectorCreated.connector.id;
+const { data: health } = await request(`/api/connectors/${connectorId}/check`, { method: "POST" });
+assert.equal(health.ok, true);
+log("connector registry and live health check", connectorId);
+
+const { data: agentCreated } = await request("/api/agents", {
+  method: "POST",
+  body: {
+    name: `Usage Agent ${unique}`,
+    handle: `usage-${unique}`,
+    kind: "custom",
+    adapter: "webhook",
+    callbackUrl: `${base}/health`,
+    heartbeatIntervalSec: 86400,
+    scopes: ["channels.read", "channels.reply", "tools.call"],
+  },
+});
+await request(`/api/connectors/${connectorId}/grants/${agentCreated.id}`, {
+  method: "PUT",
+  body: { scopes: ["tools.call", "health.read"] },
+});
+const { data: connectorList } = await request("/api/connectors");
+assert.ok(connectorList.connectors.find((row) => row.id === connectorId).grants.some((grant) => grant.agentId === agentCreated.id));
+log("scoped per-agent connector grant", `@usage-${unique}`);
+
+await request("/api/model-routing/balanced", {
+  method: "PUT",
+  body: {
+    provider: "e2e-provider",
+    model: modelName,
+    inputCostPerMtok: 2,
+    outputCostPerMtok: 8,
+    cachedInputCostPerMtok: 0.5,
+    contextWindow: 128000,
+    enabled: true,
+  },
+});
+const { data: runCreated } = await request(`/api/agents/${agentCreated.id}/test`, { method: "POST" });
+await request(`/api/agent-api/runs/${runCreated.runId}/usage`, {
+  method: "POST",
+  auth: false,
+  headers: { authorization: `Bearer ${agentCreated.botToken}` },
+  body: {
+    provider: "e2e-provider",
+    model: modelName,
+    inputTokens: 1000,
+    outputTokens: 250,
+    cachedInputTokens: 100,
+  },
+});
+const { data: usage } = await request("/api/model-routing?days=1");
+assert.ok(usage.usage.some((row) => row.model === modelName && row.source === "reported"));
+assert.ok(usage.totals.reportedEvents >= 1);
+log("model route plus runtime-reported actual usage", `${usage.totals.reportedEvents} reported event(s)`);
+
+const webhookDefinition = {
+  start: "wait",
+  states: [
+    { id: "wait", type: "wait", next: "done", config: { durationSeconds: 2 } },
+    { id: "done", type: "terminal", config: { status: "completed", output: { accepted: true } } },
+  ],
+};
+const { data: webhookWorkflow } = await request("/api/workflows", {
+  method: "POST",
+  body: { name: `Signed intake ${unique}`, triggerType: "webhook", definition: webhookDefinition },
+});
+const { data: hook } = await request(`/api/workflows/${webhookWorkflow.workflow.id}/webhooks`, {
+  method: "POST",
+  body: { name: "E2E inbound" },
+});
+const rawBody = JSON.stringify({ event: "e2e.created", id: unique, amount: 42 });
+const timestamp = String(Math.floor(Date.now() / 1000));
+const signature = `sha256=${createHmac("sha256", hook.signingSecret).update(timestamp).update(".").update(rawBody).digest("hex")}`;
+let rejected = false;
+try {
+  await request(new URL(hook.endpoint.url).pathname, {
+    method: "POST",
+    auth: false,
+    body: rawBody,
+    headers: {
+      "x-circlechat-delivery": `bad-${unique}`,
+      "x-circlechat-timestamp": timestamp,
+      "x-circlechat-signature": "sha256=bad",
+    },
+  });
+} catch (error) {
+  rejected = error.status === 401;
+}
+assert.equal(rejected, true);
+const deliveryId = `delivery-${unique}`;
+const { data: accepted } = await request(new URL(hook.endpoint.url).pathname, {
+  method: "POST",
+  auth: false,
+  body: rawBody,
+  headers: {
+    "x-circlechat-delivery": deliveryId,
+    "x-circlechat-timestamp": timestamp,
+    "x-circlechat-signature": signature,
+  },
+});
+assert.equal(accepted.accepted, true);
+const { data: duplicate } = await request(new URL(hook.endpoint.url).pathname, {
+  method: "POST",
+  auth: false,
+  body: rawBody,
+  headers: {
+    "x-circlechat-delivery": deliveryId,
+    "x-circlechat-timestamp": timestamp,
+    "x-circlechat-signature": signature,
+  },
+});
+assert.equal(duplicate.duplicate, true);
+const completedWebhook = await waitForRun(accepted.runId, (run) => run.status === "completed");
+assert.deepEqual(completedWebhook.run.outputJson.done, { accepted: true });
+assert.ok(completedWebhook.steps.some((step) => step.kind === "wait" && step.status === "completed"));
+log("signed webhook, replay protection, durable timer resume", accepted.runId);
+
+const approvalDefinition = {
+  start: "approve",
+  states: [
+    { id: "approve", type: "approval", onSuccess: "wait", onFailure: "denied", config: { prompt: "Ship it?" } },
+    { id: "wait", type: "wait", next: "done", config: { durationSeconds: 2 } },
+    { id: "done", type: "terminal", config: { status: "completed" } },
+    { id: "denied", type: "terminal", config: { status: "failed" } },
+  ],
+};
+const { data: approvalWorkflow } = await request("/api/workflows", {
+  method: "POST",
+  body: { name: `Human gate ${unique}`, triggerType: "manual", definition: approvalDefinition },
+});
+const { data: approvalRun } = await request(`/api/workflows/${approvalWorkflow.workflow.id}/runs`, {
+  method: "POST",
+  body: { input: { release: unique } },
+});
+await waitForRun(approvalRun.runId, (run) => run.status === "waiting" && run.waitKind === "human");
+await request(`/api/workflow-runs/${approvalRun.runId}/resume`, {
+  method: "POST",
+  body: { approved: true, output: { reviewer: "e2e-admin" } },
+});
+const completedApproval = await waitForRun(approvalRun.runId, (run) => run.status === "completed");
+assert.ok(completedApproval.steps.some((step) => step.kind === "approval" && step.status === "completed"));
+assert.ok(completedApproval.steps.some((step) => step.kind === "wait" && step.status === "completed"));
+log("human resume followed by a second durable wait", approvalRun.runId);
+
+// The test agent deliberately returns a bad webhook body. BullMQ retries that
+// same run three times; billing must retain one idempotent worker event, not
+// turn infrastructure retries into three model calls.
+await new Promise((resolve) => setTimeout(resolve, 6_000));
+const { data: retryUsage } = await request("/api/model-routing?days=1");
+const retryEstimate = retryUsage.usage.find(
+  (row) => row.model === modelName && row.source === "estimated",
+);
+assert.equal(retryEstimate?.events, 1);
+const { data: agentDetail } = await request(`/api/agents/${agentCreated.id}`);
+const meteredRun = agentDetail.recentRuns.find((run) => run.id === runCreated.runId);
+assert.equal(meteredRun?.tokensEst, 1250);
+log("worker retry usage is idempotent", "3 attempts → 1 estimated event");
+
+console.log("\nP0 API E2E passed.");

--- a/api/scripts/p1-e2e.mjs
+++ b/api/scripts/p1-e2e.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import http from "node:http";
+
+const base = (process.env.CC_E2E_BASE_URL || "http://127.0.0.1:3000").replace(/\/$/, "");
+const email = process.env.CC_E2E_EMAIL || "e2e@circlechat.local";
+const password = process.env.CC_E2E_PASSWORD || "e2e-password";
+let cookie = "";
+
+async function request(path, { method = "GET", body, headers = {}, auth = true, redirect = "follow" } = {}) {
+  const isForm = typeof FormData !== "undefined" && body instanceof FormData;
+  const response = await fetch(`${base}${path}`, {
+    method,
+    redirect,
+    headers: {
+      accept: "application/json",
+      ...(!isForm && body !== undefined ? { "content-type": "application/json" } : {}),
+      ...(auth && cookie ? { cookie } : {}),
+      ...headers,
+    },
+    body: body !== undefined ? (isForm || typeof body === "string" ? body : JSON.stringify(body)) : undefined,
+  });
+  const setCookie = response.headers.get("set-cookie");
+  if (setCookie) cookie = setCookie.split(";", 1)[0];
+  const text = await response.text();
+  let data = text;
+  try { data = text ? JSON.parse(text) : null; } catch { /* non-JSON */ }
+  if (redirect === "manual" && response.status >= 300 && response.status < 400) {
+    return { status: response.status, data, headers: response.headers };
+  }
+  if (!response.ok) {
+    const error = new Error(`${method} ${path} -> ${response.status}: ${text.slice(0, 500)}`);
+    error.status = response.status; error.data = data; throw error;
+  }
+  return { status: response.status, data, headers: response.headers };
+}
+
+async function expectStatus(status, path, options) {
+  try { await request(path, options); }
+  catch (error) { assert.equal(error.status, status, error.message); return error.data; }
+  assert.fail(`${path} should have returned ${status}`);
+}
+
+async function waitFor(path, predicate, timeoutMs = 15_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const response = await request(path);
+    if (predicate(response.data)) return response.data;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`${path} did not reach expected state`);
+}
+
+function log(name, detail = "") { console.log(`✓ ${name}${detail ? ` — ${detail}` : ""}`); }
+
+let lastAgentPacket = null;
+const agentServer = http.createServer((req, res) => {
+  const chunks = [];
+  req.on("data", (chunk) => chunks.push(chunk));
+  req.on("end", () => {
+    try { lastAgentPacket = JSON.parse(Buffer.concat(chunks).toString("utf8")); } catch { lastAgentPacket = null; }
+    setTimeout(() => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ actions: [{ type: "memory_set", key: "should_not_apply_after_cancel", value: true }], trace: ["slow response"] }));
+    }, 1_500);
+  });
+});
+await new Promise((resolve) => agentServer.listen(33991, "127.0.0.1", resolve));
+
+const oidcServer = http.createServer((req, res) => {
+  const url = new URL(req.url, "http://127.0.0.1:33992");
+  if (url.pathname === "/.well-known/openid-configuration") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ authorization_endpoint: "http://127.0.0.1:33992/authorize", token_endpoint: "http://127.0.0.1:33992/token", userinfo_endpoint: "http://127.0.0.1:33992/userinfo" }));
+  } else if (url.pathname === "/token") {
+    res.writeHead(200, { "content-type": "application/json" }); res.end(JSON.stringify({ access_token: "oidc-e2e-token", token_type: "Bearer" }));
+  } else if (url.pathname === "/userinfo") {
+    res.writeHead(200, { "content-type": "application/json" }); res.end(JSON.stringify({ sub: "p1-sso-user", email: "sso@circlechat.local", email_verified: true, name: "SSO Guest", preferred_username: "sso-guest" }));
+  } else { res.writeHead(200, { "content-type": "text/plain" }); res.end("authorize"); }
+});
+await new Promise((resolve) => oidcServer.listen(33992, "127.0.0.1", resolve));
+
+const gitServer = http.createServer((req, res) => {
+  const path = new URL(req.url, "http://127.0.0.1:33993").pathname;
+  let payload = {};
+  if (path.endsWith("/files")) payload = [{ filename: "src/provider.ts" }, { filename: "web/provider.tsx" }];
+  else if (path.endsWith("/reviews")) payload = [{ state: "APPROVED", user: { login: "reviewer" } }];
+  else if (path.includes("/check-runs")) payload = { check_runs: [{ name: "provider-e2e", conclusion: "success" }] };
+  else if (path.includes("/protection")) payload = { required_pull_request_reviews: { required_approving_review_count: 1 } };
+  else payload = { title: "Live provider PR", html_url: "https://github.example/live", state: "open", head: { ref: "provider", sha: "abc123" }, base: { ref: "main" } };
+  res.writeHead(200, { "content-type": "application/json" }); res.end(JSON.stringify(payload));
+});
+await new Promise((resolve) => gitServer.listen(33993, "127.0.0.1", resolve));
+
+try {
+  await request("/api/auth/login", { method: "POST", auth: false, body: { email, password } });
+  const adminCookie = cookie;
+  const unique = Date.now().toString(36);
+  const me = (await request("/api/me")).data;
+  const workspaceId = me.workspaceId;
+  const memberId = me.memberId;
+  const workspaceHandle = me.workspaces.find((row) => row.id === workspaceId).handle;
+  log("authenticated P1 administrator", workspaceHandle);
+
+  const observed = (await request("/api/decisions/observe", { method: "POST", body: {
+    kind: "decision", title: `P1 architecture ${unique}`, decision: "Use governed platform primitives.",
+    rationale: "One audit and permission boundary.", alternatives: ["Feature silos"],
+    provenance: { task: "P1", source: "e2e" }, source: "observer",
+  } })).data.memory;
+  const corrected = (await request(`/api/decisions/${observed.id}/correct`, { method: "POST", body: {
+    kind: "precedent", title: `P1 architecture ${unique}`, decision: "Reuse governed platform primitives and immutable corrections.",
+    rationale: "Preserve history.", alternatives: ["In-place mutation"], provenance: { reviewer: "e2e" }, source: "human",
+  } })).data.memory;
+  const decisions = (await request("/api/decisions")).data.decisions;
+  assert.equal(decisions.find((row) => row.id === observed.id).status, "corrected");
+  assert.equal(corrected.supersedesId, observed.id);
+  log("decision observer, provenance, and immutable correction", corrected.id);
+
+  const task = (await request("/api/tasks", { method: "POST", body: { title: `P1 app ${unique}`, bodyMd: "Ship an isolated preview.", assignees: [memberId] } })).data.task;
+  const html = `<!doctype html><html><head><title>P1 ${unique}</title></head><body><h1>P1 hosted app</h1><p>${"verified ".repeat(20)}</p></body></html>`;
+  const form = new FormData(); form.set("file", new Blob([html], { type: "text/html" }), `p1-${unique}.html`);
+  const artifact = (await request(`/api/tasks/${task.id}/artifacts`, { method: "POST", body: form })).data.artifact;
+  const createdApp = (await request("/api/apps", { method: "POST", body: { taskId: task.id, artifactId: artifact.id, name: `P1 App ${unique}` } })).data;
+  let apps = (await request("/api/apps")).data.apps;
+  let hosted = apps.find((row) => row.id === createdApp.appId);
+  const preview = await request(new URL(hosted.previewUrl).pathname, { auth: false });
+  assert.match(preview.data, /P1 hosted app/);
+  assert.match(preview.headers.get("content-security-policy"), /default-src 'none'/);
+  await expectStatus(404, new URL(hosted.publicUrl).pathname, { auth: false });
+  await request(`/api/apps/${hosted.id}/request-publish`, { method: "POST", body: {} });
+  assert.ok((await request("/api/needs-you")).data.items.some((item) => item.kind === "app_publish" && item.targetId === hosted.id));
+  await request(`/api/apps/${hosted.id}/review`, { method: "POST", body: { decision: "approve", note: "E2E release" } });
+  const published = await request(new URL(hosted.publicUrl).pathname, { auth: false });
+  assert.match(published.data, /P1 hosted app/);
+  assert.equal((await request(`/api/apps/${hosted.id}/health`)).data.healthy, true);
+  log("isolated preview, review-gated publication, logs, CSP, and health", hosted.publicUrl);
+
+  const channel = (await request("/api/conversations")).data.conversations.find((row) => row.kind === "channel");
+  const prRoomId = (await request("/api/pr-rooms", { method: "POST", body: {
+    conversationId: channel.id, provider: "github", repository: `circlechat/platform-${unique}`, prNumber: 42,
+    snapshot: { pull: { title: "P1 PR", html_url: "https://github.example/pull/42", state: "open", head: { ref: "p1" }, base: { ref: "main" } }, files: [{ filename: "api.ts" }], checks: [{ name: "e2e", conclusion: "success" }], reviews: [{ state: "APPROVED" }], protection: { required_reviews: 1 } },
+  } })).data.roomId;
+  await request(`/api/pr-rooms/${prRoomId}/sync`, { method: "POST", body: { snapshot: {
+    pull: { title: "P1 PR synced", html_url: "https://github.example/pull/42", state: "open", head: { ref: "p1" }, base: { ref: "main" } }, files: [{ filename: "api.ts" }, { filename: "web.tsx" }], checks: [{ name: "e2e", conclusion: "success" }], reviews: [{ state: "APPROVED" }], protection: { required_reviews: 1 },
+  } } });
+  const prRoom = (await request("/api/pr-rooms")).data.rooms.find((row) => row.id === prRoomId);
+  assert.equal(prRoom.diffJson.length, 2); assert.equal(prRoom.checksJson.length, 1); assert.equal(prRoom.reviewsJson.length, 1); assert.equal(prRoom.protectionJson.required_reviews, 1);
+  log("provider PR room snapshot with diffs, checks, reviews, and protection", prRoomId);
+
+  const gitConnector = (await request("/api/connectors", { method: "POST", body: { name: `P1 Git ${unique}`, kind: "http", baseUrl: "http://127.0.0.1:33993", authType: "none" } })).data.connector;
+  const liveRepo = `circlechat/live-${unique}`;
+  const liveRoomId = (await request("/api/pr-rooms", { method: "POST", body: { conversationId: channel.id, connectorId: gitConnector.id, provider: "github", repository: liveRepo, prNumber: 43 } })).data.roomId;
+  await request(`/api/pr-rooms/${liveRoomId}/sync`, { method: "POST", body: {} });
+  const liveRoom = (await request("/api/pr-rooms")).data.rooms.find((row) => row.id === liveRoomId);
+  assert.equal(liveRoom.title, "Live provider PR"); assert.equal(liveRoom.diffJson.length, 2); assert.equal(liveRoom.checksJson[0].name, "provider-e2e"); assert.equal(liveRoom.protectionJson.required_pull_request_reviews.required_approving_review_count, 1);
+  log("live governed GitHub connector sync across provider API resources", liveRoomId);
+
+  const slowAgent = (await request("/api/agents", { method: "POST", body: {
+    name: `P1 Stage Agent ${unique}`, handle: `p1-stage-${unique}`, kind: "custom", adapter: "webhook",
+    callbackUrl: "http://127.0.0.1:33991", heartbeatIntervalSec: 86400,
+    scopes: ["tasks.read", "tasks.write"], capabilities: ["review"],
+  } })).data;
+  await request("/api/board-stages/backlog", { method: "PUT", body: { title: "Intake", position: 0, exitRules: { requireAssignee: true }, nextStage: "in_progress" } });
+  await request("/api/board-stages/in_progress", { method: "PUT", body: { title: "Executing", position: 1, instructions: "Follow the P1 release checklist.", agentId: slowAgent.id, skill: "release", verification: "none", nextStage: "review" } });
+  await request("/api/board-stages/review", { method: "PUT", body: { title: "Verified review", position: 3, entryRules: { requireArtifact: true }, verification: "human", nextStage: "done" } });
+  const unassigned = (await request("/api/tasks", { method: "POST", body: { title: `Stage gate ${unique}` } })).data.task;
+  const denied = await expectStatus(400, `/api/tasks/${unassigned.id}`, { method: "PATCH", body: { status: "in_progress" } });
+  assert.equal(denied.error, "stage_rules_failed"); assert.ok(denied.violations.includes("exit:assignee_required"));
+  await request(`/api/tasks/${unassigned.id}/assignees`, { method: "POST", body: { memberId } });
+  await request(`/api/tasks/${unassigned.id}/advance`, { method: "POST", body: {} });
+  const stageTask = (await request(`/api/tasks/${unassigned.id}`)).data;
+  assert.equal(stageTask.task.status, "in_progress"); assert.ok(stageTask.activity.some((row) => row.kind === "stage_agent_assigned"));
+  await expectStatus(400, `/api/tasks/${unassigned.id}`, { method: "PATCH", body: { status: "review" } });
+  const evidence = new FormData(); evidence.set("file", new Blob([html], { type: "text/html" }), `evidence-${unique}.html`);
+  await request(`/api/tasks/${unassigned.id}/artifacts`, { method: "POST", body: evidence });
+  await request(`/api/tasks/${unassigned.id}`, { method: "PATCH", body: { status: "review" } });
+  await waitFor(`/api/agents/${slowAgent.id}`, (data) => data.recentRuns.some((run) => run.contextJson?.stageExecution?.skill === "release"));
+  assert.ok(lastAgentPacket.decisionMemory.some((row) => row.id === corrected.id));
+  assert.equal(lastAgentPacket.stageExecution.instructions, "Follow the P1 release checklist.");
+  log("stage entry/exit gates, auto-assignment, skill instructions, verification, and memory injection");
+
+  const blueprint = (await request("/api/team-blueprints", { method: "POST", body: { name: `P1 Team ${unique}`, description: "Versioned E2E export", exportWorkspace: true } })).data;
+  assert.ok(blueprint.definition.agents.length >= 1); assert.ok(blueprint.definition.channels.length >= 1); assert.ok(blueprint.definition.workflows.length >= 1);
+  const applied = (await request(`/api/team-blueprints/${blueprint.blueprintId}/apply`, { method: "POST", body: {} })).data;
+  assert.equal(applied.agents, blueprint.definition.agents.length); assert.equal(applied.channels, blueprint.definition.channels.length); assert.equal(applied.workflows, blueprint.definition.workflows.length);
+  log("versioned team export and full agent/channel/workflow instantiation", `v${blueprint.version}`);
+
+  const durable = (await request("/api/workflows", { method: "POST", body: { name: `P1 controllable ${unique}`, triggerType: "manual", definition: { start: "wait", states: [{ id: "wait", type: "wait", next: "done", config: { durationSeconds: 60 } }, { id: "done", type: "terminal" }] } } })).data.workflow;
+  const workflowRunId = (await request(`/api/workflows/${durable.id}/runs`, { method: "POST", body: { input: { e2e: unique } } })).data.runId;
+  await waitFor(`/api/workflow-runs/${workflowRunId}`, (data) => data.run.status === "waiting");
+  await request(`/api/workflow-runs/${workflowRunId}/control`, { method: "POST", body: { action: "claim" } });
+  await request(`/api/workflow-runs/${workflowRunId}/control`, { method: "POST", body: { action: "steer", text: "Prefer the verified route." } });
+  await request(`/api/workflow-runs/${workflowRunId}/control`, { method: "POST", body: { action: "follow_up", text: "Summarize the result." } });
+  await request(`/api/workflow-runs/${workflowRunId}/control`, { method: "POST", body: { action: "extend", seconds: 3600 } });
+  const cancelledWorkflow = (await request(`/api/workflow-runs/${workflowRunId}/control`, { method: "POST", body: { action: "cancel", reason: "E2E cancellation" } })).data.run;
+  assert.equal(cancelledWorkflow.status, "cancelled"); assert.equal(cancelledWorkflow.steerJson.length, 1); assert.equal(cancelledWorkflow.followupJson.length, 1); assert.ok(cancelledWorkflow.timeoutAt); assert.equal(cancelledWorkflow.ownerMemberId, memberId);
+
+  const agentRunId = (await request(`/api/agents/${slowAgent.id}/test`, { method: "POST" })).data.runId;
+  await waitFor(`/api/agents/${slowAgent.id}`, (data) => data.recentRuns.some((run) => run.id === agentRunId && run.status === "running"), 5_000);
+  await request(`/api/agent-runs/${agentRunId}/control`, { method: "POST", body: { action: "cancel", reason: "Do not apply slow response" } });
+  const cancelledAgent = await waitFor(`/api/agents/${slowAgent.id}`, (data) => data.recentRuns.some((run) => run.id === agentRunId && run.status === "cancelled"));
+  const cancelledAgentRow = cancelledAgent.recentRuns.find((run) => run.id === agentRunId);
+  assert.equal(cancelledAgentRow.status, "cancelled"); assert.notEqual(cancelledAgentRow.resultJson?.applied, 1);
+  log("workflow and agent ownership, steer, follow-up, extension, and action-safe cancellation");
+
+  const needs = (await request("/api/needs-you")).data;
+  assert.ok(needs.items.some((item) => item.kind === "task_review" && item.targetId === unassigned.id));
+  assert.ok(needs.counts.total >= 1);
+  log("unified Needs you aggregation", `${needs.counts.total} item(s)`);
+
+  await request("/api/enterprise/roles", { method: "POST", body: { key: `reviewer-${unique}`.slice(0, 40), name: "Release reviewer", permissions: ["workspace.read", "runs.control", "audit.export"] } });
+  await request("/api/enterprise/governance", { method: "PUT", body: { retentionDays: 365, dataResidency: "eu-west" } });
+  const enterprise = (await request("/api/enterprise")).data;
+  assert.equal(enterprise.workspace.retentionDays, 365); assert.equal(enterprise.workspace.dataResidency, "eu-west");
+  const service = (await request("/api/enterprise/service-accounts", { method: "POST", body: { name: `P1 CI ${unique}`, scopes: ["workflows.read", "workflows.run"] } })).data;
+  const verifiedService = await request("/api/service-api/whoami", { auth: false, headers: { authorization: `Bearer ${service.token}` } });
+  assert.deepEqual(verifiedService.data.account.scopes, ["workflows.read", "workflows.run"]);
+  const serviceWorkflows = await request("/api/service-api/workflows", { auth: false, headers: { authorization: `Bearer ${service.token}` } });
+  assert.ok(serviceWorkflows.data.workflows.some((row) => row.id === durable.id));
+  const serviceRun = await request(`/api/service-api/workflows/${durable.id}/runs`, { method: "POST", auth: false, headers: { authorization: `Bearer ${service.token}` }, body: { input: { source: "service-e2e" } } });
+  assert.equal(serviceRun.status, 202);
+  await request(`/api/enterprise/service-accounts/${service.account.id}/revoke`, { method: "POST", body: {} });
+  await expectStatus(401, "/api/service-api/whoami", { auth: false, headers: { authorization: `Bearer ${service.token}` } });
+  log("custom RBAC, governance policy, scoped service identity, and revocation");
+
+  const guestEmail = `guest-${unique}@circlechat.local`;
+  const invite = (await request("/api/auth/invite", { method: "POST", body: { email: guestEmail, role: "guest", channelIds: [channel.id] } })).data;
+  cookie = "";
+  await request("/api/auth/accept-invite", { method: "POST", auth: false, body: { token: new URL(invite.inviteUrl).pathname.split("/").pop(), name: "P1 Guest", handle: `p1-guest-${unique}`, password: "guest-password" } });
+  const guestConversations = (await request("/api/conversations")).data.conversations;
+  assert.deepEqual(guestConversations.map((row) => row.id), [channel.id]);
+  await expectStatus(403, "/api/decisions/observe", { method: "POST", body: { kind: "decision", title: "Guest write", decision: "No" } });
+  cookie = adminCookie;
+  log("guest role and explicit channel boundary", channel.name);
+
+  await request("/api/enterprise/sso", { method: "PUT", body: { issuer: "http://127.0.0.1:33992", clientId: "circlechat-e2e", clientSecret: "oidc-secret", domains: ["circlechat.local"], defaultRole: "guest", enabled: true } });
+  const start = await request(`/api/auth/sso/${workspaceHandle}`, { auth: false, redirect: "manual" });
+  assert.equal(start.status, 302);
+  const authorize = new URL(start.headers.get("location"));
+  assert.equal(authorize.searchParams.get("code_challenge_method"), "S256");
+  cookie = "";
+  const callback = await request(`/api/auth/sso/callback?code=e2e-code&state=${encodeURIComponent(authorize.searchParams.get("state"))}`, { auth: false, redirect: "manual" });
+  assert.equal(callback.status, 302); assert.ok(cookie.startsWith("cc_session="));
+  const ssoMe = (await request("/api/me")).data;
+  assert.equal(ssoMe.user.email, "sso@circlechat.local"); assert.equal(ssoMe.workspaces.find((row) => row.id === workspaceId).role, "guest");
+  cookie = adminCookie;
+  log("OIDC discovery, PKCE state, token exchange, domain policy, and guest provisioning");
+
+  const auditJson = (await request("/api/enterprise/audit?format=json&days=1")).data.events;
+  assert.ok(auditJson.some((event) => event.action === "sso.login"));
+  assert.ok(auditJson.some((event) => event.action === "app.publish_approved"));
+  const auditCsv = await request("/api/enterprise/audit?format=csv&days=1");
+  assert.match(auditCsv.data, /app\.publish_approved/);
+  log("permission-filtered JSON and CSV audit export", `${auditJson.length} event(s)`);
+
+  const isolatedWorkspace = (await request("/api/workspaces", { method: "POST", body: { name: `P1 Isolation ${unique}` } })).data.workspace;
+  assert.equal((await request("/api/decisions")).data.decisions.some((row) => row.id === corrected.id), false);
+  assert.equal((await request("/api/apps")).data.apps.some((row) => row.id === hosted.id), false);
+  assert.equal((await request("/api/pr-rooms")).data.rooms.some((row) => row.id === prRoomId), false);
+  await expectStatus(404, `/api/decisions/${corrected.id}/correct`, { method: "POST", body: { kind: "decision", title: "Cross tenant", decision: "Denied" } });
+  await expectStatus(404, `/api/workflow-runs/${workflowRunId}`, {});
+  await expectStatus(404, `/api/pr-rooms/${prRoomId}/sync`, { method: "POST", body: { snapshot: {} } });
+  await request(`/api/workspaces/${workspaceId}/switch`, { method: "POST", body: {} });
+  log("cross-workspace isolation for decisions, apps, PR rooms, and run controls", isolatedWorkspace.id);
+
+  console.log("\nP1 API E2E passed.");
+} finally {
+  await new Promise((resolve) => agentServer.close(resolve));
+  await new Promise((resolve) => oidcServer.close(resolve));
+  await new Promise((resolve) => gitServer.close(resolve));
+}

--- a/api/src/__tests__/model-routing.test.ts
+++ b/api/src/__tests__/model-routing.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateUsageCost,
+  chooseModelTier,
+  normalizeUsage,
+  selectConfiguredRoute,
+  type ModelRouteRecord,
+} from "../lib/model-routing.js";
+
+const route = (tier: string, enabled = true): ModelRouteRecord => ({
+  tier,
+  enabled,
+  provider: "test",
+  model: `model-${tier}`,
+  inputCostPerMtok: 2,
+  outputCostPerMtok: 8,
+  cachedInputCostPerMtok: 0.5,
+  contextWindow: 100_000,
+});
+
+describe("model routing", () => {
+  it("uses economy for background work and escalates high-stakes text", () => {
+    expect(chooseModelTier({ trigger: "scheduled" })).toBe("economy");
+    expect(chooseModelTier({ trigger: "task_assigned", text: "Production security architecture migration" })).toBe("frontier");
+    expect(chooseModelTier({ trigger: "dm", text: "Board decision after a breach" })).toBe("advisor");
+    expect(chooseModelTier({ trigger: "dm", requestedTier: "economy" })).toBe("economy");
+  });
+
+  it("falls back only to enabled routes", () => {
+    expect(selectConfiguredRoute([route("frontier", false), route("balanced")], "frontier")?.tier).toBe("balanced");
+    expect(selectConfiguredRoute([], "balanced")).toBeNull();
+  });
+
+  it("prices cached and uncached tokens independently", () => {
+    expect(calculateUsageCost({ inputTokens: 1_000_000, cachedInputTokens: 250_000, outputTokens: 100_000 }, route("balanced")))
+      .toBeCloseTo(2.425);
+    expect(calculateUsageCost({ inputTokens: 100, outputTokens: 100, costUsd: 0.123 }, route("balanced")))
+      .toBe(0.123);
+  });
+
+  it("normalizes malformed counters", () => {
+    expect(normalizeUsage({ inputTokens: -10, outputTokens: 2.9, cachedInputTokens: 99 })).toMatchObject({
+      inputTokens: 0,
+      outputTokens: 2,
+      cachedInputTokens: 0,
+    });
+  });
+});

--- a/api/src/__tests__/p1-platform.test.ts
+++ b/api/src/__tests__/p1-platform.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { permits } from "../lib/access-control.js";
+import {
+  appContentSecurityPolicy,
+  evaluateStageRules,
+  normalizePrSnapshot,
+  safeSlug,
+  StageRulesSchema,
+  TeamBlueprintSchema,
+} from "../lib/p1-platform.js";
+
+describe("executable board stages", () => {
+  it("reports every unmet entry and exit contract deterministically", () => {
+    const rules = StageRulesSchema.parse({
+      requireAssignee: true,
+      requiredLabels: ["security", "release"],
+      minProgress: 80,
+      requireArtifact: true,
+      requireVerification: true,
+    });
+    expect(evaluateStageRules(rules, {
+      assignees: [], labels: ["security"], progress: 50, artifactCount: 0, verificationPassed: false,
+    })).toEqual([
+      "assignee_required",
+      "label_required:release",
+      "progress_below:80",
+      "artifact_required",
+      "verification_required",
+    ]);
+  });
+
+  it("rejects unknown rule keys instead of silently ignoring policy typos", () => {
+    expect(() => StageRulesSchema.parse({ requireArtfact: true })).toThrow();
+  });
+});
+describe("team blueprints", () => {
+  it("validates every packaged resource family", () => {
+    const result = TeamBlueprintSchema.parse({
+      agents: [{ key: "lead", name: "Lead", handle: "lead", scopes: ["tasks.write"], budgetUsdMonth: 25 }],
+      relationships: [{ childKey: "lead", parentKey: null }],
+      skills: [{ agentKey: "lead", name: "release", content: "Verify, then ship." }],
+      channels: [{ name: "release", memberKeys: ["lead"] }],
+      workflows: [{ name: "Ship", definition: { start: "done", states: [{ id: "done", type: "terminal" }] } }],
+    });
+    expect(result.agents[0].budgetUsdMonth).toBe(25);
+    expect(result.channels[0].memberKeys).toEqual(["lead"]);
+  });
+});
+
+describe("provider PR normalization", () => {
+  it("normalizes GitHub PR, checks, reviews, files, and protection", () => {
+    const snapshot = normalizePrSnapshot("github", {
+      pull: { title: "Ship", html_url: "https://github.test/acme/app/pull/7", state: "open", head: { ref: "feature" }, base: { ref: "main" } },
+      files: [{ filename: "src/app.ts", additions: 5 }],
+      checks: [{ name: "test", conclusion: "success" }],
+      reviews: [{ state: "APPROVED" }],
+      protection: { required_status_checks: { strict: true } },
+    });
+    expect(snapshot).toMatchObject({ title: "Ship", headRef: "feature", baseRef: "main", state: "open" });
+    expect(snapshot.diff).toHaveLength(1);
+    expect(snapshot.checks).toHaveLength(1);
+    expect(snapshot.reviews).toHaveLength(1);
+    expect(snapshot.protection).toHaveProperty("required_status_checks");
+  });
+
+  it("normalizes GitLab merge requests and changes", () => {
+    const snapshot = normalizePrSnapshot("gitlab", {
+      mergeRequest: { title: "Merge", web_url: "https://gitlab.test/a/b/-/merge_requests/3", state: "merged", source_branch: "feat", target_branch: "main" },
+      changes: { changes: [{ old_path: "a", new_path: "b" }] },
+      pipelines: [{ status: "success" }], approvals: [{ user: { name: "Ada" } }],
+    });
+    expect(snapshot).toMatchObject({ title: "Merge", state: "merged", headRef: "feat", baseRef: "main" });
+    expect(snapshot.diff).toHaveLength(1);
+  });
+});
+
+describe("app isolation and RBAC helpers", () => {
+  it("uses stable safe slugs and a deny-by-default CSP", () => {
+    expect(safeSlug("  My <App>  ")).toBe("my-app");
+    expect(appContentSecurityPolicy()).toContain("default-src 'none'");
+    expect(appContentSecurityPolicy()).toContain("connect-src 'none'");
+    expect(appContentSecurityPolicy()).toContain("form-action 'none'");
+  });
+
+  it("recognizes explicit permissions and admin wildcard only", () => {
+    expect(permits(["runs.control"], "runs.control")).toBe(true);
+    expect(permits(["workspace.read"], "runs.control")).toBe(false);
+    expect(permits(["*"], "audit.export")).toBe(true);
+  });
+});

--- a/api/src/__tests__/secret-box.test.ts
+++ b/api/src/__tests__/secret-box.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { decryptSecret, encryptSecret } from "../lib/secret-box.js";
+
+describe("credential envelope", () => {
+  it("round trips without exposing plaintext and detects tampering", () => {
+    const value = { bearerToken: "top-secret", headers: { "x-api-key": "hidden" } };
+    const envelope = encryptSecret(value);
+    expect(envelope.startsWith("v1.")).toBe(true);
+    expect(envelope).not.toContain("top-secret");
+    expect(decryptSecret(envelope)).toEqual(value);
+    const parts = envelope.split(".");
+    parts[3] = `${parts[3][0] === "A" ? "B" : "A"}${parts[3].slice(1)}`;
+    expect(() => decryptSecret(parts.join("."))).toThrow("secret_decryption_failed");
+  });
+});

--- a/api/src/__tests__/signed-webhook.test.ts
+++ b/api/src/__tests__/signed-webhook.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { signWebhook, verifyWebhookSignature } from "../lib/signed-webhook.js";
+
+describe("signed webhook verification", () => {
+  const secret = "whsec_test-secret";
+  const now = new Date("2026-08-06T12:00:00Z");
+  const timestamp = String(Math.floor(now.getTime() / 1000));
+  const body = Buffer.from('{"event":"deal.closed","amount":42}');
+
+  it("accepts the exact body in the replay window", () => {
+    expect(
+      verifyWebhookSignature({
+        secret,
+        timestamp,
+        signature: signWebhook(secret, timestamp, body),
+        rawBody: body,
+        now,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects a semantically equivalent but byte-different body", () => {
+    expect(
+      verifyWebhookSignature({
+        secret,
+        timestamp,
+        signature: signWebhook(secret, timestamp, body),
+        rawBody: '{ "event": "deal.closed", "amount": 42 }',
+        now,
+      }),
+    ).toEqual({ ok: false, error: "bad_signature" });
+  });
+
+  it("rejects stale and incomplete requests", () => {
+    expect(
+      verifyWebhookSignature({
+        secret,
+        timestamp: String(Number(timestamp) - 301),
+        signature: "sha256=nope",
+        rawBody: body,
+        now,
+      }),
+    ).toEqual({ ok: false, error: "stale_timestamp" });
+    expect(verifyWebhookSignature({ secret, timestamp: undefined, signature: undefined, rawBody: body, now }))
+      .toEqual({ ok: false, error: "missing_signature" });
+  });
+});

--- a/api/src/__tests__/workflow-definition.test.ts
+++ b/api/src/__tests__/workflow-definition.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseWorkflowDefinition,
+  resolveWorkflowTemplate,
+  transitionFor,
+} from "../lib/workflow-definition.js";
+
+describe("workflow definition validation", () => {
+  it("accepts all durable state families and resolves branches", () => {
+    const definition = parseWorkflowDefinition({
+      start: "agent",
+      states: [
+        { id: "agent", type: "agent", config: { agentId: "a_1" }, onSuccess: "tool", onFailure: "failed" },
+        { id: "tool", type: "connector", config: { connectorId: "conn_1" }, next: "wait" },
+        { id: "wait", type: "wait", config: { durationSeconds: 2 }, next: "approval" },
+        { id: "approval", type: "approval", onSuccess: "poll", onFailure: "failed" },
+        { id: "poll", type: "poll", config: { connectorId: "conn_1", intervalSeconds: 5 }, onSuccess: "done", onFailure: "failed" },
+        { id: "done", type: "terminal", config: { status: "completed" } },
+        { id: "failed", type: "terminal", config: { status: "failed" } },
+      ],
+    });
+    expect(definition.states).toHaveLength(7);
+    expect(transitionFor(definition.states[0], "success")).toBe("tool");
+    expect(transitionFor(definition.states[0], "failure")).toBe("failed");
+  });
+
+  it("rejects duplicate ids, missing targets, and invalid waits", () => {
+    expect(() => parseWorkflowDefinition({ start: "a", states: [{ id: "a", type: "approval" }, { id: "a", type: "approval" }] }))
+      .toThrow("duplicate_state:a");
+    expect(() => parseWorkflowDefinition({ start: "a", states: [{ id: "a", type: "approval", next: "missing" }] }))
+      .toThrow("transition_target_missing:a:missing");
+    expect(() => parseWorkflowDefinition({ start: "a", states: [{ id: "a", type: "wait", config: { durationSeconds: 0 } }] }))
+      .toThrow("wait_duration_invalid:a");
+  });
+});
+
+describe("workflow templates", () => {
+  it("preserves exact expression types and interpolates strings", () => {
+    const result = resolveWorkflowTemplate(
+      { amount: "$input.amount", note: "Deal $input.deal.id by $steps.lookup.data.owner" },
+      { input: { amount: 42, deal: { id: "D-7" } }, steps: { lookup: { data: { owner: "Ada" } } } },
+    );
+    expect(result).toEqual({ amount: 42, note: "Deal D-7 by Ada" });
+  });
+});

--- a/api/src/agents/adapters/dispatch.ts
+++ b/api/src/agents/adapters/dispatch.ts
@@ -2,14 +2,21 @@ import type { ContextPacket } from "../context.js";
 import type { agents } from "../../db/schema.js";
 import { callOpenClawWebhook } from "./openclaw.js";
 import { callHermesSocket } from "./hermes.js";
+import type { ReportedModelUsage } from "../../lib/model-routing.js";
 
 type Agent = typeof agents.$inferSelect;
+
+export interface AgentCallResponse {
+  actions: unknown[];
+  trace?: string[];
+  usage?: ReportedModelUsage;
+}
 
 export async function callAgent(
   agent: Agent,
   kind: "heartbeat" | "event",
   packet: ContextPacket,
-): Promise<{ actions: unknown[]; trace?: string[] } | "HEARTBEAT_OK"> {
+): Promise<AgentCallResponse | "HEARTBEAT_OK"> {
   if (agent.adapter === "webhook") {
     if (!agent.callbackUrl) throw new Error("no_callback_url");
     return callOpenClawWebhook({

--- a/api/src/agents/adapters/hermes.ts
+++ b/api/src/agents/adapters/hermes.ts
@@ -1,11 +1,12 @@
 import type { ContextPacket } from "../context.js";
 import { config } from "../../lib/config.js";
+import type { AgentCallResponse } from "./dispatch.js";
 
 export async function callHermesSocket(params: {
   agentId: string;
   kind: "heartbeat" | "event";
   packet: ContextPacket;
-}): Promise<{ actions: unknown[]; trace?: string[] } | "HEARTBEAT_OK"> {
+}): Promise<AgentCallResponse | "HEARTBEAT_OK"> {
   // The WS registry lives in the API process; the worker dispatches via HTTP.
   const url = `${config.apiInternalUrl.replace(/\/$/, "")}/_internal/agent-dispatch`;
   const res = await fetch(url, {
@@ -16,10 +17,10 @@ export async function callHermesSocket(params: {
   if (res.status === 404) throw new Error("agent_not_connected");
   if (!res.ok) throw new Error(`dispatch_${res.status}`);
   const { reply } = (await res.json()) as {
-    reply: { status?: string; actions?: unknown[]; trace?: string[] } | undefined;
+    reply: AgentCallResponse & { status?: string } | undefined;
   };
   if (!reply) return { actions: [] };
   if (reply.status === "HEARTBEAT_OK") return "HEARTBEAT_OK";
-  if (Array.isArray(reply.actions)) return { actions: reply.actions, trace: reply.trace };
+  if (Array.isArray(reply.actions)) return { actions: reply.actions, trace: reply.trace, usage: reply.usage };
   return { actions: [] };
 }

--- a/api/src/agents/adapters/openclaw.ts
+++ b/api/src/agents/adapters/openclaw.ts
@@ -1,11 +1,12 @@
 import type { ContextPacket } from "../context.js";
+import type { AgentCallResponse } from "./dispatch.js";
 
 export async function callOpenClawWebhook(params: {
   callbackUrl: string;
   botToken: string;
   kind: "heartbeat" | "event";
   packet: ContextPacket;
-}): Promise<{ actions: unknown[]; trace?: string[] } | "HEARTBEAT_OK"> {
+}): Promise<AgentCallResponse | "HEARTBEAT_OK"> {
   const url = new URL(params.callbackUrl);
   url.pathname = url.pathname.replace(/\/+$/, "") + (params.kind === "heartbeat" ? "/heartbeat" : "/event");
 
@@ -33,7 +34,7 @@ export async function callOpenClawWebhook(params: {
   try {
     const parsed = JSON.parse(text);
     if (parsed === "HEARTBEAT_OK" || parsed?.status === "HEARTBEAT_OK") return "HEARTBEAT_OK";
-    if (Array.isArray(parsed?.actions)) return { actions: parsed.actions, trace: parsed.trace };
+    if (Array.isArray(parsed?.actions)) return { actions: parsed.actions, trace: parsed.trace, usage: parsed.usage };
     return { actions: [] };
   } catch {
     if (text.trim() === "HEARTBEAT_OK") return "HEARTBEAT_OK";

--- a/api/src/agents/context.ts
+++ b/api/src/agents/context.ts
@@ -15,6 +15,7 @@ import {
   taskLabels,
   taskComments,
   workspaces,
+  decisionMemories,
 } from "../db/schema.js";
 import { loadReportingFor, type ReportingBundle } from "../routes/org.js";
 import { listGoals, getGoalAncestry } from "../lib/goals-core.js";
@@ -104,6 +105,39 @@ export interface ContextPacket {
   trigger: string;
   triggerConversationId?: string | null;
   triggerMessageId?: string;
+  steering?: string | null;
+  // Platform recommendation only: the external runtime remains free to use a
+  // pinned model, but capable runtimes can route this turn to the selected
+  // tier/model and report exact usage back with their response.
+  modelRoute?: {
+    tier: string;
+    provider: string | null;
+    model: string | null;
+    contextWindow: number | null;
+  };
+  workflow?: {
+    runId: string;
+    workflowId: string;
+    name: string;
+    stateId: string | null;
+    input: Record<string, unknown>;
+    priorStepOutputs: Record<string, unknown>;
+    steer: Array<Record<string, unknown>>;
+    followUps: Array<Record<string, unknown>>;
+  };
+  runControls?: {
+    steer: Array<Record<string, unknown>>;
+    followUps: Array<Record<string, unknown>>;
+    timeoutAt: Date | null;
+  };
+  stageExecution?: {
+    stage: string;
+    title: string;
+    instructions: string;
+    skill: string | null;
+    verification: string;
+    nextStage: string | null;
+  };
   // Set when the agent's PREVIOUS run ended in failure (crash, gateway error,
   // reaped after a worker death). Continuity: without this the agent has
   // amnesia about its own dead run and silently drops whatever it was doing.
@@ -167,6 +201,18 @@ export interface ContextPacket {
     byConversation: Record<string, Record<string, unknown>>;
     byTask: Record<string, Record<string, unknown>>;
   };
+  // Typed human-correctable decisions and precedents. This complements fact
+  // retrieval with the reasoning and exceptions behind workspace choices.
+  decisionMemory: Array<{
+    id: string;
+    kind: string;
+    title: string;
+    decision: string;
+    rationale: string;
+    alternatives: string[];
+    provenance: Record<string, unknown>;
+    createdAt: string;
+  }>;
   // Letta-style in-context memory blocks (always shown, self-edited). `team` is
   // shared across the workspace; `notes` is private. See lib/memory-blocks.ts.
   memoryBlocks: Array<{
@@ -263,6 +309,7 @@ export async function buildContext(opts: {
   previousRunFailure?: { errorText: string; finishedAt: string | null } | null;
   stuckBreak?: string | null;
   lastCodeResult?: string | null;
+  steering?: string | null;
 }): Promise<ContextPacket> {
   const [a] = await db.select().from(agents).where(eq(agents.id, opts.agentId)).limit(1);
   if (!a) throw new Error("agent_not_found");
@@ -918,6 +965,12 @@ export async function buildContext(opts: {
   // file bodies (both budget-bounded, fail-safe → empty). Same triggerText the
   // knowledge layer uses, so a run "about" a project pulls that project's files.
   const projectCtx = await buildProjectContext(triggerText);
+  const decisions = await db
+    .select()
+    .from(decisionMemories)
+    .where(and(eq(decisionMemories.workspaceId, a.workspaceId), eq(decisionMemories.status, "active")))
+    .orderBy(desc(decisionMemories.createdAt))
+    .limit(30);
 
   return {
     agent: {
@@ -943,6 +996,7 @@ export async function buildContext(opts: {
     trigger: opts.trigger,
     triggerConversationId: opts.conversationId ?? null,
     triggerMessageId: opts.messageId,
+    steering: opts.steering ?? null,
     previousRunFailure: opts.previousRunFailure ?? null,
     stuckBreak: opts.stuckBreak ?? null,
     lastCodeResult: opts.lastCodeResult ?? null,
@@ -970,6 +1024,16 @@ export async function buildContext(opts: {
         ...(taskCtx ? [taskCtx.id] : []),
       ]),
     },
+    decisionMemory: decisions.map((memory) => ({
+      id: memory.id,
+      kind: memory.kind,
+      title: memory.title,
+      decision: memory.decision,
+      rationale: memory.rationale,
+      alternatives: memory.alternativesJson,
+      provenance: memory.provenanceJson,
+      createdAt: memory.createdAt.toISOString(),
+    })),
     memoryBlocks,
     reporting,
     goals: activeGoals,

--- a/api/src/agents/enqueue.ts
+++ b/api/src/agents/enqueue.ts
@@ -17,6 +17,9 @@ export async function enqueueAgentEvent(
     taskId?: string;
     status?: string;
     chainDepth?: number;
+    workflowRunId?: string;
+    workflowStepId?: string;
+    stageExecution?: AgentJobPayload["stageExecution"];
   },
 ): Promise<string> {
   const runId = id("run");
@@ -64,6 +67,9 @@ export async function enqueueAgentEvent(
       taskId: ev.taskId,
       status: ev.status,
       chainDepth: ev.chainDepth,
+      workflowRunId: ev.workflowRunId,
+      workflowStepId: ev.workflowStepId,
+      stageExecution: ev.stageExecution,
     } satisfies AgentJobPayload,
     { jobId: runId },
   );

--- a/api/src/agents/queue.ts
+++ b/api/src/agents/queue.ts
@@ -30,6 +30,7 @@ export interface AgentJobPayload {
     | "approval_response"
     | "test"
     | "ambient"
+    | "workflow"
     // Immediate follow-up turn the worker grants itself after a run that made
     // board progress, so multi-step work doesn't stall until the next
     // heartbeat. Bounded by chainDepth + the per-run budget gate.
@@ -42,4 +43,19 @@ export interface AgentJobPayload {
   // How many continuations deep this run is (0 = a normal trigger). Capped in
   // the worker so a chain can't run away.
   chainDepth?: number;
+  // Durable workflow correlation. The workflow worker parks its step until
+  // this agent run completes, then the agent worker resumes that exact step.
+  workflowRunId?: string;
+  workflowStepId?: string;
+  // Immutable snapshot of the board stage that caused this run. The task may
+  // move again before a busy worker starts; execution must still obey the
+  // original stage contract rather than reading a later column by accident.
+  stageExecution?: {
+    stage: string;
+    title: string;
+    instructions: string;
+    skill: string | null;
+    verification: string;
+    nextStage: string | null;
+  };
 }

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -34,6 +34,10 @@ export const workspaces = pgTable(
     // When the hard-stop notification last fired (separate from the 80% warn
     // marker so "budget reached" still notifies after a warning already did).
     budgetStoppedAt: timestamp("budget_stopped_at", { withTimezone: true }),
+    // Enterprise governance controls. NULL retention means operator policy;
+    // residency is an explicit deployment/data-placement label.
+    retentionDays: integer("retention_days"),
+    dataResidency: varchar("data_residency", { length: 32 }).notNull().default("operator"),
   },
   (t) => ({
     handleIdx: uniqueIndex("workspaces_handle_key").on(t.handle),
@@ -231,6 +235,12 @@ export const agentRuns = pgTable(
     // never reaches us. Estimated is better than blind; see lib/budgets.ts.
     tokensEst: integer("tokens_est"),
     errorText: text("error_text"),
+    cancelRequestedAt: timestamp("cancel_requested_at", { withTimezone: true }),
+    cancelledBy: varchar("cancelled_by", { length: 32 }),
+    steerJson: jsonb("steer_json").$type<Array<Record<string, unknown>>>().notNull().default([]),
+    followupJson: jsonb("followup_json").$type<Array<Record<string, unknown>>>().notNull().default([]),
+    timeoutAt: timestamp("timeout_at", { withTimezone: true }),
+    ownerMemberId: varchar("owner_member_id", { length: 32 }),
   },
   (t) => ({
     agentStartedIdx: index("agent_runs_agent_started_idx").on(t.agentId, t.startedAt),
@@ -276,6 +286,8 @@ export const invites = pgTable(
     invitedBy: varchar("invited_by", { length: 32 }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
     acceptedAt: timestamp("accepted_at", { withTimezone: true }),
+    role: varchar("role", { length: 40 }).notNull().default("member"),
+    channelIds: jsonb("channel_ids").$type<string[]>().notNull().default([]),
   },
   (t) => ({
     tokenIdx: uniqueIndex("invites_token_key").on(t.token),
@@ -681,3 +693,451 @@ export type ProgressLedger = {
 };
 
 export type GoalLedger = typeof goalLedgers.$inferSelect;
+
+// ───────────────── connector / MCP registry ──────────────────────────────
+// Connectors are workspace-owned and intentionally split into public config
+// plus encrypted credentials.  `kind=mcp` speaks MCP's JSON-RPC HTTP shape;
+// `kind=http` is a governed generic REST connector.  Grants keep a connector
+// installed in the workspace from automatically becoming available to every
+// agent.
+export const connectors = pgTable(
+  "connectors",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    name: varchar("name", { length: 120 }).notNull(),
+    description: text("description").notNull().default(""),
+    kind: varchar("kind", { length: 16 }).notNull(), // http | mcp
+    baseUrl: text("base_url").notNull(),
+    authType: varchar("auth_type", { length: 20 }).notNull().default("none"), // none | bearer | header | oauth2
+    configJson: jsonb("config_json").$type<Record<string, unknown>>().notNull().default({}),
+    secretCiphertext: text("secret_ciphertext"),
+    status: varchar("status", { length: 20 }).notNull().default("unchecked"), // unchecked | healthy | error | disabled
+    lastCheckedAt: timestamp("last_checked_at", { withTimezone: true }),
+    lastError: text("last_error"),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    wsIdx: index("connectors_ws_idx").on(t.workspaceId, t.status),
+    wsName: uniqueIndex("connectors_ws_name_key").on(t.workspaceId, t.name),
+  }),
+);
+
+export const agentConnectorGrants = pgTable(
+  "agent_connector_grants",
+  {
+    connectorId: varchar("connector_id", { length: 32 }).notNull(),
+    agentId: varchar("agent_id", { length: 32 }).notNull(),
+    scopes: jsonb("scopes").$type<string[]>().notNull().default([]),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.connectorId, t.agentId] }),
+    agentIdx: index("agent_connector_grants_agent_idx").on(t.agentId),
+  }),
+);
+
+// ───────────────── durable workflows ─────────────────────────────────────
+export type WorkflowStateDefinition = {
+  id: string;
+  type: "agent" | "connector" | "wait" | "approval" | "poll" | "terminal";
+  name?: string;
+  next?: string;
+  onSuccess?: string;
+  onFailure?: string;
+  config?: Record<string, unknown>;
+};
+
+export type WorkflowDefinition = {
+  start: string;
+  states: WorkflowStateDefinition[];
+};
+
+export const workflows = pgTable(
+  "workflows",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    name: varchar("name", { length: 140 }).notNull(),
+    description: text("description").notNull().default(""),
+    status: varchar("status", { length: 20 }).notNull().default("active"), // active | paused
+    triggerType: varchar("trigger_type", { length: 20 }).notNull().default("manual"), // manual | webhook
+    definitionJson: jsonb("definition_json").$type<WorkflowDefinition>().notNull(),
+    version: integer("version").notNull().default(1),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    wsIdx: index("workflows_ws_idx").on(t.workspaceId, t.status),
+    wsName: uniqueIndex("workflows_ws_name_key").on(t.workspaceId, t.name),
+  }),
+);
+
+export const workflowRuns = pgTable(
+  "workflow_runs",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workflowId: varchar("workflow_id", { length: 32 }).notNull(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    status: varchar("status", { length: 20 }).notNull().default("queued"), // queued | running | waiting | completed | failed | cancelled
+    currentStateId: varchar("current_state_id", { length: 80 }),
+    inputJson: jsonb("input_json").$type<Record<string, unknown>>().notNull().default({}),
+    outputJson: jsonb("output_json").$type<Record<string, unknown>>().notNull().default({}),
+    waitKind: varchar("wait_kind", { length: 20 }), // agent | human | timer | poll
+    waitKey: varchar("wait_key", { length: 100 }),
+    waitUntil: timestamp("wait_until", { withTimezone: true }),
+    errorText: text("error_text"),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    startedAt: timestamp("started_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+    finishedAt: timestamp("finished_at", { withTimezone: true }),
+    cancelRequestedAt: timestamp("cancel_requested_at", { withTimezone: true }),
+    cancelledBy: varchar("cancelled_by", { length: 32 }),
+    steerJson: jsonb("steer_json").$type<Array<Record<string, unknown>>>().notNull().default([]),
+    followupJson: jsonb("followup_json").$type<Array<Record<string, unknown>>>().notNull().default([]),
+    timeoutAt: timestamp("timeout_at", { withTimezone: true }),
+    ownerMemberId: varchar("owner_member_id", { length: 32 }),
+  },
+  (t) => ({
+    workflowIdx: index("workflow_runs_workflow_idx").on(t.workflowId, t.startedAt),
+    wsStatusIdx: index("workflow_runs_ws_status_idx").on(t.workspaceId, t.status),
+  }),
+);
+
+export const workflowSteps = pgTable(
+  "workflow_steps",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    runId: varchar("run_id", { length: 32 }).notNull(),
+    stateId: varchar("state_id", { length: 80 }).notNull(),
+    kind: varchar("kind", { length: 20 }).notNull(),
+    attempt: integer("attempt").notNull().default(1),
+    status: varchar("status", { length: 20 }).notNull().default("running"), // running | waiting | completed | failed
+    inputJson: jsonb("input_json").$type<Record<string, unknown>>().notNull().default({}),
+    outputJson: jsonb("output_json").$type<Record<string, unknown>>().notNull().default({}),
+    agentRunId: varchar("agent_run_id", { length: 32 }),
+    errorText: text("error_text"),
+    startedAt: timestamp("started_at", { withTimezone: true }).defaultNow().notNull(),
+    finishedAt: timestamp("finished_at", { withTimezone: true }),
+  },
+  (t) => ({
+    runIdx: index("workflow_steps_run_idx").on(t.runId, t.startedAt),
+    runStateAttempt: uniqueIndex("workflow_steps_run_state_attempt_key").on(t.runId, t.stateId, t.attempt),
+  }),
+);
+
+// Every webhook endpoint gets a distinct signing secret.  It is encrypted at
+// rest and returned only once at creation/rotation.  Delivery ids provide
+// replay protection and safe client retries.
+export const webhookEndpoints = pgTable(
+  "webhook_endpoints",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    workflowId: varchar("workflow_id", { length: 32 }).notNull(),
+    name: varchar("name", { length: 120 }).notNull(),
+    secretCiphertext: text("secret_ciphertext").notNull(),
+    active: boolean("active").notNull().default(true),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    workflowIdx: index("webhook_endpoints_workflow_idx").on(t.workflowId),
+  }),
+);
+
+export const webhookEvents = pgTable(
+  "webhook_events",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    endpointId: varchar("endpoint_id", { length: 32 }).notNull(),
+    deliveryId: varchar("delivery_id", { length: 120 }).notNull(),
+    signatureValid: boolean("signature_valid").notNull().default(false),
+    status: varchar("status", { length: 20 }).notNull().default("received"), // received | accepted | rejected | duplicate
+    payloadJson: jsonb("payload_json").$type<Record<string, unknown>>().notNull().default({}),
+    workflowRunId: varchar("workflow_run_id", { length: 32 }),
+    errorText: text("error_text"),
+    receivedAt: timestamp("received_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    endpointDelivery: uniqueIndex("webhook_events_endpoint_delivery_key").on(t.endpointId, t.deliveryId),
+    endpointIdx: index("webhook_events_endpoint_idx").on(t.endpointId, t.receivedAt),
+  }),
+);
+
+// ───────────────── model routing + actual usage ──────────────────────────
+export const modelRoutes = pgTable(
+  "model_routes",
+  {
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    tier: varchar("tier", { length: 20 }).notNull(), // economy | balanced | frontier | advisor
+    provider: varchar("provider", { length: 60 }).notNull(),
+    model: varchar("model", { length: 120 }).notNull(),
+    inputCostPerMtok: real("input_cost_per_mtok").notNull().default(0),
+    outputCostPerMtok: real("output_cost_per_mtok").notNull().default(0),
+    cachedInputCostPerMtok: real("cached_input_cost_per_mtok").notNull().default(0),
+    contextWindow: integer("context_window"),
+    enabled: boolean("enabled").notNull().default(true),
+    updatedBy: varchar("updated_by", { length: 32 }).notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.workspaceId, t.tier] }),
+  }),
+);
+
+export const modelUsageEvents = pgTable(
+  "model_usage_events",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    agentId: varchar("agent_id", { length: 32 }).notNull(),
+    runId: varchar("run_id", { length: 32 }).notNull(),
+    // Stable idempotency key for one logical model call. The agent worker uses
+    // `worker` so BullMQ retries update one event; runtime-side multi-call
+    // reports get a fresh key and remain individually auditable.
+    eventKey: varchar("event_key", { length: 80 }).notNull(),
+    provider: varchar("provider", { length: 60 }).notNull().default("unknown"),
+    model: varchar("model", { length: 120 }).notNull().default("unknown"),
+    routeTier: varchar("route_tier", { length: 20 }),
+    inputTokens: integer("input_tokens").notNull().default(0),
+    outputTokens: integer("output_tokens").notNull().default(0),
+    cachedInputTokens: integer("cached_input_tokens").notNull().default(0),
+    costUsd: real("cost_usd").notNull().default(0),
+    source: varchar("source", { length: 20 }).notNull().default("reported"), // reported | estimated
+    occurredAt: timestamp("occurred_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    runIdx: index("model_usage_events_run_idx").on(t.runId),
+    runEventKey: uniqueIndex("model_usage_events_run_event_key").on(t.runId, t.eventKey),
+    wsTimeIdx: index("model_usage_events_ws_time_idx").on(t.workspaceId, t.occurredAt),
+    agentTimeIdx: index("model_usage_events_agent_time_idx").on(t.agentId, t.occurredAt),
+  }),
+);
+
+// ───────────────── P1 product platform ──────────────────────────────────
+export const decisionMemories = pgTable(
+  "decision_memories",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    kind: varchar("kind", { length: 20 }).notNull(),
+    title: varchar("title", { length: 180 }).notNull(),
+    decision: text("decision").notNull(),
+    rationale: text("rationale").notNull().default(""),
+    alternativesJson: jsonb("alternatives_json").$type<string[]>().notNull().default([]),
+    provenanceJson: jsonb("provenance_json").$type<Record<string, unknown>>().notNull().default({}),
+    source: varchar("source", { length: 20 }).notNull().default("observer"),
+    status: varchar("status", { length: 20 }).notNull().default("active"),
+    supersedesId: varchar("supersedes_id", { length: 32 }),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    correctedAt: timestamp("corrected_at", { withTimezone: true }),
+  },
+  (t) => ({ wsIdx: index("decision_memories_ws_idx").on(t.workspaceId, t.status, t.createdAt) }),
+);
+
+export const hostedApps = pgTable(
+  "hosted_apps",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    taskId: varchar("task_id", { length: 32 }).notNull(),
+    name: varchar("name", { length: 140 }).notNull(),
+    slug: varchar("slug", { length: 80 }).notNull(),
+    previewToken: varchar("preview_token", { length: 80 }).notNull(),
+    status: varchar("status", { length: 20 }).notNull().default("preview"),
+    activeDeploymentId: varchar("active_deployment_id", { length: 32 }),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    slugKey: uniqueIndex("hosted_apps_slug_key").on(t.slug),
+    previewKey: uniqueIndex("hosted_apps_preview_key").on(t.previewToken),
+    wsIdx: index("hosted_apps_ws_idx").on(t.workspaceId, t.status),
+  }),
+);
+
+export const appDeployments = pgTable(
+  "app_deployments",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    appId: varchar("app_id", { length: 32 }).notNull(),
+    artifactId: varchar("artifact_id", { length: 32 }).notNull(),
+    artifactSha256: varchar("artifact_sha256", { length: 64 }),
+    status: varchar("status", { length: 20 }).notNull().default("preview"),
+    healthStatus: varchar("health_status", { length: 20 }).notNull().default("healthy"),
+    requestedBy: varchar("requested_by", { length: 32 }).notNull(),
+    reviewedBy: varchar("reviewed_by", { length: 32 }),
+    reviewNote: text("review_note"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+  },
+  (t) => ({ appIdx: index("app_deployments_app_idx").on(t.appId, t.createdAt) }),
+);
+
+export const appLogs = pgTable(
+  "app_logs",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    appId: varchar("app_id", { length: 32 }).notNull(),
+    deploymentId: varchar("deployment_id", { length: 32 }),
+    level: varchar("level", { length: 12 }).notNull().default("info"),
+    event: varchar("event", { length: 80 }).notNull(),
+    message: text("message").notNull().default(""),
+    metaJson: jsonb("meta_json").$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ appIdx: index("app_logs_app_idx").on(t.appId, t.createdAt) }),
+);
+
+export const prRooms = pgTable(
+  "pr_rooms",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    conversationId: varchar("conversation_id", { length: 32 }).notNull(),
+    connectorId: varchar("connector_id", { length: 32 }),
+    provider: varchar("provider", { length: 20 }).notNull(),
+    repository: varchar("repository", { length: 240 }).notNull(),
+    prNumber: integer("pr_number").notNull(),
+    title: varchar("title", { length: 240 }).notNull().default(""),
+    url: text("url").notNull().default(""),
+    state: varchar("state", { length: 20 }).notNull().default("open"),
+    headRef: varchar("head_ref", { length: 160 }).notNull().default(""),
+    baseRef: varchar("base_ref", { length: 160 }).notNull().default(""),
+    diffJson: jsonb("diff_json").$type<Array<Record<string, unknown>>>().notNull().default([]),
+    checksJson: jsonb("checks_json").$type<Array<Record<string, unknown>>>().notNull().default([]),
+    reviewsJson: jsonb("reviews_json").$type<Array<Record<string, unknown>>>().notNull().default([]),
+    protectionJson: jsonb("protection_json").$type<Record<string, unknown>>().notNull().default({}),
+    lastSyncedAt: timestamp("last_synced_at", { withTimezone: true }),
+    lastError: text("last_error"),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    uniq: uniqueIndex("pr_rooms_unique").on(t.workspaceId, t.provider, t.repository, t.prNumber),
+    convIdx: index("pr_rooms_conv_idx").on(t.conversationId),
+  }),
+);
+
+export const boardStages = pgTable(
+  "board_stages",
+  {
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    stage: varchar("stage", { length: 20 }).notNull(),
+    title: varchar("title", { length: 80 }).notNull(),
+    position: integer("position").notNull().default(0),
+    instructions: text("instructions").notNull().default(""),
+    entryRulesJson: jsonb("entry_rules_json").$type<Record<string, unknown>>().notNull().default({}),
+    exitRulesJson: jsonb("exit_rules_json").$type<Record<string, unknown>>().notNull().default({}),
+    agentId: varchar("agent_id", { length: 32 }),
+    skill: varchar("skill", { length: 120 }),
+    verification: varchar("verification", { length: 20 }).notNull().default("none"),
+    escalationMemberId: varchar("escalation_member_id", { length: 32 }),
+    nextStage: varchar("next_stage", { length: 20 }),
+    updatedBy: varchar("updated_by", { length: 32 }).notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ pk: primaryKey({ columns: [t.workspaceId, t.stage] }) }),
+);
+
+export type TeamBlueprintDefinition = {
+  agents: Array<Record<string, unknown>>;
+  relationships: Array<Record<string, unknown>>;
+  skills: Array<Record<string, unknown>>;
+  channels: Array<Record<string, unknown>>;
+  workflows: Array<Record<string, unknown>>;
+};
+
+export const teamBlueprints = pgTable(
+  "team_blueprints",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    name: varchar("name", { length: 140 }).notNull(),
+    description: text("description").notNull().default(""),
+    version: integer("version").notNull().default(1),
+    definitionJson: jsonb("definition_json").$type<TeamBlueprintDefinition>().notNull(),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ uniq: uniqueIndex("team_blueprints_ws_name_ver_key").on(t.workspaceId, t.name, t.version) }),
+);
+
+export const workspaceRoles = pgTable(
+  "workspace_roles",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    key: varchar("key", { length: 40 }).notNull(),
+    name: varchar("name", { length: 80 }).notNull(),
+    permissionsJson: jsonb("permissions_json").$type<string[]>().notNull().default([]),
+    isSystem: boolean("is_system").notNull().default(false),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ uniq: uniqueIndex("workspace_roles_ws_key").on(t.workspaceId, t.key) }),
+);
+
+export const serviceAccounts = pgTable(
+  "service_accounts",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    name: varchar("name", { length: 100 }).notNull(),
+    tokenHash: varchar("token_hash", { length: 64 }).notNull(),
+    scopesJson: jsonb("scopes_json").$type<string[]>().notNull().default([]),
+    lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    tokenKey: uniqueIndex("service_accounts_token_key").on(t.tokenHash),
+    wsIdx: index("service_accounts_ws_idx").on(t.workspaceId, t.revokedAt),
+  }),
+);
+
+export const ssoConnections = pgTable(
+  "sso_connections",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    issuer: text("issuer").notNull(),
+    clientId: varchar("client_id", { length: 240 }).notNull(),
+    clientSecretCiphertext: text("client_secret_ciphertext").notNull(),
+    domainsJson: jsonb("domains_json").$type<string[]>().notNull().default([]),
+    defaultRole: varchar("default_role", { length: 40 }).notNull().default("member"),
+    enabled: boolean("enabled").notNull().default(true),
+    createdBy: varchar("created_by", { length: 32 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ wsKey: uniqueIndex("sso_connections_ws_key").on(t.workspaceId) }),
+);
+
+export const auditEvents = pgTable(
+  "audit_events",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    workspaceId: varchar("workspace_id", { length: 32 }).notNull(),
+    actorType: varchar("actor_type", { length: 20 }).notNull(),
+    actorId: varchar("actor_id", { length: 32 }).notNull(),
+    action: varchar("action", { length: 100 }).notNull(),
+    targetType: varchar("target_type", { length: 40 }).notNull(),
+    targetId: varchar("target_id", { length: 64 }),
+    metaJson: jsonb("meta_json").$type<Record<string, unknown>>().notNull().default({}),
+    ipHash: varchar("ip_hash", { length: 64 }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ wsTimeIdx: index("audit_events_ws_time_idx").on(t.workspaceId, t.createdAt) }),
+);

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -25,6 +25,13 @@ import agentAttachRoutes from "./routes/agent-attach.js";
 import agentSkillsRoutes from "./routes/agent-skills.js";
 import searchRoutes from "./routes/search.js";
 import notificationRoutes from "./routes/notifications.js";
+import connectorRoutes from "./routes/connectors.js";
+import workflowRoutes from "./routes/workflows.js";
+import modelRoutingRoutes from "./routes/model-routing.js";
+import platformRoutes, { appServeRoutes } from "./routes/platform.js";
+import runControlRoutes from "./routes/run-controls.js";
+import needsYouRoutes from "./routes/needs-you.js";
+import enterpriseRoutes, { enterprisePublicRoutes, serviceApiRoutes } from "./routes/enterprise.js";
 import { fileServeRoutes, fileDirectoryRoutes } from "./routes/files.js";
 import eventsWs from "./ws/events.js";
 import agentSocketWs from "./ws/agent-socket.js";
@@ -86,10 +93,20 @@ await app.register(analyticsRoutes, { prefix: "/api" });
 await app.register(agentApiRoutes, { prefix: "/api" });
 await app.register(searchRoutes, { prefix: "/api" });
 await app.register(notificationRoutes, { prefix: "/api" });
+await app.register(connectorRoutes, { prefix: "/api" });
+await app.register(workflowRoutes, { prefix: "/api" });
+await app.register(modelRoutingRoutes, { prefix: "/api" });
+await app.register(platformRoutes, { prefix: "/api" });
+await app.register(runControlRoutes, { prefix: "/api" });
+await app.register(needsYouRoutes, { prefix: "/api" });
+await app.register(enterpriseRoutes, { prefix: "/api" });
+await app.register(enterprisePublicRoutes, { prefix: "/api" });
+await app.register(serviceApiRoutes, { prefix: "/api" });
 await app.register(fileDirectoryRoutes, { prefix: "/api" });
 // Auth-checked file serving — registered at root so URLs are /files/<key>
 // and not /api/files/<key>. Must run before fastifyStatic so the route matches.
 await app.register(fileServeRoutes);
+await app.register(appServeRoutes);
 await app.register(eventsWs);
 await app.register(agentSocketWs);
 

--- a/api/src/lib/access-control.ts
+++ b/api/src/lib/access-control.ts
@@ -1,0 +1,70 @@
+import { createHash } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import type { FastifyRequest } from "fastify";
+import { db } from "../db/index.js";
+import { auditEvents, workspaceMembers, workspaceRoles } from "../db/schema.js";
+import { id } from "./ids.js";
+import { config } from "./config.js";
+
+export const BUILTIN_PERMISSIONS: Record<string, string[]> = {
+  admin: ["*"],
+  member: ["workspace.read", "workspace.write", "runs.control", "apps.request_publish"],
+  guest: ["workspace.read", "channels.write"],
+};
+
+export async function workspaceAccess(workspaceId: string, userId: string): Promise<{
+  role: string;
+  permissions: string[];
+} | null> {
+  const [membership] = await db
+    .select({ role: workspaceMembers.role })
+    .from(workspaceMembers)
+    .where(and(eq(workspaceMembers.workspaceId, workspaceId), eq(workspaceMembers.userId, userId)))
+    .limit(1);
+  if (!membership) return null;
+  const builtIn = BUILTIN_PERMISSIONS[membership.role];
+  if (builtIn) return { role: membership.role, permissions: builtIn };
+  const [custom] = await db
+    .select({ permissions: workspaceRoles.permissionsJson })
+    .from(workspaceRoles)
+    .where(and(eq(workspaceRoles.workspaceId, workspaceId), eq(workspaceRoles.key, membership.role)))
+    .limit(1);
+  return { role: membership.role, permissions: custom?.permissions ?? [] };
+}
+export function permits(permissions: string[], permission: string): boolean {
+  return permissions.includes("*") || permissions.includes(permission);
+}
+
+export async function requirePermission(req: FastifyRequest, permission: string): Promise<boolean> {
+  const workspaceId = req.auth?.workspaceId;
+  const userId = req.auth?.userId;
+  if (!workspaceId || !userId) return false;
+  const access = await workspaceAccess(workspaceId, userId);
+  return Boolean(access && permits(access.permissions, permission));
+}
+
+export async function writeAudit(input: {
+  workspaceId: string;
+  actorId: string;
+  action: string;
+  targetType: string;
+  targetId?: string | null;
+  actorType?: "user" | "agent" | "service" | "system";
+  meta?: Record<string, unknown>;
+  ip?: string;
+}): Promise<void> {
+  const ipHash = input.ip
+    ? createHash("sha256").update(`${config.sessionSecret}:${input.ip}`).digest("hex")
+    : null;
+  await db.insert(auditEvents).values({
+    id: id("audit"),
+    workspaceId: input.workspaceId,
+    actorType: input.actorType ?? "user",
+    actorId: input.actorId,
+    action: input.action,
+    targetType: input.targetType,
+    targetId: input.targetId ?? null,
+    metaJson: input.meta ?? {},
+    ipHash,
+  });
+}

--- a/api/src/lib/connector-runtime.ts
+++ b/api/src/lib/connector-runtime.ts
@@ -1,0 +1,147 @@
+import type { connectors } from "../db/schema.js";
+import { decryptSecret } from "./secret-box.js";
+import { resolveWorkflowTemplate } from "./workflow-definition.js";
+
+type Connector = typeof connectors.$inferSelect;
+type ConnectorSecret = {
+  bearerToken?: string;
+  oauthAccessToken?: string;
+  headers?: Record<string, string>;
+};
+
+export interface ConnectorInvocation {
+  operation?: string;
+  method?: string;
+  path?: string;
+  headers?: Record<string, string>;
+  query?: Record<string, string | number | boolean>;
+  body?: unknown;
+  input: Record<string, unknown>;
+  steps: Record<string, unknown>;
+}
+
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+
+function connectorHeaders(connector: Connector): Headers {
+  const headers = new Headers({ accept: "application/json" });
+  const configHeaders = (connector.configJson.headers ?? {}) as Record<string, unknown>;
+  for (const [name, value] of Object.entries(configHeaders)) {
+    if (typeof value === "string") headers.set(name, value);
+  }
+  if (!connector.secretCiphertext) return headers;
+  const secret = decryptSecret<ConnectorSecret>(connector.secretCiphertext);
+  for (const [name, value] of Object.entries(secret.headers ?? {})) headers.set(name, value);
+  const token = secret.oauthAccessToken ?? secret.bearerToken;
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  return headers;
+}
+
+function connectorUrl(connector: Connector, path = "", query?: ConnectorInvocation["query"]): URL {
+  const base = new URL(connector.baseUrl);
+  if (!/^https?:$/.test(base.protocol) || base.username || base.password) throw new Error("connector_url_invalid");
+  const url = path ? new URL(path.replace(/^\/+/, ""), base.toString().replace(/\/?$/, "/")) : base;
+  // A workflow may select a path, never a second host.
+  if (url.origin !== base.origin) throw new Error("connector_cross_origin_path");
+  for (const [name, value] of Object.entries(query ?? {})) url.searchParams.set(name, String(value));
+  return url;
+}
+
+export async function invokeConnector(
+  connector: Connector,
+  invocation: ConnectorInvocation,
+): Promise<{ status: number; headers: Record<string, string>; data: unknown }> {
+  if (connector.status === "disabled") throw new Error("connector_disabled");
+  const ctx = { input: invocation.input, steps: invocation.steps };
+  const resolved = resolveWorkflowTemplate(
+    {
+      path: invocation.path ?? "",
+      query: invocation.query ?? {},
+      body: invocation.body,
+      headers: invocation.headers ?? {},
+      operation: invocation.operation,
+    },
+    ctx,
+  ) as {
+    path: string;
+    query: Record<string, string | number | boolean>;
+    body: unknown;
+    headers: Record<string, string>;
+    operation?: string;
+  };
+
+  const headers = connectorHeaders(connector);
+  for (const [name, value] of Object.entries(resolved.headers ?? {})) headers.set(name, String(value));
+  const controller = new AbortController();
+  const configuredTimeout = Number(connector.configJson.timeoutMs ?? 30_000);
+  const timeoutMs = Math.max(1_000, Math.min(120_000, configuredTimeout || 30_000));
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let response: Response;
+  try {
+    if (connector.kind === "mcp") {
+      headers.set("content-type", "application/json");
+      headers.set("accept", "application/json, text/event-stream");
+      response = await fetch(connectorUrl(connector, resolved.path).toString(), {
+        method: "POST",
+        headers,
+        signal: controller.signal,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: `cc-${Date.now()}`,
+          method: "tools/call",
+          params: { name: resolved.operation, arguments: resolved.body ?? {} },
+        }),
+      });
+    } else {
+      const method = String(invocation.method ?? "POST").toUpperCase();
+      const permitsBody = method !== "GET" && method !== "HEAD";
+      if (permitsBody && resolved.body !== undefined) headers.set("content-type", "application/json");
+      response = await fetch(connectorUrl(connector, resolved.path, resolved.query).toString(), {
+        method,
+        headers,
+        signal: controller.signal,
+        redirect: "manual",
+        body: permitsBody && resolved.body !== undefined ? JSON.stringify(resolved.body) : undefined,
+      });
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.length > MAX_RESPONSE_BYTES) throw new Error("connector_response_too_large");
+  const text = bytes.toString("utf8");
+  let data: unknown = text;
+  if (text) {
+    try { data = JSON.parse(text); } catch { /* text response */ }
+  } else data = null;
+  if (!response.ok) throw new Error(`connector_http_${response.status}:${text.slice(0, 300)}`);
+  return { status: response.status, headers: Object.fromEntries(response.headers.entries()), data };
+}
+
+export async function checkConnector(connector: Connector): Promise<{ ok: boolean; error?: string }> {
+  try {
+    if (connector.kind === "mcp") {
+      const headers = connectorHeaders(connector);
+      headers.set("content-type", "application/json");
+      headers.set("accept", "application/json, text/event-stream");
+      const response = await fetch(connectorUrl(connector).toString(), {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ jsonrpc: "2.0", id: "cc-health", method: "tools/list", params: {} }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) throw new Error(`http_${response.status}`);
+    } else {
+      const path = typeof connector.configJson.healthPath === "string" ? connector.configJson.healthPath : "";
+      const response = await fetch(connectorUrl(connector, path).toString(), {
+        method: "GET",
+        headers: connectorHeaders(connector),
+        redirect: "manual",
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) throw new Error(`http_${response.status}`);
+    }
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: (error as Error).message.slice(0, 300) };
+  }
+}

--- a/api/src/lib/events.ts
+++ b/api/src/lib/events.ts
@@ -23,7 +23,8 @@ export type Event =
   | { type: "goal.updated"; workspaceId: string; goalId: string; goal?: unknown; status?: string }
   | { type: "goal.deleted"; workspaceId: string; goalId: string }
   | { type: "notification.new"; memberId: string; notification: unknown }
-  | { type: "notification.read"; memberId: string; notificationId: string | null };
+  | { type: "notification.read"; memberId: string; notificationId: string | null }
+  | { type: "workflow.run.updated"; workspaceId: string; workflowId: string; runId: string; status: string };
 
 const CONV_CHANNEL = (conversationId: string): string => `cc:conv:${conversationId}`;
 const WORKSPACE_CHANNEL = (workspaceId: string): string => `cc:workspace:${workspaceId}`;

--- a/api/src/lib/model-routing.ts
+++ b/api/src/lib/model-routing.ts
@@ -1,0 +1,83 @@
+export type ModelTier = "economy" | "balanced" | "frontier" | "advisor";
+
+export interface ModelRouteRecord {
+  tier: string;
+  provider: string;
+  model: string;
+  inputCostPerMtok: number;
+  outputCostPerMtok: number;
+  cachedInputCostPerMtok: number;
+  contextWindow: number | null;
+  enabled: boolean;
+}
+
+export interface ReportedModelUsage {
+  provider?: string;
+  model?: string;
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens?: number;
+  costUsd?: number;
+}
+
+const FRONTIER_SIGNALS = /\b(architecture|security|incident|migration|production|legal|financial|strategy|root cause|trade-?off|data loss)\b/i;
+const ADVISOR_SIGNALS = /\b(board|executive|high stakes|irreversible|compliance|acquisition|termination|breach)\b/i;
+
+export function chooseModelTier(input: {
+  trigger: string;
+  text?: string;
+  requestedTier?: string | null;
+}): ModelTier {
+  if (["economy", "balanced", "frontier", "advisor"].includes(input.requestedTier ?? "")) {
+    return input.requestedTier as ModelTier;
+  }
+  const text = input.text ?? "";
+  if (ADVISOR_SIGNALS.test(text)) return "advisor";
+  if (FRONTIER_SIGNALS.test(text) || text.length > 5000) return "frontier";
+  if (input.trigger === "scheduled" || input.trigger === "ambient") return "economy";
+  if (input.trigger === "approval_response") return "frontier";
+  return "balanced";
+}
+
+export function selectConfiguredRoute(
+  routes: ModelRouteRecord[],
+  wanted: ModelTier,
+): ModelRouteRecord | null {
+  const enabled = routes.filter((route) => route.enabled);
+  const exact = enabled.find((route) => route.tier === wanted);
+  if (exact) return exact;
+  const fallbackOrder: ModelTier[] = ["balanced", "frontier", "economy", "advisor"];
+  for (const tier of fallbackOrder) {
+    const route = enabled.find((candidate) => candidate.tier === tier);
+    if (route) return route;
+  }
+  return null;
+}
+
+export function calculateUsageCost(usage: ReportedModelUsage, route: ModelRouteRecord | null): number {
+  if (usage.costUsd != null && Number.isFinite(usage.costUsd) && usage.costUsd >= 0) return usage.costUsd;
+  if (!route) return 0;
+  const cached = Math.max(0, usage.cachedInputTokens ?? 0);
+  const uncachedInput = Math.max(0, usage.inputTokens - cached);
+  return (
+    (uncachedInput * route.inputCostPerMtok +
+      cached * route.cachedInputCostPerMtok +
+      Math.max(0, usage.outputTokens) * route.outputCostPerMtok) /
+    1_000_000
+  );
+}
+
+export function normalizeUsage(input: ReportedModelUsage): ReportedModelUsage {
+  const integer = (value: number | undefined): number =>
+    Number.isFinite(value) ? Math.max(0, Math.floor(value!)) : 0;
+  return {
+    provider: input.provider?.slice(0, 60),
+    model: input.model?.slice(0, 120),
+    inputTokens: integer(input.inputTokens),
+    outputTokens: integer(input.outputTokens),
+    cachedInputTokens: Math.min(integer(input.cachedInputTokens), integer(input.inputTokens)),
+    ...(input.costUsd != null && Number.isFinite(input.costUsd)
+      ? { costUsd: Math.max(0, input.costUsd) }
+      : {}),
+  };
+}

--- a/api/src/lib/model-usage-store.ts
+++ b/api/src/lib/model-usage-store.ts
@@ -1,0 +1,106 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { agentRuns, agents, modelRoutes, modelUsageEvents } from "../db/schema.js";
+import { id } from "./ids.js";
+import {
+  calculateUsageCost,
+  chooseModelTier,
+  normalizeUsage,
+  selectConfiguredRoute,
+  type ModelRouteRecord,
+  type ReportedModelUsage,
+} from "./model-routing.js";
+
+export async function modelRecommendation(input: {
+  workspaceId: string;
+  trigger: string;
+  text?: string;
+  requestedTier?: string | null;
+}): Promise<{
+  tier: string;
+  provider: string | null;
+  model: string | null;
+  contextWindow: number | null;
+}> {
+  const tier = chooseModelTier(input);
+  const rows = await db.select().from(modelRoutes).where(eq(modelRoutes.workspaceId, input.workspaceId));
+  const route = selectConfiguredRoute(rows as ModelRouteRecord[], tier);
+  return {
+    tier,
+    provider: route?.provider ?? null,
+    model: route?.model ?? null,
+    contextWindow: route?.contextWindow ?? null,
+  };
+}
+
+export async function recordModelUsage(input: {
+  workspaceId: string;
+  agentId: string;
+  runId: string;
+  routeTier?: string | null;
+  usage: ReportedModelUsage;
+  source: "reported" | "estimated";
+  eventKey?: string;
+}): Promise<{ tokens: number; costUsd: number }> {
+  const usage = normalizeUsage(input.usage);
+  const routes = await db.select().from(modelRoutes).where(eq(modelRoutes.workspaceId, input.workspaceId));
+  const route = selectConfiguredRoute(
+    routes as ModelRouteRecord[],
+    (input.routeTier as "economy" | "balanced" | "frontier" | "advisor") ?? "balanced",
+  );
+  const costUsd = calculateUsageCost(usage, route);
+  const [agent] = await db.select({ model: agents.model }).from(agents).where(eq(agents.id, input.agentId)).limit(1);
+  const usageId = id("usage");
+  const eventKey = input.eventKey ?? usageId;
+  const values = {
+    id: usageId,
+    workspaceId: input.workspaceId,
+    agentId: input.agentId,
+    runId: input.runId,
+    eventKey,
+    provider: usage.provider ?? route?.provider ?? "unknown",
+    model: usage.model ?? route?.model ?? agent?.model ?? "unknown",
+    routeTier: input.routeTier ?? null,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    cachedInputTokens: usage.cachedInputTokens ?? 0,
+    costUsd,
+    source: input.source,
+  };
+  await db
+    .insert(modelUsageEvents)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [modelUsageEvents.runId, modelUsageEvents.eventKey],
+      set: {
+        provider: values.provider,
+        model: values.model,
+        routeTier: values.routeTier,
+        inputTokens: values.inputTokens,
+        outputTokens: values.outputTokens,
+        cachedInputTokens: values.cachedInputTokens,
+        costUsd: values.costUsd,
+        source: values.source,
+        occurredAt: new Date(),
+      },
+    });
+  return { tokens: usage.inputTokens + usage.outputTokens, costUsd };
+}
+
+// Runtime-side reporting can arrive after the worker wrote an estimate. Replace
+// the run aggregate with the sum of reported events when any exist; otherwise
+// keep estimates. This avoids charging both estimated and actual usage.
+export async function refreshAgentRunUsage(runId: string): Promise<void> {
+  const [totals] = await db
+    .select({
+      tokens: sql<number>`coalesce(sum(${modelUsageEvents.inputTokens} + ${modelUsageEvents.outputTokens}), 0)::int`,
+      cost: sql<number>`coalesce(sum(${modelUsageEvents.costUsd}), 0)::float`,
+    })
+    .from(modelUsageEvents)
+    .where(and(eq(modelUsageEvents.runId, runId), eq(modelUsageEvents.source, "reported")));
+  if ((totals?.tokens ?? 0) <= 0 && (totals?.cost ?? 0) <= 0) return;
+  await db
+    .update(agentRuns)
+    .set({ tokensEst: totals.tokens, costUsd: totals.cost })
+    .where(eq(agentRuns.id, runId));
+}

--- a/api/src/lib/p1-platform.ts
+++ b/api/src/lib/p1-platform.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+
+export const DECISION_KINDS = ["decision", "precedent", "policy", "exception", "steer"] as const;
+export const BOARD_STAGE_KEYS = ["backlog", "in_progress", "blocked", "review", "done"] as const;
+
+export const StageRulesSchema = z.object({
+  requireAssignee: z.boolean().optional(),
+  requiredLabels: z.array(z.string().min(1).max(40)).max(20).optional(),
+  minProgress: z.number().int().min(0).max(100).optional(),
+  requireArtifact: z.boolean().optional(),
+  requireVerification: z.boolean().optional(),
+}).strict();
+
+export type StageRules = z.infer<typeof StageRulesSchema>;
+
+export function evaluateStageRules(
+  rules: StageRules,
+  context: {
+    assignees: string[];
+    labels: string[];
+    progress: number;
+    artifactCount: number;
+    verificationPassed: boolean;
+  },
+): string[] {
+  const violations: string[] = [];
+  if (rules.requireAssignee && context.assignees.length === 0) violations.push("assignee_required");
+  for (const label of rules.requiredLabels ?? []) {
+    if (!context.labels.includes(label)) violations.push(`label_required:${label}`);
+  }
+  if (rules.minProgress !== undefined && context.progress < rules.minProgress) {
+    violations.push(`progress_below:${rules.minProgress}`);
+  }
+  if (rules.requireArtifact && context.artifactCount === 0) violations.push("artifact_required");
+  if (rules.requireVerification && !context.verificationPassed) violations.push("verification_required");
+  return violations;
+}
+const BlueprintAgent = z.object({
+  key: z.string().min(1).max(60),
+  name: z.string().min(1).max(100),
+  handle: z.string().min(2).max(40),
+  title: z.string().max(160).optional(),
+  brief: z.string().max(10_000).optional(),
+  capabilities: z.array(z.string().max(80)).max(50).optional(),
+  scopes: z.array(z.string().max(80)).max(50).optional(),
+  budgetUsdMonth: z.number().nonnegative().nullable().optional(),
+});
+
+export const TeamBlueprintSchema = z.object({
+  agents: z.array(BlueprintAgent).max(100).default([]),
+  relationships: z.array(z.object({ childKey: z.string(), parentKey: z.string().nullable() })).max(200).default([]),
+  skills: z.array(z.object({ agentKey: z.string(), name: z.string(), content: z.string().max(100_000).optional() })).max(300).default([]),
+  channels: z.array(z.object({ name: z.string().min(1).max(100), topic: z.string().max(500).optional(), memberKeys: z.array(z.string()).optional() })).max(100).default([]),
+  workflows: z.array(z.object({ name: z.string().min(1).max(140), description: z.string().max(3_000).optional(), triggerType: z.enum(["manual", "webhook"]).optional(), definition: z.unknown() })).max(100).default([]),
+});
+
+export type TeamBlueprintInput = z.infer<typeof TeamBlueprintSchema>;
+
+export type NormalizedPrSnapshot = {
+  title: string;
+  url: string;
+  state: string;
+  headRef: string;
+  baseRef: string;
+  diff: Array<Record<string, unknown>>;
+  checks: Array<Record<string, unknown>>;
+  reviews: Array<Record<string, unknown>>;
+  protection: Record<string, unknown>;
+};
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function records(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value.map(record) : [];
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+// Accepts the provider API shapes or a connector that has already grouped the
+// individual API responses into {pull|mergeRequest, files, checks, reviews,
+// protection}. Keeping normalization pure makes both providers deterministic
+// and lets connector fixtures exercise the full PR-room path without network.
+export function normalizePrSnapshot(provider: "github" | "gitlab", raw: unknown): NormalizedPrSnapshot {
+  const root = record(raw);
+  if (provider === "github") {
+    const pr = record(root.pull ?? root.pr ?? root);
+    return {
+      title: text(pr.title),
+      url: text(pr.html_url ?? pr.url),
+      state: text(pr.merged_at ? "merged" : pr.state) || "open",
+      headRef: text(record(pr.head).ref ?? pr.head_ref),
+      baseRef: text(record(pr.base).ref ?? pr.base_ref),
+      diff: records(root.files ?? pr.files),
+      checks: records(root.checks ?? root.check_runs),
+      reviews: records(root.reviews),
+      protection: record(root.protection ?? root.branch_protection),
+    };
+  }
+  const mr = record(root.mergeRequest ?? root.merge_request ?? root);
+  const changes = record(root.changes ?? mr.changes);
+  return {
+    title: text(mr.title),
+    url: text(mr.web_url ?? mr.url),
+    state: text(mr.state) || "opened",
+    headRef: text(mr.source_branch),
+    baseRef: text(mr.target_branch),
+    diff: records(changes.changes ?? root.files),
+    checks: records(root.pipelines ?? root.checks),
+    reviews: records(root.approvals ?? root.reviews),
+    protection: record(root.protection ?? root.protected_branch),
+  };
+}
+
+export function safeSlug(value: string): string {
+  return value.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 64) || "app";
+}
+
+export function appContentSecurityPolicy(): string {
+  return [
+    "default-src 'none'",
+    "style-src 'unsafe-inline'",
+    "script-src 'unsafe-inline'",
+    "img-src data: https:",
+    "font-src data:",
+    "connect-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+    "frame-ancestors 'self'",
+  ].join("; ");
+}

--- a/api/src/lib/secret-box.ts
+++ b/api/src/lib/secret-box.ts
@@ -1,0 +1,40 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+import { config } from "./config.js";
+
+// Small envelope used for connector and webhook credentials.  The deployment's
+// SESSION_SECRET is already required and private; domain-separating its hash
+// gives this store a dedicated 256-bit AES key without adding another mandatory
+// secret to existing installs.  `v1.iv.tag.ciphertext`, all base64url.
+function key(): Buffer {
+  return createHash("sha256")
+    .update("circlechat:credential-store:v1\0")
+    .update(config.sessionSecret)
+    .digest();
+}
+
+export function encryptSecret(value: unknown): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key(), iv);
+  const plaintext = Buffer.from(JSON.stringify(value), "utf8");
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return ["v1", iv.toString("base64url"), tag.toString("base64url"), encrypted.toString("base64url")].join(".");
+}
+
+export function decryptSecret<T = Record<string, unknown>>(envelope: string): T {
+  const [version, ivText, tagText, encryptedText] = envelope.split(".");
+  if (version !== "v1" || !ivText || !tagText || encryptedText === undefined) {
+    throw new Error("invalid_secret_envelope");
+  }
+  try {
+    const decipher = createDecipheriv("aes-256-gcm", key(), Buffer.from(ivText, "base64url"));
+    decipher.setAuthTag(Buffer.from(tagText, "base64url"));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(encryptedText, "base64url")),
+      decipher.final(),
+    ]);
+    return JSON.parse(plaintext.toString("utf8")) as T;
+  } catch {
+    throw new Error("secret_decryption_failed");
+  }
+}

--- a/api/src/lib/signed-webhook.ts
+++ b/api/src/lib/signed-webhook.ts
@@ -1,0 +1,36 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export const WEBHOOK_MAX_SKEW_SECONDS = 5 * 60;
+
+export function signWebhook(secret: string, timestamp: string, rawBody: string | Buffer): string {
+  return `sha256=${createHmac("sha256", secret)
+    .update(timestamp)
+    .update(".")
+    .update(rawBody)
+    .digest("hex")}`;
+}
+
+export function verifyWebhookSignature(opts: {
+  secret: string;
+  timestamp: string | undefined;
+  signature: string | undefined;
+  rawBody: string | Buffer;
+  now?: Date;
+  maxSkewSeconds?: number;
+}): { ok: true } | { ok: false; error: "missing_signature" | "stale_timestamp" | "bad_signature" } {
+  if (!opts.timestamp || !opts.signature) return { ok: false, error: "missing_signature" };
+  const timestampSeconds = Number(opts.timestamp);
+  const nowSeconds = Math.floor((opts.now ?? new Date()).getTime() / 1000);
+  if (
+    !Number.isFinite(timestampSeconds) ||
+    Math.abs(nowSeconds - timestampSeconds) > (opts.maxSkewSeconds ?? WEBHOOK_MAX_SKEW_SECONDS)
+  ) {
+    return { ok: false, error: "stale_timestamp" };
+  }
+  const expected = Buffer.from(signWebhook(opts.secret, opts.timestamp, opts.rawBody), "utf8");
+  const actual = Buffer.from(opts.signature.trim(), "utf8");
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    return { ok: false, error: "bad_signature" };
+  }
+  return { ok: true };
+}

--- a/api/src/lib/tasks-core.ts
+++ b/api/src/lib/tasks-core.ts
@@ -9,6 +9,8 @@ import {
   taskActivity,
   members,
   goals,
+  boardStages,
+  taskVerifications,
 } from "../db/schema.js";
 import { id } from "./ids.js";
 import { publishToWorkspace } from "./events.js";
@@ -18,6 +20,7 @@ import { liveArtifactRows, isSubstantiveArtifact, purgeArtifactsForTasks } from 
 import { forgetTaskKnowledge } from "./knowledge.js";
 import { verifyTaskForDone, deterministicGateForDone } from "./task-verifier.js";
 import { recordProgress } from "./ledger-core.js";
+import { evaluateStageRules, StageRulesSchema } from "./p1-platform.js";
 
 export const STATUSES = ["backlog", "in_progress", "blocked", "review", "done"] as const;
 export type Status = (typeof STATUSES)[number];
@@ -158,6 +161,86 @@ export async function maybeFireAgentTrigger(
     .limit(1);
   if (!m || m.kind !== "agent") return;
   await enqueueAgentEvent(m.refId, { trigger, conversationId, taskId });
+}
+
+async function stageContext(task: TaskRow): Promise<{
+  assignees: string[];
+  labels: string[];
+  progress: number;
+  artifactCount: number;
+  verificationPassed: boolean;
+}> {
+  const [assigned, labels, artifacts, latestVerification] = await Promise.all([
+    db.select({ memberId: taskAssignees.memberId }).from(taskAssignees).where(eq(taskAssignees.taskId, task.id)),
+    db.select({ label: taskLabels.label }).from(taskLabels).where(eq(taskLabels.taskId, task.id)),
+    liveArtifactRows(task.id),
+    db.select({ verdict: taskVerifications.verdict }).from(taskVerifications)
+      .where(eq(taskVerifications.taskId, task.id)).orderBy(desc(taskVerifications.createdAt)).limit(1),
+  ]);
+  return {
+    assignees: assigned.map((row) => row.memberId),
+    labels: labels.map((row) => row.label),
+    progress: task.progress,
+    artifactCount: artifacts.length,
+    verificationPassed: latestVerification[0]?.verdict === "pass",
+  };
+}
+
+async function assertStageTransition(task: TaskRow, target: Status, actorMemberId: string): Promise<{
+  violations: string[];
+  escalationMemberId: string | null;
+}> {
+  const rows = await db.select().from(boardStages).where(and(
+    eq(boardStages.workspaceId, task.workspaceId),
+    inArray(boardStages.stage, [task.status, target]),
+  ));
+  if (!rows.length) return { violations: [], escalationMemberId: null };
+  const source = rows.find((row) => row.stage === task.status);
+  const destination = rows.find((row) => row.stage === target);
+  const context = await stageContext(task);
+  const [actor] = await db.select({ kind: members.kind }).from(members).where(eq(members.id, actorMemberId)).limit(1);
+  const violations = [
+    ...evaluateStageRules(StageRulesSchema.parse(source?.exitRulesJson ?? {}), context).map((value) => `exit:${value}`),
+    ...evaluateStageRules(StageRulesSchema.parse(destination?.entryRulesJson ?? {}), context).map((value) => `entry:${value}`),
+  ];
+  const verification = destination?.verification ?? "none";
+  if (verification === "artifact" && context.artifactCount === 0) violations.push("entry:artifact_required");
+  if (verification === "judge" && !context.verificationPassed) violations.push("entry:verification_required");
+  if (verification === "human" && actor?.kind !== "user") violations.push("entry:human_review_required");
+  return { violations: Array.from(new Set(violations)), escalationMemberId: destination?.escalationMemberId ?? source?.escalationMemberId ?? null };
+}
+
+async function executeStageEntry(
+  taskId: string,
+  stage: Status,
+  actorMemberId: string,
+  workspaceId: string,
+  conversationId: string | null,
+): Promise<void> {
+  const [cfg] = await db.select().from(boardStages).where(and(eq(boardStages.workspaceId, workspaceId), eq(boardStages.stage, stage))).limit(1);
+  if (!cfg?.agentId) return;
+  const [agentMember] = await db.select({ id: members.id }).from(members).where(and(eq(members.workspaceId, workspaceId), eq(members.kind, "agent"), eq(members.refId, cfg.agentId))).limit(1);
+  if (!agentMember) return;
+  await db.insert(taskAssignees).values({ taskId, memberId: agentMember.id, assignedBy: actorMemberId }).onConflictDoNothing();
+  await logActivity(taskId, actorMemberId, "stage_agent_assigned", {
+    stage,
+    agentId: cfg.agentId,
+    skill: cfg.skill,
+    instructions: cfg.instructions,
+  });
+  await enqueueAgentEvent(cfg.agentId, {
+    trigger: "task_assigned",
+    taskId,
+    conversationId,
+    stageExecution: {
+      stage: cfg.stage,
+      title: cfg.title,
+      instructions: cfg.instructions,
+      skill: cfg.skill,
+      verification: cfg.verification,
+      nextStage: cfg.nextStage,
+    },
+  });
 }
 
 // ───── list / get ─────
@@ -335,6 +418,24 @@ export async function updateTask(taskId: string, input: UpdateTaskInput, actorMe
   const t = await loadTask(taskId);
   const g = guard(t, workspaceId);
   if (!g.ok) return { error: g.error! };
+  if (input.status !== undefined && input.status !== t!.status) {
+    const stageGate = await assertStageTransition(t!, input.status, actorMemberId);
+    if (stageGate.violations.length) {
+      if (stageGate.escalationMemberId) {
+        void notify({
+          workspaceId,
+          memberId: stageGate.escalationMemberId,
+          kind: "system",
+          actorMemberId,
+          title: `Stage rule blocked “${t!.title}”`,
+          body: stageGate.violations.join(", "),
+          link: `/board?task=${taskId}`,
+          taskId,
+        }).catch(() => {});
+      }
+      return { error: "stage_rules_failed", violations: stageGate.violations };
+    }
+  }
   // Done-requires-evidence: an agent can't move a task to `done` without
   // either an attached deliverable on a task comment OR a human reviewer
   // having weighed in after the agent's most recent comment. Humans can
@@ -358,6 +459,7 @@ export async function updateTask(taskId: string, input: UpdateTaskInput, actorMe
   await db.update(tasks).set(patch).where(eq(tasks.id, taskId));
   if (input.status !== undefined && input.status !== t!.status) {
     await logActivity(taskId, actorMemberId, "status_changed", { from: t!.status, to: input.status });
+    await executeStageEntry(taskId, input.status, actorMemberId, workspaceId, t!.conversationId);
   }
   if (input.title !== undefined && input.title !== t!.title) {
     await logActivity(taskId, actorMemberId, "renamed", { from: t!.title, to: input.title });

--- a/api/src/lib/workflow-definition.ts
+++ b/api/src/lib/workflow-definition.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+import type { WorkflowDefinition, WorkflowStateDefinition } from "../db/schema.js";
+
+const StateId = z.string().min(1).max(80).regex(/^[a-zA-Z][a-zA-Z0-9_-]*$/);
+const State = z.object({
+  id: StateId,
+  type: z.enum(["agent", "connector", "wait", "approval", "poll", "terminal"]),
+  name: z.string().max(120).optional(),
+  next: StateId.optional(),
+  onSuccess: StateId.optional(),
+  onFailure: StateId.optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
+});
+const Definition = z.object({ start: StateId, states: z.array(State).min(1).max(100) });
+
+export function parseWorkflowDefinition(input: unknown): WorkflowDefinition {
+  const parsed = Definition.parse(input) as WorkflowDefinition;
+  const ids = new Set<string>();
+  for (const state of parsed.states) {
+    if (ids.has(state.id)) throw new Error(`duplicate_state:${state.id}`);
+    ids.add(state.id);
+  }
+  if (!ids.has(parsed.start)) throw new Error(`start_state_missing:${parsed.start}`);
+  for (const state of parsed.states) {
+    for (const target of [state.next, state.onSuccess, state.onFailure]) {
+      if (target && !ids.has(target)) throw new Error(`transition_target_missing:${state.id}:${target}`);
+    }
+    validateStateConfig(state);
+  }
+  return parsed;
+}
+
+function validateStateConfig(state: WorkflowStateDefinition): void {
+  const cfg = state.config ?? {};
+  if (state.type === "agent" && typeof cfg.agentId !== "string") {
+    throw new Error(`agent_state_requires_agent_id:${state.id}`);
+  }
+  if ((state.type === "connector" || state.type === "poll") && typeof cfg.connectorId !== "string") {
+    throw new Error(`connector_state_requires_connector_id:${state.id}`);
+  }
+  if (state.type === "wait") {
+    const seconds = Number(cfg.durationSeconds);
+    if (!Number.isFinite(seconds) || seconds < 1 || seconds > 30 * 24 * 60 * 60) {
+      throw new Error(`wait_duration_invalid:${state.id}`);
+    }
+  }
+  if (state.type === "poll") {
+    const seconds = Number(cfg.intervalSeconds ?? 30);
+    if (!Number.isFinite(seconds) || seconds < 1 || seconds > 24 * 60 * 60) {
+      throw new Error(`poll_interval_invalid:${state.id}`);
+    }
+  }
+  if (state.type === "terminal") {
+    const status = String(cfg.status ?? "completed");
+    if (status !== "completed" && status !== "failed") {
+      throw new Error(`terminal_status_invalid:${state.id}`);
+    }
+  }
+}
+
+export function stateById(definition: WorkflowDefinition, stateId: string): WorkflowStateDefinition {
+  const state = definition.states.find((candidate) => candidate.id === stateId);
+  if (!state) throw new Error(`workflow_state_missing:${stateId}`);
+  return state;
+}
+
+export function transitionFor(
+  state: WorkflowStateDefinition,
+  outcome: "success" | "failure",
+): string | null {
+  return (outcome === "success" ? state.onSuccess : state.onFailure) ?? state.next ?? null;
+}
+
+// JSON-safe template resolver used by connector states. Exact `$input.foo`
+// expressions retain the source value's type; embedded expressions stringify.
+// `$steps.<state>...` addresses outputs accumulated by earlier states.
+export function resolveWorkflowTemplate(
+  value: unknown,
+  context: { input: Record<string, unknown>; steps: Record<string, unknown> },
+): unknown {
+  if (Array.isArray(value)) return value.map((item) => resolveWorkflowTemplate(item, context));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, child]) => [
+        key,
+        resolveWorkflowTemplate(child, context),
+      ]),
+    );
+  }
+  if (typeof value !== "string") return value;
+  const exact = /^\$(input|steps)(?:\.([a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*))?$/.exec(value);
+  if (exact) return readPath(context[exact[1] as "input" | "steps"], exact[2] ?? "");
+  return value.replace(/\$(input|steps)\.([a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*)/g, (_m, root, path) => {
+    const found = readPath(context[root as "input" | "steps"], path);
+    return found == null ? "" : typeof found === "string" ? found : JSON.stringify(found);
+  });
+}
+
+export function readPath(value: unknown, path: string): unknown {
+  if (!path) return value;
+  return path.split(".").reduce<unknown>((current, part) => {
+    if (!current || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[part];
+  }, value);
+}

--- a/api/src/lib/workflow-engine.ts
+++ b/api/src/lib/workflow-engine.ts
@@ -1,0 +1,425 @@
+import { Worker } from "bullmq";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db } from "../db/index.js";
+import {
+  agentConnectorGrants,
+  agents,
+  connectors,
+  workflowRuns,
+  workflows,
+  workflowSteps,
+  type WorkflowDefinition,
+  type WorkflowStateDefinition,
+} from "../db/schema.js";
+import { enqueueAgentEvent } from "../agents/enqueue.js";
+import { id } from "./ids.js";
+import { redis } from "./redis.js";
+import { publishToWorkspace } from "./events.js";
+import { invokeConnector } from "./connector-runtime.js";
+import { parseWorkflowDefinition, readPath, stateById, transitionFor } from "./workflow-definition.js";
+import { enqueueWorkflowRun, WORKFLOW_QUEUE, type WorkflowJobPayload } from "./workflow-queue.js";
+
+type WorkflowRun = typeof workflowRuns.$inferSelect;
+type WorkflowStep = typeof workflowSteps.$inferSelect;
+
+export async function startWorkflowRun(input: {
+  workflowId: string;
+  workspaceId: string;
+  payload: Record<string, unknown>;
+  createdBy: string;
+}): Promise<string> {
+  const [workflow] = await db
+    .select()
+    .from(workflows)
+    .where(and(eq(workflows.id, input.workflowId), eq(workflows.workspaceId, input.workspaceId)))
+    .limit(1);
+  if (!workflow) throw new Error("workflow_not_found");
+  if (workflow.status !== "active") throw new Error("workflow_paused");
+  const definition = parseWorkflowDefinition(workflow.definitionJson);
+  const runId = id("wfrun");
+  await db.insert(workflowRuns).values({
+    id: runId,
+    workflowId: workflow.id,
+    workspaceId: workflow.workspaceId,
+    status: "queued",
+    currentStateId: definition.start,
+    inputJson: input.payload,
+    outputJson: {},
+    createdBy: input.createdBy,
+    ownerMemberId: input.createdBy,
+  });
+  await enqueueWorkflowRun(runId, "start");
+  await publishToWorkspace(input.workspaceId, {
+    type: "workflow.run.updated",
+    workspaceId: input.workspaceId,
+    workflowId: workflow.id,
+    runId,
+    status: "queued",
+  });
+  return runId;
+}
+
+async function loadRun(runId: string): Promise<{
+  run: WorkflowRun;
+  workflow: typeof workflows.$inferSelect;
+  definition: WorkflowDefinition;
+}> {
+  const [row] = await db
+    .select({ run: workflowRuns, workflow: workflows })
+    .from(workflowRuns)
+    .innerJoin(workflows, eq(workflows.id, workflowRuns.workflowId))
+    .where(eq(workflowRuns.id, runId))
+    .limit(1);
+  if (!row) throw new Error("workflow_run_not_found");
+  return { ...row, definition: parseWorkflowDefinition(row.workflow.definitionJson) };
+}
+
+async function nextAttempt(runId: string, stateId: string): Promise<number> {
+  const [row] = await db
+    .select({ value: sql<number>`coalesce(max(${workflowSteps.attempt}), 0)::int` })
+    .from(workflowSteps)
+    .where(and(eq(workflowSteps.runId, runId), eq(workflowSteps.stateId, stateId)));
+  return (row?.value ?? 0) + 1;
+}
+
+async function createStep(run: WorkflowRun, state: WorkflowStateDefinition): Promise<WorkflowStep> {
+  const step: typeof workflowSteps.$inferInsert = {
+    id: id("wfstep"),
+    runId: run.id,
+    stateId: state.id,
+    kind: state.type,
+    attempt: await nextAttempt(run.id, state.id),
+    status: "running",
+    inputJson: run.inputJson,
+    outputJson: {},
+  };
+  await db.insert(workflowSteps).values(step);
+  return step as WorkflowStep;
+}
+
+async function setStepOutput(
+  stepId: string,
+  status: "completed" | "failed" | "waiting",
+  output: Record<string, unknown> = {},
+  errorText: string | null = null,
+): Promise<void> {
+  await db
+    .update(workflowSteps)
+    .set({
+      status,
+      outputJson: output,
+      errorText,
+      ...(status === "waiting" ? {} : { finishedAt: new Date() }),
+    })
+    .where(eq(workflowSteps.id, stepId));
+}
+
+function mergedOutputs(run: WorkflowRun, stateId: string, output: unknown): Record<string, unknown> {
+  return { ...(run.outputJson ?? {}), [stateId]: output };
+}
+
+async function advance(
+  run: WorkflowRun,
+  state: WorkflowStateDefinition,
+  outcome: "success" | "failure",
+  output: unknown,
+  errorText?: string,
+): Promise<void> {
+  const next = transitionFor(state, outcome);
+  const outputs = mergedOutputs(run, state.id, output);
+  if (!next) {
+    const status = outcome === "success" ? "completed" : "failed";
+    await db
+      .update(workflowRuns)
+      .set({
+        status,
+        outputJson: outputs,
+        errorText: errorText ?? null,
+        waitKind: null,
+        waitKey: null,
+        waitUntil: null,
+        updatedAt: new Date(),
+        finishedAt: new Date(),
+      })
+      .where(eq(workflowRuns.id, run.id));
+    await publishRun(run, status);
+    return;
+  }
+  await db
+    .update(workflowRuns)
+    .set({
+      status: "queued",
+      currentStateId: next,
+      outputJson: outputs,
+      errorText: null,
+      waitKind: null,
+      waitKey: null,
+      waitUntil: null,
+      updatedAt: new Date(),
+    })
+    .where(eq(workflowRuns.id, run.id));
+  await enqueueWorkflowRun(run.id, "transition");
+  await publishRun(run, "queued");
+}
+
+async function publishRun(run: WorkflowRun, status: string): Promise<void> {
+  await publishToWorkspace(run.workspaceId, {
+    type: "workflow.run.updated",
+    workspaceId: run.workspaceId,
+    workflowId: run.workflowId,
+    runId: run.id,
+    status,
+  });
+}
+
+async function executeConnectorState(
+  run: WorkflowRun,
+  state: WorkflowStateDefinition,
+): Promise<unknown> {
+  const cfg = state.config ?? {};
+  const connectorId = String(cfg.connectorId);
+  const [connector] = await db
+    .select()
+    .from(connectors)
+    .where(and(eq(connectors.id, connectorId), eq(connectors.workspaceId, run.workspaceId)))
+    .limit(1);
+  if (!connector) throw new Error("connector_not_found");
+  if (typeof cfg.agentId === "string") {
+    const [grant] = await db
+      .select()
+      .from(agentConnectorGrants)
+      .where(
+        and(
+          eq(agentConnectorGrants.connectorId, connector.id),
+          eq(agentConnectorGrants.agentId, cfg.agentId),
+        ),
+      )
+      .limit(1);
+    if (!grant) throw new Error("connector_not_granted_to_agent");
+  }
+  return invokeConnector(connector, {
+    operation: typeof cfg.operation === "string" ? cfg.operation : undefined,
+    method: typeof cfg.method === "string" ? cfg.method : undefined,
+    path: typeof cfg.path === "string" ? cfg.path : undefined,
+    headers: (cfg.headers ?? {}) as Record<string, string>,
+    query: (cfg.query ?? {}) as Record<string, string | number | boolean>,
+    body: cfg.body,
+    input: run.inputJson,
+    steps: run.outputJson,
+  });
+}
+
+async function resumeTimer(run: WorkflowRun, definition: WorkflowDefinition, stepId: string): Promise<void> {
+  if (run.status !== "waiting" || run.waitKind !== "timer" || run.waitKey !== stepId) return;
+  const [step] = await db.select().from(workflowSteps).where(eq(workflowSteps.id, stepId)).limit(1);
+  if (!step || step.runId !== run.id || step.status !== "waiting") return;
+  const state = stateById(definition, step.stateId);
+  const output = { waitedUntil: new Date().toISOString() };
+  await setStepOutput(step.id, "completed", output);
+  await advance(run, state, "success", output);
+}
+
+export async function processWorkflowJob(payload: WorkflowJobPayload): Promise<void> {
+  const { run, definition } = await loadRun(payload.runId);
+  if (["completed", "failed", "cancelled"].includes(run.status)) return;
+  if (run.cancelRequestedAt || (run.timeoutAt && run.timeoutAt <= new Date())) {
+    await db.update(workflowRuns).set({
+      status: "cancelled", errorText: run.cancelRequestedAt ? "cancelled_by_user" : "run_timeout",
+      finishedAt: new Date(), updatedAt: new Date(),
+    }).where(eq(workflowRuns.id, run.id));
+    await publishRun(run, "cancelled");
+    return;
+  }
+  if (payload.reason === "timer" && payload.resumeStepId) {
+    await resumeTimer(run, definition, payload.resumeStepId);
+    return;
+  }
+  // Only poll wakes are allowed to re-enter an explicitly waiting run. Agent
+  // and human resumes advance the row to queued before enqueuing.
+  if (run.status === "waiting" && !(payload.reason === "poll" && run.waitKind === "poll")) return;
+  const stateId = run.currentStateId ?? definition.start;
+  const state = stateById(definition, stateId);
+  await db
+    .update(workflowRuns)
+    .set({ status: "running", waitKind: null, waitKey: null, waitUntil: null, updatedAt: new Date() })
+    .where(eq(workflowRuns.id, run.id));
+  const activeRun = { ...run, status: "running", currentStateId: stateId };
+  const step = await createStep(activeRun, state);
+
+  try {
+    if (state.type === "agent") {
+      const agentId = String(state.config?.agentId);
+      const [agent] = await db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.id, agentId), eq(agents.workspaceId, run.workspaceId)))
+        .limit(1);
+      if (!agent) throw new Error("workflow_agent_not_found");
+      const agentRunId = await enqueueAgentEvent(agentId, {
+        trigger: "workflow",
+        workflowRunId: run.id,
+        workflowStepId: step.id,
+      });
+      await db
+        .update(workflowSteps)
+        .set({ status: "waiting", agentRunId })
+        .where(eq(workflowSteps.id, step.id));
+      await db
+        .update(workflowRuns)
+        .set({ status: "waiting", waitKind: "agent", waitKey: step.id, updatedAt: new Date() })
+        .where(eq(workflowRuns.id, run.id));
+      await publishRun(run, "waiting");
+      return;
+    }
+
+    if (state.type === "connector") {
+      const result = await executeConnectorState(activeRun, state);
+      await setStepOutput(step.id, "completed", result as Record<string, unknown>);
+      await advance(activeRun, state, "success", result);
+      return;
+    }
+
+    if (state.type === "wait") {
+      const durationSeconds = Number(state.config?.durationSeconds);
+      const waitUntil = new Date(Date.now() + durationSeconds * 1000);
+      await setStepOutput(step.id, "waiting", { waitUntil: waitUntil.toISOString() });
+      await db
+        .update(workflowRuns)
+        .set({ status: "waiting", waitKind: "timer", waitKey: step.id, waitUntil, updatedAt: new Date() })
+        .where(eq(workflowRuns.id, run.id));
+      await enqueueWorkflowRun(run.id, "timer", { delayMs: durationSeconds * 1000, resumeStepId: step.id });
+      await publishRun(run, "waiting");
+      return;
+    }
+
+    if (state.type === "approval") {
+      await setStepOutput(step.id, "waiting", { prompt: String(state.config?.prompt ?? state.name ?? state.id) });
+      await db
+        .update(workflowRuns)
+        .set({ status: "waiting", waitKind: "human", waitKey: step.id, updatedAt: new Date() })
+        .where(eq(workflowRuns.id, run.id));
+      await publishRun(run, "waiting");
+      return;
+    }
+
+    if (state.type === "poll") {
+      const result = await executeConnectorState(activeRun, state);
+      const value = readPath(result, String(state.config?.path ?? "data"));
+      const matches = state.config && "equals" in state.config
+        ? JSON.stringify(value) === JSON.stringify(state.config.equals)
+        : Boolean(value);
+      if (matches) {
+        await setStepOutput(step.id, "completed", result as Record<string, unknown>);
+        await advance(activeRun, state, "success", result);
+        return;
+      }
+      const intervalSeconds = Number(state.config?.intervalSeconds ?? 30);
+      const timeoutSeconds = Number(state.config?.timeoutSeconds ?? 3600);
+      if (step.attempt * intervalSeconds >= timeoutSeconds) {
+        const error = "poll_timeout";
+        await setStepOutput(step.id, "failed", result as Record<string, unknown>, error);
+        await advance(activeRun, state, "failure", result, error);
+        return;
+      }
+      const waitUntil = new Date(Date.now() + intervalSeconds * 1000);
+      await setStepOutput(step.id, "waiting", result as Record<string, unknown>);
+      await db
+        .update(workflowRuns)
+        .set({ status: "waiting", waitKind: "poll", waitKey: step.id, waitUntil, updatedAt: new Date() })
+        .where(eq(workflowRuns.id, run.id));
+      await enqueueWorkflowRun(run.id, "poll", { delayMs: intervalSeconds * 1000 });
+      await publishRun(run, "waiting");
+      return;
+    }
+
+    const terminalStatus = String(state.config?.status ?? "completed");
+    const output = (state.config?.output ?? activeRun.outputJson) as Record<string, unknown>;
+    await setStepOutput(step.id, terminalStatus === "failed" ? "failed" : "completed", output);
+    await db
+      .update(workflowRuns)
+      .set({
+        status: terminalStatus === "failed" ? "failed" : "completed",
+        outputJson: mergedOutputs(activeRun, state.id, output),
+        errorText: terminalStatus === "failed" ? String(state.config?.error ?? "workflow_failed") : null,
+        updatedAt: new Date(),
+        finishedAt: new Date(),
+      })
+      .where(eq(workflowRuns.id, run.id));
+    await publishRun(run, terminalStatus === "failed" ? "failed" : "completed");
+  } catch (error) {
+    const message = (error as Error).message.slice(0, 500);
+    await setStepOutput(step.id, "failed", {}, message);
+    await advance(activeRun, state, "failure", {}, message);
+  }
+}
+
+export async function resumeWorkflowFromAgent(input: {
+  workflowRunId: string;
+  workflowStepId: string;
+  success: boolean;
+  output: Record<string, unknown>;
+  errorText?: string;
+}): Promise<void> {
+  const { run, definition } = await loadRun(input.workflowRunId);
+  if (run.status !== "waiting" || run.waitKind !== "agent" || run.waitKey !== input.workflowStepId) return;
+  const [step] = await db.select().from(workflowSteps).where(eq(workflowSteps.id, input.workflowStepId)).limit(1);
+  if (!step || step.runId !== run.id || step.status !== "waiting") return;
+  const state = stateById(definition, step.stateId);
+  await setStepOutput(step.id, input.success ? "completed" : "failed", input.output, input.errorText ?? null);
+  await advance(run, state, input.success ? "success" : "failure", input.output, input.errorText);
+}
+
+export async function resumeWorkflowFromHuman(input: {
+  runId: string;
+  workspaceId: string;
+  approved: boolean;
+  output: Record<string, unknown>;
+}): Promise<void> {
+  const { run, definition } = await loadRun(input.runId);
+  if (run.workspaceId !== input.workspaceId) throw new Error("workflow_run_not_found");
+  if (run.status !== "waiting" || run.waitKind !== "human" || !run.waitKey) {
+    throw new Error("workflow_not_waiting_for_human");
+  }
+  const [step] = await db.select().from(workflowSteps).where(eq(workflowSteps.id, run.waitKey)).limit(1);
+  if (!step || step.runId !== run.id || step.status !== "waiting") throw new Error("workflow_wait_step_missing");
+  const state = stateById(definition, step.stateId);
+  await setStepOutput(step.id, input.approved ? "completed" : "failed", input.output, input.approved ? null : "denied");
+  await advance(run, state, input.approved ? "success" : "failure", input.output, input.approved ? undefined : "denied");
+}
+
+export async function workflowAgentContext(runId: string): Promise<{
+  runId: string;
+  workflowId: string;
+  name: string;
+  stateId: string | null;
+  input: Record<string, unknown>;
+  priorStepOutputs: Record<string, unknown>;
+  steer: Array<Record<string, unknown>>;
+  followUps: Array<Record<string, unknown>>;
+} | null> {
+  const [row] = await db
+    .select({ run: workflowRuns, name: workflows.name })
+    .from(workflowRuns)
+    .innerJoin(workflows, eq(workflows.id, workflowRuns.workflowId))
+    .where(eq(workflowRuns.id, runId))
+    .limit(1);
+  if (!row) return null;
+  return {
+    runId: row.run.id,
+    workflowId: row.run.workflowId,
+    name: row.name,
+    stateId: row.run.currentStateId,
+    input: row.run.inputJson,
+    priorStepOutputs: row.run.outputJson,
+    steer: row.run.steerJson,
+    followUps: row.run.followupJson,
+  };
+}
+
+export function startWorkflowWorker(): Worker<WorkflowJobPayload> {
+  return new Worker<WorkflowJobPayload>(WORKFLOW_QUEUE, (job) => processWorkflowJob(job.data), {
+    connection: redis,
+    concurrency: 10,
+    lockDuration: 120_000,
+  });
+}

--- a/api/src/lib/workflow-queue.ts
+++ b/api/src/lib/workflow-queue.ts
@@ -1,0 +1,33 @@
+import { Queue } from "bullmq";
+import { redis } from "./redis.js";
+import { id } from "./ids.js";
+
+export const WORKFLOW_QUEUE = "workflow-runs";
+
+export interface WorkflowJobPayload {
+  runId: string;
+  reason: "start" | "transition" | "timer" | "poll" | "agent" | "human" | "retry";
+  resumeStepId?: string;
+}
+
+export const workflowQueue = new Queue<WorkflowJobPayload>(WORKFLOW_QUEUE, {
+  connection: redis,
+  defaultJobOptions: {
+    attempts: 5,
+    backoff: { type: "exponential", delay: 1_000 },
+    removeOnComplete: 1_000,
+    removeOnFail: 1_000,
+  },
+});
+
+export async function enqueueWorkflowRun(
+  runId: string,
+  reason: WorkflowJobPayload["reason"],
+  opts: { delayMs?: number; resumeStepId?: string } = {},
+): Promise<void> {
+  await workflowQueue.add(
+    `workflow:${runId}`,
+    { runId, reason, resumeStepId: opts.resumeStepId },
+    { jobId: id("wfjob"), delay: Math.max(0, opts.delayMs ?? 0) },
+  );
+}

--- a/api/src/routes/agent-api.ts
+++ b/api/src/routes/agent-api.ts
@@ -53,6 +53,7 @@ import {
   resolveHandlesToMemberIds,
   fireMentionTriggers,
 } from "../agents/mention-triggers.js";
+import { recordModelUsage, refreshAgentRunUsage } from "../lib/model-usage-store.js";
 
 // Auth: Bearer <agent.botToken>  → resolves `req.agentCtx` with agentId + memberId.
 // Anything hitting these endpoints is a trusted agent process and can see messages
@@ -194,6 +195,41 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
   // GET /agent-api/me — who am I?
   app.get("/agent-api/me", async (req) => {
     return req.agentCtx;
+  });
+
+  // Runtimes that cannot return usage inline (for example a long-lived socket
+  // with a separate gateway callback) may report one or more actual model calls
+  // against their own run. The agent token and run ownership check prevent one
+  // runtime from writing another agent's bill.
+  app.post("/agent-api/runs/:runId/usage", async (req, reply) => {
+    const runId = (req.params as { runId: string }).runId;
+    const body = z
+      .object({
+        provider: z.string().min(1).max(60).optional(),
+        model: z.string().min(1).max(120).optional(),
+        inputTokens: z.number().int().min(0),
+        outputTokens: z.number().int().min(0),
+        cachedInputTokens: z.number().int().min(0).optional(),
+        costUsd: z.number().min(0).max(1_000_000).optional(),
+      })
+      .parse(req.body);
+    const [run] = await db
+      .select({ id: agentRuns.id, agentId: agentRuns.agentId, contextJson: agentRuns.contextJson })
+      .from(agentRuns)
+      .where(and(eq(agentRuns.id, runId), eq(agentRuns.agentId, req.agentCtx!.agentId)))
+      .limit(1);
+    if (!run) return reply.code(404).send({ error: "agent_run_not_found" });
+    const routeTier = ((run.contextJson.modelRoute as { tier?: unknown } | undefined)?.tier);
+    const usage = await recordModelUsage({
+      workspaceId: req.agentCtx!.workspaceId,
+      agentId: req.agentCtx!.agentId,
+      runId,
+      routeTier: typeof routeTier === "string" ? routeTier : null,
+      usage: body,
+      source: "reported",
+    });
+    await refreshAgentRunUsage(runId);
+    return reply.code(201).send({ ok: true, ...usage });
   });
 
   // POST /agent-api/act — the UNIFIED, FULLY-GATED action endpoint. This is the

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { db } from "../db/index.js";
 import {
   users,
@@ -11,6 +11,7 @@ import {
   workspaces,
   workspaceMembers,
   sessions,
+  workspaceRoles,
 } from "../db/schema.js";
 import {
   hashPassword,
@@ -27,6 +28,7 @@ import {
 import { id, rawToken } from "../lib/ids.js";
 import { config } from "../lib/config.js";
 import { deriveUniqueWorkspaceHandle } from "../lib/workspace-handle.js";
+import { workspaceAccess } from "../lib/access-control.js";
 
 const SignupBody = z.object({
   email: z.string().email(),
@@ -45,7 +47,11 @@ const LoginBody = z.object({
   password: z.string().min(1),
 });
 
-const InviteBody = z.object({ email: z.string().email() });
+const InviteBody = z.object({
+  email: z.string().email(),
+  role: z.string().min(2).max(40).regex(/^[a-z][a-z0-9_-]*$/).default("member"),
+  channelIds: z.array(z.string()).max(100).default([]),
+});
 
 const UpdateMeBody = z.object({
   name: z.string().min(1).max(100).optional(),
@@ -279,6 +285,19 @@ export default async function authRoutes(app: FastifyInstance): Promise<void> {
     const body = InviteBody.parse(req.body);
     const { memberId, workspaceId } = req.auth!;
     if (!workspaceId || !memberId) return reply.code(409).send({ error: "no_workspace" });
+    const access = await workspaceAccess(workspaceId, req.auth!.userId);
+    if (!access?.permissions.includes("*")) return reply.code(403).send({ error: "admin_only" });
+    if (!["admin", "member", "guest"].includes(body.role)) {
+      const [custom] = await db.select({ id: workspaceRoles.id }).from(workspaceRoles)
+        .where(and(eq(workspaceRoles.workspaceId, workspaceId), eq(workspaceRoles.key, body.role))).limit(1);
+      if (!custom) return reply.code(400).send({ error: "role_not_found" });
+    }
+    if (body.channelIds.length) {
+      const valid = await db.select({ id: conversations.id }).from(conversations)
+        .where(and(eq(conversations.workspaceId, workspaceId), eq(conversations.kind, "channel")));
+      const validIds = new Set(valid.map((channel) => channel.id));
+      if (body.channelIds.some((channelId) => !validIds.has(channelId))) return reply.code(400).send({ error: "channel_not_found" });
+    }
     const token = rawToken(40);
     const invId = id("inv");
     await db.insert(invites).values({
@@ -287,6 +306,8 @@ export default async function authRoutes(app: FastifyInstance): Promise<void> {
       email: body.email,
       token,
       invitedBy: memberId,
+      role: body.role,
+      channelIds: body.channelIds,
     });
     const url = `${config.publicBaseUrl}/invite/${token}`;
     if (!config.smtpUrl) {
@@ -308,6 +329,8 @@ export default async function authRoutes(app: FastifyInstance): Promise<void> {
         invitedBy: invites.invitedBy,
         createdAt: invites.createdAt,
         acceptedAt: invites.acceptedAt,
+        role: invites.role,
+        channelIds: invites.channelIds,
       })
       .from(invites)
       .where(eq(invites.workspaceId, workspaceId));
@@ -318,6 +341,8 @@ export default async function authRoutes(app: FastifyInstance): Promise<void> {
         email: r.email,
         invitedBy: r.invitedBy,
         createdAt: r.createdAt,
+        role: r.role,
+        channelIds: r.channelIds,
         inviteUrl: `${config.publicBaseUrl}/invite/${r.token}`,
       })),
     };
@@ -383,7 +408,7 @@ export default async function authRoutes(app: FastifyInstance): Promise<void> {
         };
       }
     }
-    return { email: inv.email, workspace: ws, viewer };
+    return { email: inv.email, workspace: ws, role: inv.role, channelIds: inv.channelIds, viewer };
   });
 
   // One-click join for already-authenticated users. Auto-add to the
@@ -401,32 +426,11 @@ export default async function authRoutes(app: FastifyInstance): Promise<void> {
 
     await db
       .insert(workspaceMembers)
-      .values({ workspaceId: inv.workspaceId, userId: user.id, role: "member" })
+      .values({ workspaceId: inv.workspaceId, userId: user.id, role: inv.role })
       .onConflictDoNothing();
     const memberId = await ensureUserMember(inv.workspaceId, user.id);
 
-    const publicChannels = await db
-      .select({ id: conversations.id })
-      .from(conversations)
-      .where(
-        and(
-          eq(conversations.workspaceId, inv.workspaceId),
-          eq(conversations.kind, "channel"),
-          eq(conversations.isPrivate, false),
-        ),
-      );
-    if (publicChannels.length) {
-      await db
-        .insert(conversationMembers)
-        .values(
-          publicChannels.map((c) => ({
-            conversationId: c.id,
-            memberId,
-            role: "member" as const,
-          })),
-        )
-        .onConflictDoNothing();
-    }
+    await joinInviteChannels(inv.workspaceId, memberId, inv.role, inv.channelIds);
 
     await db.update(invites).set({ acceptedAt: new Date() }).where(eq(invites.id, inv.id));
     // Switch them into the newly-joined workspace so the UI lands there.
@@ -471,32 +475,11 @@ export default async function authRoutes(app: FastifyInstance): Promise<void> {
 
     await db
       .insert(workspaceMembers)
-      .values({ workspaceId: inv.workspaceId, userId: uid, role: "member" })
+      .values({ workspaceId: inv.workspaceId, userId: uid, role: inv.role })
       .onConflictDoNothing();
     const memberId = await ensureUserMember(inv.workspaceId, uid);
 
-    const publicChannels = await db
-      .select({ id: conversations.id })
-      .from(conversations)
-      .where(
-        and(
-          eq(conversations.workspaceId, inv.workspaceId),
-          eq(conversations.kind, "channel"),
-          eq(conversations.isPrivate, false),
-        ),
-      );
-    if (publicChannels.length) {
-      await db
-        .insert(conversationMembers)
-        .values(
-          publicChannels.map((c) => ({
-            conversationId: c.id,
-            memberId,
-            role: "member" as const,
-          })),
-        )
-        .onConflictDoNothing();
-    }
+    await joinInviteChannels(inv.workspaceId, memberId, inv.role, inv.channelIds);
 
     await db.update(invites).set({ acceptedAt: new Date() }).where(eq(invites.id, inv.id));
 
@@ -504,6 +487,14 @@ export default async function authRoutes(app: FastifyInstance): Promise<void> {
     setSessionCookie(reply, sid);
     return { ok: true, memberId, workspaceId: inv.workspaceId };
   });
+}
+
+async function joinInviteChannels(workspaceId: string, memberId: string, role: string, invitedChannelIds: string[]): Promise<void> {
+  const channels = role === "guest"
+    ? await db.select({ id: conversations.id }).from(conversations).where(and(eq(conversations.workspaceId, workspaceId), inArray(conversations.id, invitedChannelIds)))
+    : await db.select({ id: conversations.id }).from(conversations).where(and(eq(conversations.workspaceId, workspaceId), eq(conversations.kind, "channel"), eq(conversations.isPrivate, false)));
+  if (!channels.length) return;
+  await db.insert(conversationMembers).values(channels.map((channel) => ({ conversationId: channel.id, memberId, role: "member" as const }))).onConflictDoNothing();
 }
 
 function publicUser(u: {

--- a/api/src/routes/connectors.ts
+++ b/api/src/routes/connectors.ts
@@ -1,0 +1,304 @@
+import { FastifyInstance } from "fastify";
+import { and, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db/index.js";
+import { agentConnectorGrants, agents, connectors } from "../db/schema.js";
+import { requireWorkspace } from "../auth/session.js";
+import { checkConnector, invokeConnector } from "../lib/connector-runtime.js";
+import { config } from "../lib/config.js";
+import { id } from "../lib/ids.js";
+import { decryptSecret, encryptSecret } from "../lib/secret-box.js";
+
+const Secret = z.object({
+  bearerToken: z.string().max(20_000).optional(),
+  oauthAccessToken: z.string().max(20_000).optional(),
+  oauthRefreshToken: z.string().max(20_000).optional(),
+  oauthExpiresAt: z.string().optional(),
+  clientSecret: z.string().max(20_000).optional(),
+  headers: z.record(z.string(), z.string().max(20_000)).optional(),
+});
+
+const Create = z.object({
+  name: z.string().min(1).max(120),
+  description: z.string().max(2_000).optional(),
+  kind: z.enum(["http", "mcp"]),
+  baseUrl: z.string().url(),
+  authType: z.enum(["none", "bearer", "header", "oauth2"]).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
+  secret: Secret.optional(),
+});
+
+const Patch = Create.partial();
+
+function publicConnector<T extends typeof connectors.$inferSelect>(connector: T): Omit<T, "secretCiphertext"> & { hasSecret: boolean } {
+  const { secretCiphertext, ...rest } = connector;
+  return { ...rest, hasSecret: !!secretCiphertext };
+}
+
+function oauthConfig(connector: typeof connectors.$inferSelect): {
+  authorizationUrl: string;
+  tokenUrl: string;
+  clientId: string;
+  scopes: string[];
+} {
+  const oauth = (connector.configJson.oauth ?? {}) as Record<string, unknown>;
+  const parsed = z
+    .object({
+      authorizationUrl: z.string().url(),
+      tokenUrl: z.string().url(),
+      clientId: z.string().min(1),
+      scopes: z.array(z.string()).default([]),
+    })
+    .parse(oauth);
+  return parsed;
+}
+
+export default async function connectorRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/connectors", { preHandler: requireWorkspace }, async (req) => {
+    const workspaceId = req.auth!.workspaceId!;
+    const rows = await db.select().from(connectors).where(eq(connectors.workspaceId, workspaceId));
+    const ids = rows.map((row) => row.id);
+    const grants = ids.length
+      ? await db.select().from(agentConnectorGrants).where(inArray(agentConnectorGrants.connectorId, ids))
+      : [];
+    return {
+      connectors: rows.map((row) => ({
+        ...publicConnector(row),
+        grants: grants.filter((grant) => grant.connectorId === row.id),
+      })),
+    };
+  });
+
+  app.post("/connectors", { preHandler: requireWorkspace }, async (req, reply) => {
+    const body = Create.parse(req.body);
+    const url = new URL(body.baseUrl);
+    if (!/^https?:$/.test(url.protocol) || url.username || url.password) {
+      return reply.code(400).send({ error: "connector_url_invalid" });
+    }
+    const connectorId = id("conn");
+    await db.insert(connectors).values({
+      id: connectorId,
+      workspaceId: req.auth!.workspaceId!,
+      name: body.name,
+      description: body.description ?? "",
+      kind: body.kind,
+      baseUrl: body.baseUrl,
+      authType: body.authType ?? "none",
+      configJson: body.config ?? {},
+      secretCiphertext: body.secret ? encryptSecret(body.secret) : null,
+      createdBy: req.auth!.memberId!,
+    });
+    const [created] = await db.select().from(connectors).where(eq(connectors.id, connectorId)).limit(1);
+    return reply.code(201).send({ connector: publicConnector(created) });
+  });
+
+  app.patch("/connectors/:id", { preHandler: requireWorkspace }, async (req, reply) => {
+    const connectorId = (req.params as { id: string }).id;
+    const body = Patch.parse(req.body);
+    const [existing] = await db
+      .select()
+      .from(connectors)
+      .where(and(eq(connectors.id, connectorId), eq(connectors.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!existing) return reply.code(404).send({ error: "connector_not_found" });
+    if (body.baseUrl) {
+      const url = new URL(body.baseUrl);
+      if (!/^https?:$/.test(url.protocol) || url.username || url.password) {
+        return reply.code(400).send({ error: "connector_url_invalid" });
+      }
+    }
+    await db
+      .update(connectors)
+      .set({
+        ...(body.name !== undefined ? { name: body.name } : {}),
+        ...(body.description !== undefined ? { description: body.description } : {}),
+        ...(body.kind !== undefined ? { kind: body.kind } : {}),
+        ...(body.baseUrl !== undefined ? { baseUrl: body.baseUrl } : {}),
+        ...(body.authType !== undefined ? { authType: body.authType } : {}),
+        ...(body.config !== undefined ? { configJson: body.config } : {}),
+        ...(body.secret !== undefined ? { secretCiphertext: encryptSecret(body.secret) } : {}),
+        status: "unchecked",
+        updatedAt: new Date(),
+      })
+      .where(eq(connectors.id, connectorId));
+    const [updated] = await db.select().from(connectors).where(eq(connectors.id, connectorId)).limit(1);
+    return { connector: publicConnector(updated) };
+  });
+
+  app.delete("/connectors/:id", { preHandler: requireWorkspace }, async (req, reply) => {
+    const connectorId = (req.params as { id: string }).id;
+    const [existing] = await db
+      .select({ id: connectors.id })
+      .from(connectors)
+      .where(and(eq(connectors.id, connectorId), eq(connectors.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!existing) return reply.code(404).send({ error: "connector_not_found" });
+    await db.delete(agentConnectorGrants).where(eq(agentConnectorGrants.connectorId, connectorId));
+    await db.delete(connectors).where(eq(connectors.id, connectorId));
+    return reply.code(204).send();
+  });
+
+  app.post("/connectors/:id/check", { preHandler: requireWorkspace }, async (req, reply) => {
+    const connectorId = (req.params as { id: string }).id;
+    const [connector] = await db
+      .select()
+      .from(connectors)
+      .where(and(eq(connectors.id, connectorId), eq(connectors.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!connector) return reply.code(404).send({ error: "connector_not_found" });
+    const result = await checkConnector(connector);
+    await db
+      .update(connectors)
+      .set({
+        status: result.ok ? "healthy" : "error",
+        lastCheckedAt: new Date(),
+        lastError: result.error ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(connectors.id, connector.id));
+    return result;
+  });
+
+  app.post("/connectors/:id/invoke", { preHandler: requireWorkspace }, async (req, reply) => {
+    const connectorId = (req.params as { id: string }).id;
+    const body = z
+      .object({
+        operation: z.string().optional(),
+        method: z.string().optional(),
+        path: z.string().optional(),
+        headers: z.record(z.string(), z.string()).optional(),
+        query: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
+        body: z.unknown().optional(),
+      })
+      .parse(req.body ?? {});
+    const [connector] = await db
+      .select()
+      .from(connectors)
+      .where(and(eq(connectors.id, connectorId), eq(connectors.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!connector) return reply.code(404).send({ error: "connector_not_found" });
+    return invokeConnector(connector, { ...body, input: {}, steps: {} });
+  });
+
+  app.put("/connectors/:id/grants/:agentId", { preHandler: requireWorkspace }, async (req, reply) => {
+    const { id: connectorId, agentId } = req.params as { id: string; agentId: string };
+    const body = z.object({ scopes: z.array(z.string().min(1).max(100)).max(100).default([]) }).parse(req.body ?? {});
+    const [connector] = await db
+      .select({ id: connectors.id })
+      .from(connectors)
+      .where(and(eq(connectors.id, connectorId), eq(connectors.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    const [agent] = await db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.id, agentId), eq(agents.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!connector || !agent) return reply.code(404).send({ error: "connector_or_agent_not_found" });
+    await db
+      .insert(agentConnectorGrants)
+      .values({ connectorId, agentId, scopes: body.scopes, createdBy: req.auth!.memberId! })
+      .onConflictDoUpdate({
+        target: [agentConnectorGrants.connectorId, agentConnectorGrants.agentId],
+        set: { scopes: body.scopes, createdBy: req.auth!.memberId!, createdAt: new Date() },
+      });
+    return { ok: true };
+  });
+
+  app.delete("/connectors/:id/grants/:agentId", { preHandler: requireWorkspace }, async (req, reply) => {
+    const { id: connectorId, agentId } = req.params as { id: string; agentId: string };
+    const [connector] = await db
+      .select({ id: connectors.id })
+      .from(connectors)
+      .where(and(eq(connectors.id, connectorId), eq(connectors.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!connector) return reply.code(404).send({ error: "connector_not_found" });
+    await db
+      .delete(agentConnectorGrants)
+      .where(and(eq(agentConnectorGrants.connectorId, connectorId), eq(agentConnectorGrants.agentId, agentId)));
+    return reply.code(204).send();
+  });
+
+  // Generic OAuth 2 authorization-code flow. Provider-specific URLs/client id/
+  // scopes live in public connector config; the client secret and resulting
+  // tokens remain inside the encrypted credential envelope.
+  app.post("/connectors/:id/oauth/start", { preHandler: requireWorkspace }, async (req, reply) => {
+    const connectorId = (req.params as { id: string }).id;
+    const [connector] = await db
+      .select()
+      .from(connectors)
+      .where(and(eq(connectors.id, connectorId), eq(connectors.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!connector) return reply.code(404).send({ error: "connector_not_found" });
+    if (connector.authType !== "oauth2") return reply.code(400).send({ error: "connector_not_oauth" });
+    const oauth = oauthConfig(connector);
+    const redirectUri = `${config.publicBaseUrl.replace(/\/$/, "")}/api/connectors/oauth/callback`;
+    const state = encryptSecret({
+      connectorId: connector.id,
+      workspaceId: connector.workspaceId,
+      expiresAt: Date.now() + 10 * 60 * 1000,
+      nonce: id("oauth"),
+    });
+    const url = new URL(oauth.authorizationUrl);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("client_id", oauth.clientId);
+    url.searchParams.set("redirect_uri", redirectUri);
+    url.searchParams.set("state", state);
+    if (oauth.scopes.length) url.searchParams.set("scope", oauth.scopes.join(" "));
+    return { authorizationUrl: url.toString() };
+  });
+
+  // Deliberately unauthenticated: the provider redirects the browser here.
+  // The encrypted, short-lived state binds the callback to one workspace and
+  // connector; no ambient session authority is used.
+  app.get("/connectors/oauth/callback", async (req, reply) => {
+    const query = z.object({ code: z.string().min(1), state: z.string().min(1) }).parse(req.query);
+    let state: { connectorId: string; workspaceId: string; expiresAt: number };
+    try { state = decryptSecret(query.state); } catch { return reply.code(400).send({ error: "oauth_state_invalid" }); }
+    if (state.expiresAt < Date.now()) return reply.code(400).send({ error: "oauth_state_expired" });
+    const [connector] = await db
+      .select()
+      .from(connectors)
+      .where(and(eq(connectors.id, state.connectorId), eq(connectors.workspaceId, state.workspaceId)))
+      .limit(1);
+    if (!connector) return reply.code(404).send({ error: "connector_not_found" });
+    const oauth = oauthConfig(connector);
+    const oldSecret = connector.secretCiphertext
+      ? decryptSecret<Record<string, unknown>>(connector.secretCiphertext)
+      : {};
+    const clientSecret = typeof oldSecret.clientSecret === "string" ? oldSecret.clientSecret : "";
+    const redirectUri = `${config.publicBaseUrl.replace(/\/$/, "")}/api/connectors/oauth/callback`;
+    const response = await fetch(oauth.tokenUrl, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: query.code,
+        client_id: oauth.clientId,
+        client_secret: clientSecret,
+        redirect_uri: redirectUri,
+      }),
+      signal: AbortSignal.timeout(20_000),
+    });
+    const token = (await response.json()) as Record<string, unknown>;
+    if (!response.ok || typeof token.access_token !== "string") {
+      return reply.code(400).send({ error: "oauth_token_exchange_failed" });
+    }
+    const expiresIn = Number(token.expires_in ?? 0);
+    await db
+      .update(connectors)
+      .set({
+        secretCiphertext: encryptSecret({
+          ...oldSecret,
+          oauthAccessToken: token.access_token,
+          ...(typeof token.refresh_token === "string" ? { oauthRefreshToken: token.refresh_token } : {}),
+          ...(expiresIn > 0 ? { oauthExpiresAt: new Date(Date.now() + expiresIn * 1000).toISOString() } : {}),
+        }),
+        status: "healthy",
+        lastCheckedAt: new Date(),
+        lastError: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(connectors.id, connector.id));
+    return reply.redirect(`${config.publicBaseUrl.replace(/\/$/, "")}/automation?oauth=connected`);
+  });
+}

--- a/api/src/routes/conversations.ts
+++ b/api/src/routes/conversations.ts
@@ -12,6 +12,7 @@ import {
   messages,
   reactions,
   presence,
+  workspaceMembers,
 } from "../db/schema.js";
 import { requireWorkspace } from "../auth/session.js";
 import { id } from "../lib/ids.js";
@@ -176,13 +177,19 @@ export default async function conversationRoutes(app: FastifyInstance): Promise<
       ]);
       // Auto-join every member of THIS workspace to public channels.
       if (!(body.isPrivate ?? false)) {
-        const wsMembers = await db
+        const [wsMembers, guestUsers] = await Promise.all([db
           .select({ id: members.id })
           .from(members)
-          .where(eq(members.workspaceId, workspaceId!));
+          .where(eq(members.workspaceId, workspaceId!)),
+        db.select({ userId: workspaceMembers.userId }).from(workspaceMembers)
+          .where(and(eq(workspaceMembers.workspaceId, workspaceId!), eq(workspaceMembers.role, "guest")))]);
+        const guestMemberRows = guestUsers.length
+          ? await db.select({ id: members.id }).from(members).where(and(eq(members.workspaceId, workspaceId!), eq(members.kind, "user"), inArray(members.refId, guestUsers.map((row) => row.userId))))
+          : [];
+        const guestMemberIds = new Set(guestMemberRows.map((row) => row.id));
         const toAdd = wsMembers
           .map((m) => m.id)
-          .filter((m) => m !== memberId && !extra.includes(m));
+          .filter((m) => m !== memberId && !extra.includes(m) && !guestMemberIds.has(m));
         if (toAdd.length) {
           await db.insert(conversationMembers).values(
             toAdd.map((m) => ({ conversationId: convId, memberId: m, role: "member" as const })),

--- a/api/src/routes/enterprise.ts
+++ b/api/src/routes/enterprise.ts
@@ -1,0 +1,299 @@
+import { createHash, randomBytes } from "node:crypto";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { and, desc, eq, gt, isNull } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db/index.js";
+import {
+  auditEvents,
+  conversationMembers,
+  conversations,
+  members,
+  serviceAccounts,
+  sessions,
+  ssoConnections,
+  users,
+  workspaceMembers,
+  workspaceRoles,
+  workspaces,
+  workflows,
+} from "../db/schema.js";
+import { requireWorkspace, createSession, ensureUserMember, hashPassword, setSessionCookie } from "../auth/session.js";
+import { requirePermission, workspaceAccess, writeAudit } from "../lib/access-control.js";
+import { config } from "../lib/config.js";
+import { decryptSecret, encryptSecret } from "../lib/secret-box.js";
+import { id, rawToken } from "../lib/ids.js";
+import { redis } from "../lib/redis.js";
+import { startWorkflowRun } from "../lib/workflow-engine.js";
+
+const RoleBody = z.object({
+  key: z.string().min(2).max(40).regex(/^[a-z][a-z0-9_-]*$/),
+  name: z.string().min(1).max(80),
+  permissions: z.array(z.enum([
+    "workspace.read", "workspace.write", "channels.write", "runs.control",
+    "apps.request_publish", "audit.export", "access.manage",
+  ])).max(30),
+});
+
+const SsoBody = z.object({
+  issuer: z.string().url(),
+  clientId: z.string().min(1).max(240),
+  clientSecret: z.string().min(1).max(4_000).optional(),
+  domains: z.array(z.string().min(1).max(255)).max(50).default([]),
+  defaultRole: z.string().min(2).max(40).default("member"),
+  enabled: z.boolean().default(true),
+});
+
+type OidcDiscovery = {
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint: string;
+};
+
+function sha(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function base64url(value: Buffer): string {
+  return value.toString("base64url");
+}
+
+function callbackUrl(): string {
+  return `${config.publicBaseUrl.replace(/\/$/, "")}/api/auth/sso/callback`;
+}
+
+async function admin(req: FastifyRequest, reply: FastifyReply): Promise<boolean> {
+  if (await requirePermission(req, "*")) return true;
+  reply.code(403).send({ error: "admin_only" });
+  return false;
+}
+
+async function discovery(issuer: string): Promise<OidcDiscovery> {
+  const url = new URL(issuer);
+  const local = ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+  if (url.protocol !== "https:" && !local) throw new Error("oidc_issuer_must_use_https");
+  if (url.username || url.password) throw new Error("oidc_issuer_invalid");
+  const response = await fetch(`${issuer.replace(/\/$/, "")}/.well-known/openid-configuration`, { signal: AbortSignal.timeout(10_000) });
+  if (!response.ok) throw new Error(`oidc_discovery_${response.status}`);
+  const parsed = z.object({ authorization_endpoint: z.string().url(), token_endpoint: z.string().url(), userinfo_endpoint: z.string().url() }).parse(await response.json());
+  for (const endpoint of Object.values(parsed)) {
+    const next = new URL(endpoint);
+    if (next.origin !== url.origin) throw new Error("oidc_cross_origin_endpoint");
+  }
+  return parsed;
+}
+
+export default async function enterpriseRoutes(app: FastifyInstance): Promise<void> {
+  app.addHook("preHandler", requireWorkspace);
+
+  app.get("/enterprise", async (req) => {
+    const workspaceId = req.auth!.workspaceId!;
+    const [workspace, roles, accounts, sso, access] = await Promise.all([
+      db.select({ retentionDays: workspaces.retentionDays, dataResidency: workspaces.dataResidency }).from(workspaces).where(eq(workspaces.id, workspaceId)).limit(1).then((rows) => rows[0]),
+      db.select().from(workspaceRoles).where(eq(workspaceRoles.workspaceId, workspaceId)).orderBy(workspaceRoles.name),
+      db.select({ id: serviceAccounts.id, name: serviceAccounts.name, scopesJson: serviceAccounts.scopesJson, lastUsedAt: serviceAccounts.lastUsedAt, expiresAt: serviceAccounts.expiresAt, revokedAt: serviceAccounts.revokedAt, createdAt: serviceAccounts.createdAt }).from(serviceAccounts).where(eq(serviceAccounts.workspaceId, workspaceId)).orderBy(desc(serviceAccounts.createdAt)),
+      db.select().from(ssoConnections).where(eq(ssoConnections.workspaceId, workspaceId)).limit(1).then((rows) => rows[0]),
+      workspaceAccess(workspaceId, req.auth!.userId),
+    ]);
+    return {
+      workspace,
+      access,
+      builtInRoles: [
+        { key: "admin", name: "Admin", permissions: ["*"] },
+        { key: "member", name: "Member", permissions: ["workspace.read", "workspace.write", "runs.control", "apps.request_publish"] },
+        { key: "guest", name: "Guest", permissions: ["workspace.read", "channels.write"] },
+      ],
+      roles,
+      serviceAccounts: accounts,
+      sso: sso ? { id: sso.id, issuer: sso.issuer, clientId: sso.clientId, domains: sso.domainsJson, defaultRole: sso.defaultRole, enabled: sso.enabled, hasSecret: true } : null,
+    };
+  });
+
+  app.put("/enterprise/governance", async (req, reply) => {
+    if (!(await admin(req, reply))) return;
+    const body = z.object({ retentionDays: z.number().int().min(1).max(3_650).nullable(), dataResidency: z.string().min(2).max(32).regex(/^[a-z0-9_-]+$/i) }).parse(req.body);
+    await db.update(workspaces).set({ retentionDays: body.retentionDays, dataResidency: body.dataResidency }).where(eq(workspaces.id, req.auth!.workspaceId!));
+    await writeAudit({ workspaceId: req.auth!.workspaceId!, actorId: req.auth!.memberId!, action: "governance.updated", targetType: "workspace", targetId: req.auth!.workspaceId!, meta: body, ip: req.ip });
+    return { ok: true, ...body };
+  });
+
+  app.post("/enterprise/roles", async (req, reply) => {
+    if (!(await admin(req, reply))) return;
+    const body = RoleBody.parse(req.body);
+    if (["admin", "member", "guest"].includes(body.key)) return reply.code(409).send({ error: "system_role" });
+    const roleId = id("role");
+    await db.insert(workspaceRoles).values({ id: roleId, workspaceId: req.auth!.workspaceId!, key: body.key, name: body.name, permissionsJson: body.permissions, createdBy: req.auth!.memberId! })
+      .onConflictDoUpdate({ target: [workspaceRoles.workspaceId, workspaceRoles.key], set: { name: body.name, permissionsJson: body.permissions, updatedAt: new Date() } });
+    await writeAudit({ workspaceId: req.auth!.workspaceId!, actorId: req.auth!.memberId!, action: "role.upserted", targetType: "role", targetId: body.key, meta: { permissions: body.permissions }, ip: req.ip });
+    const [role] = await db.select().from(workspaceRoles).where(and(eq(workspaceRoles.workspaceId, req.auth!.workspaceId!), eq(workspaceRoles.key, body.key))).limit(1);
+    return reply.code(201).send({ role });
+  });
+
+  app.delete("/enterprise/roles/:key", async (req, reply) => {
+    if (!(await admin(req, reply))) return;
+    const key = (req.params as { key: string }).key;
+    if (["admin", "member", "guest"].includes(key)) return reply.code(409).send({ error: "system_role" });
+    const [used] = await db.select({ userId: workspaceMembers.userId }).from(workspaceMembers).where(and(eq(workspaceMembers.workspaceId, req.auth!.workspaceId!), eq(workspaceMembers.role, key))).limit(1);
+    if (used) return reply.code(409).send({ error: "role_in_use" });
+    await db.delete(workspaceRoles).where(and(eq(workspaceRoles.workspaceId, req.auth!.workspaceId!), eq(workspaceRoles.key, key)));
+    return { ok: true };
+  });
+
+  app.post("/enterprise/service-accounts", async (req, reply) => {
+    if (!(await admin(req, reply))) return;
+    const body = z.object({ name: z.string().min(1).max(100), scopes: z.array(z.string().min(1).max(80)).min(1).max(50), expiresAt: z.string().datetime().nullable().optional() }).parse(req.body);
+    const token = `cc_sa_${rawToken(48)}`;
+    const accountId = id("svc");
+    await db.insert(serviceAccounts).values({ id: accountId, workspaceId: req.auth!.workspaceId!, name: body.name, tokenHash: sha(token), scopesJson: body.scopes, expiresAt: body.expiresAt ? new Date(body.expiresAt) : null, createdBy: req.auth!.memberId! });
+    await writeAudit({ workspaceId: req.auth!.workspaceId!, actorId: req.auth!.memberId!, action: "service_account.created", targetType: "service_account", targetId: accountId, meta: { scopes: body.scopes }, ip: req.ip });
+    return reply.code(201).send({ account: { id: accountId, name: body.name, scopes: body.scopes, expiresAt: body.expiresAt ?? null }, token });
+  });
+
+  app.post("/enterprise/service-accounts/:id/revoke", async (req, reply) => {
+    if (!(await admin(req, reply))) return;
+    const accountId = (req.params as { id: string }).id;
+    const result = await db.update(serviceAccounts).set({ revokedAt: new Date() }).where(and(eq(serviceAccounts.id, accountId), eq(serviceAccounts.workspaceId, req.auth!.workspaceId!))).returning({ id: serviceAccounts.id });
+    if (!result.length) return reply.code(404).send({ error: "service_account_not_found" });
+    return { ok: true };
+  });
+
+  app.put("/enterprise/sso", async (req, reply) => {
+    if (!(await admin(req, reply))) return;
+    const body = SsoBody.parse(req.body);
+    await discovery(body.issuer);
+    const [existing] = await db.select().from(ssoConnections).where(eq(ssoConnections.workspaceId, req.auth!.workspaceId!)).limit(1);
+    if (!existing && !body.clientSecret) return reply.code(400).send({ error: "client_secret_required" });
+    const secret = body.clientSecret ? encryptSecret({ clientSecret: body.clientSecret }) : existing!.clientSecretCiphertext;
+    await db.insert(ssoConnections).values({
+      id: existing?.id ?? id("sso"), workspaceId: req.auth!.workspaceId!, issuer: body.issuer.replace(/\/$/, ""),
+      clientId: body.clientId, clientSecretCiphertext: secret, domainsJson: body.domains.map((domain) => domain.toLowerCase()),
+      defaultRole: body.defaultRole, enabled: body.enabled, createdBy: req.auth!.memberId!,
+    }).onConflictDoUpdate({ target: ssoConnections.workspaceId, set: {
+      issuer: body.issuer.replace(/\/$/, ""), clientId: body.clientId, clientSecretCiphertext: secret,
+      domainsJson: body.domains.map((domain) => domain.toLowerCase()), defaultRole: body.defaultRole,
+      enabled: body.enabled, updatedAt: new Date(),
+    } });
+    await writeAudit({ workspaceId: req.auth!.workspaceId!, actorId: req.auth!.memberId!, action: "sso.configured", targetType: "sso", targetId: existing?.id, meta: { issuer: body.issuer, domains: body.domains, enabled: body.enabled }, ip: req.ip });
+    return { ok: true };
+  });
+
+  app.get("/enterprise/audit", async (req, reply) => {
+    const access = await workspaceAccess(req.auth!.workspaceId!, req.auth!.userId);
+    if (!access || (!access.permissions.includes("*") && !access.permissions.includes("audit.export"))) return reply.code(403).send({ error: "permission_denied" });
+    const query = z.object({ format: z.enum(["json", "csv"]).default("json"), days: z.coerce.number().int().min(1).max(3650).default(30) }).parse(req.query);
+    const rows = await db.select().from(auditEvents).where(and(eq(auditEvents.workspaceId, req.auth!.workspaceId!), gt(auditEvents.createdAt, new Date(Date.now() - query.days * 86_400_000)))).orderBy(desc(auditEvents.createdAt)).limit(50_000);
+    if (query.format === "json") return { events: rows };
+    const escape = (value: unknown) => `"${String(value ?? "").replaceAll('"', '""')}"`;
+    const csv = ["created_at,actor_type,actor_id,action,target_type,target_id,meta_json", ...rows.map((row) => [row.createdAt.toISOString(), row.actorType, row.actorId, row.action, row.targetType, row.targetId ?? "", JSON.stringify(row.metaJson)].map(escape).join(","))].join("\n");
+    return reply.header("content-disposition", "attachment; filename=circlechat-audit.csv").type("text/csv; charset=utf-8").send(csv);
+  });
+}
+
+export async function enterprisePublicRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/auth/sso/:workspaceHandle", async (req, reply) => {
+    const handle = (req.params as { workspaceHandle: string }).workspaceHandle;
+    const [row] = await db.select({ connection: ssoConnections, workspace: workspaces })
+      .from(ssoConnections).innerJoin(workspaces, eq(workspaces.id, ssoConnections.workspaceId))
+      .where(and(eq(workspaces.handle, handle), eq(ssoConnections.enabled, true))).limit(1);
+    if (!row) return reply.code(404).send({ error: "sso_not_configured" });
+    const doc = await discovery(row.connection.issuer);
+    const state = base64url(randomBytes(32));
+    const verifier = base64url(randomBytes(48));
+    const challenge = base64url(createHash("sha256").update(verifier).digest());
+    await redis.set(`cc:oidc:${state}`, JSON.stringify({ connectionId: row.connection.id, verifier }), "EX", 600);
+    const url = new URL(doc.authorization_endpoint);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("client_id", row.connection.clientId);
+    url.searchParams.set("redirect_uri", callbackUrl());
+    url.searchParams.set("scope", "openid email profile");
+    url.searchParams.set("state", state);
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    return reply.redirect(url.toString());
+  });
+
+  app.get("/auth/sso/callback", async (req, reply) => {
+    const query = z.object({ code: z.string().min(1), state: z.string().min(20) }).parse(req.query);
+    const stored = await redis.getdel(`cc:oidc:${query.state}`);
+    if (!stored) return reply.code(400).send({ error: "oidc_state_invalid" });
+    const state = z.object({ connectionId: z.string(), verifier: z.string() }).parse(JSON.parse(stored));
+    const [connection] = await db.select().from(ssoConnections).where(and(eq(ssoConnections.id, state.connectionId), eq(ssoConnections.enabled, true))).limit(1);
+    if (!connection) return reply.code(404).send({ error: "sso_not_configured" });
+    const doc = await discovery(connection.issuer);
+    const { clientSecret } = decryptSecret<{ clientSecret: string }>(connection.clientSecretCiphertext);
+    const tokenResponse = await fetch(doc.token_endpoint, {
+      method: "POST", headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
+      body: new URLSearchParams({ grant_type: "authorization_code", code: query.code, redirect_uri: callbackUrl(), client_id: connection.clientId, client_secret: clientSecret, code_verifier: state.verifier }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!tokenResponse.ok) return reply.code(401).send({ error: "oidc_token_exchange_failed" });
+    const token = z.object({ access_token: z.string().min(1) }).parse(await tokenResponse.json());
+    const userResponse = await fetch(doc.userinfo_endpoint, { headers: { authorization: `Bearer ${token.access_token}`, accept: "application/json" }, signal: AbortSignal.timeout(10_000) });
+    if (!userResponse.ok) return reply.code(401).send({ error: "oidc_userinfo_failed" });
+    const identity = z.object({ sub: z.string(), email: z.string().email(), email_verified: z.boolean().optional(), name: z.string().optional(), preferred_username: z.string().optional() }).parse(await userResponse.json());
+    if (identity.email_verified === false) return reply.code(403).send({ error: "oidc_email_unverified" });
+    const email = identity.email.toLowerCase();
+    const domain = email.split("@")[1];
+    if (connection.domainsJson.length && !connection.domainsJson.includes(domain)) return reply.code(403).send({ error: "oidc_domain_not_allowed" });
+    let [user] = await db.select().from(users).where(eq(users.email, email)).limit(1);
+    if (!user) {
+      const userId = id("u");
+      const baseHandle = (identity.preferred_username ?? email.split("@")[0]).toLowerCase().replace(/[^a-z0-9._-]/g, "-").slice(0, 30) || "sso-user";
+      let handle = baseHandle;
+      if ((await db.select({ id: users.id }).from(users).where(eq(users.handle, handle)).limit(1)).length) handle = `${baseHandle}-${rawToken(4).toLowerCase()}`.slice(0, 40);
+      await db.insert(users).values({ id: userId, email, name: identity.name ?? email.split("@")[0], handle, passwordHash: await hashPassword(rawToken(48)), avatarColor: "slate" });
+      [user] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
+    }
+    await db.insert(workspaceMembers).values({ workspaceId: connection.workspaceId, userId: user.id, role: connection.defaultRole }).onConflictDoNothing();
+    const memberId = await ensureUserMember(connection.workspaceId, user.id);
+    if (connection.defaultRole !== "guest") {
+      const channels = await db.select({ id: conversations.id }).from(conversations).where(and(eq(conversations.workspaceId, connection.workspaceId), eq(conversations.kind, "channel"), eq(conversations.isPrivate, false)));
+      if (channels.length) await db.insert(conversationMembers).values(channels.map((channel) => ({ conversationId: channel.id, memberId, role: "member" }))).onConflictDoNothing();
+    }
+    const sid = await createSession(user.id, connection.workspaceId);
+    setSessionCookie(reply, sid);
+    await writeAudit({ workspaceId: connection.workspaceId, actorId: memberId, action: "sso.login", targetType: "user", targetId: user.id, meta: { issuer: connection.issuer, subject: identity.sub }, ip: req.ip });
+    return reply.redirect(`${config.publicBaseUrl.replace(/\/$/, "")}/`);
+  });
+}
+
+export async function serviceApiRoutes(app: FastifyInstance): Promise<void> {
+  async function authenticate(req: FastifyRequest, reply: FastifyReply, scope?: string) {
+    const token = String(req.headers.authorization ?? "").replace(/^Bearer\s+/i, "");
+    if (!token.startsWith("cc_sa_")) { reply.code(401).send({ error: "service_token_required" }); return null; }
+    const [account] = await db.select().from(serviceAccounts).where(and(eq(serviceAccounts.tokenHash, sha(token)), isNull(serviceAccounts.revokedAt))).limit(1);
+    if (!account || (account.expiresAt && account.expiresAt <= new Date())) { reply.code(401).send({ error: "service_token_invalid" }); return null; }
+    if (scope && !account.scopesJson.includes(scope) && !account.scopesJson.includes("*")) { reply.code(403).send({ error: "service_scope_required", scope }); return null; }
+    await db.update(serviceAccounts).set({ lastUsedAt: new Date() }).where(eq(serviceAccounts.id, account.id));
+    await writeAudit({ workspaceId: account.workspaceId, actorType: "service", actorId: account.id, action: "service_account.authenticated", targetType: "service_account", targetId: account.id, ip: req.ip });
+    return account;
+  }
+
+  app.get("/service-api/whoami", async (req, reply) => {
+    const account = await authenticate(req, reply);
+    if (!account) return;
+    return { account: { id: account.id, name: account.name, workspaceId: account.workspaceId, scopes: account.scopesJson } };
+  });
+
+  app.get("/service-api/workflows", async (req, reply) => {
+    const account = await authenticate(req, reply, "workflows.read");
+    if (!account) return;
+    const rows = await db.select({ id: workflows.id, name: workflows.name, status: workflows.status, triggerType: workflows.triggerType, version: workflows.version })
+      .from(workflows).where(eq(workflows.workspaceId, account.workspaceId)).orderBy(workflows.name);
+    return { workflows: rows };
+  });
+
+  app.post("/service-api/workflows/:id/runs", async (req, reply) => {
+    const account = await authenticate(req, reply, "workflows.run");
+    if (!account) return;
+    const workflowId = (req.params as { id: string }).id;
+    const body = z.object({ input: z.record(z.string(), z.unknown()).default({}) }).parse(req.body ?? {});
+    try {
+      const runId = await startWorkflowRun({ workflowId, workspaceId: account.workspaceId, payload: body.input, createdBy: account.id });
+      await writeAudit({ workspaceId: account.workspaceId, actorType: "service", actorId: account.id, action: "service_account.workflow_started", targetType: "workflow_run", targetId: runId, meta: { workflowId }, ip: req.ip });
+      return reply.code(202).send({ runId });
+    } catch (error) {
+      const message = (error as Error).message;
+      return reply.code(message === "workflow_not_found" ? 404 : 409).send({ error: message });
+    }
+  });
+}

--- a/api/src/routes/model-routing.ts
+++ b/api/src/routes/model-routing.ts
@@ -1,0 +1,93 @@
+import { FastifyInstance } from "fastify";
+import { and, desc, eq, gte, sql } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db/index.js";
+import { modelRoutes, modelUsageEvents } from "../db/schema.js";
+import { requireWorkspace } from "../auth/session.js";
+
+const Tiers = ["economy", "balanced", "frontier", "advisor"] as const;
+
+export default async function modelRoutingRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/model-routing", { preHandler: requireWorkspace }, async (req) => {
+    const workspaceId = req.auth!.workspaceId!;
+    const query = z.object({ days: z.coerce.number().int().min(1).max(365).default(30) }).parse(req.query ?? {});
+    const since = new Date(Date.now() - query.days * 24 * 60 * 60 * 1000);
+    const routes = await db
+      .select()
+      .from(modelRoutes)
+      .where(eq(modelRoutes.workspaceId, workspaceId))
+      .orderBy(modelRoutes.tier);
+    const usage = await db
+      .select({
+        provider: modelUsageEvents.provider,
+        model: modelUsageEvents.model,
+        routeTier: modelUsageEvents.routeTier,
+        source: modelUsageEvents.source,
+        inputTokens: sql<number>`sum(${modelUsageEvents.inputTokens})::int`,
+        outputTokens: sql<number>`sum(${modelUsageEvents.outputTokens})::int`,
+        cachedInputTokens: sql<number>`sum(${modelUsageEvents.cachedInputTokens})::int`,
+        costUsd: sql<number>`sum(${modelUsageEvents.costUsd})::float`,
+        events: sql<number>`count(*)::int`,
+      })
+      .from(modelUsageEvents)
+      .where(and(eq(modelUsageEvents.workspaceId, workspaceId), gte(modelUsageEvents.occurredAt, since)))
+      .groupBy(
+        modelUsageEvents.provider,
+        modelUsageEvents.model,
+        modelUsageEvents.routeTier,
+        modelUsageEvents.source,
+      )
+      .orderBy(desc(sql`sum(${modelUsageEvents.costUsd})`));
+    return {
+      tiers: Tiers,
+      routes,
+      usage,
+      totals: usage.reduce(
+        (total, row) => ({
+          inputTokens: total.inputTokens + row.inputTokens,
+          outputTokens: total.outputTokens + row.outputTokens,
+          cachedInputTokens: total.cachedInputTokens + row.cachedInputTokens,
+          costUsd: total.costUsd + row.costUsd,
+          events: total.events + row.events,
+          reportedEvents: total.reportedEvents + (row.source === "reported" ? row.events : 0),
+        }),
+        { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, costUsd: 0, events: 0, reportedEvents: 0 },
+      ),
+    };
+  });
+
+  app.put("/model-routing/:tier", { preHandler: requireWorkspace }, async (req, reply) => {
+    const tier = z.enum(Tiers).parse((req.params as { tier: string }).tier);
+    const body = z
+      .object({
+        provider: z.string().min(1).max(60),
+        model: z.string().min(1).max(120),
+        inputCostPerMtok: z.number().min(0).max(1_000),
+        outputCostPerMtok: z.number().min(0).max(1_000),
+        cachedInputCostPerMtok: z.number().min(0).max(1_000).default(0),
+        contextWindow: z.number().int().min(1_000).max(100_000_000).nullable().optional(),
+        enabled: z.boolean().default(true),
+      })
+      .parse(req.body);
+    const workspaceId = req.auth!.workspaceId!;
+    await db
+      .insert(modelRoutes)
+      .values({
+        workspaceId,
+        tier,
+        ...body,
+        contextWindow: body.contextWindow ?? null,
+        updatedBy: req.auth!.memberId!,
+      })
+      .onConflictDoUpdate({
+        target: [modelRoutes.workspaceId, modelRoutes.tier],
+        set: { ...body, contextWindow: body.contextWindow ?? null, updatedBy: req.auth!.memberId!, updatedAt: new Date() },
+      });
+    const [route] = await db
+      .select()
+      .from(modelRoutes)
+      .where(and(eq(modelRoutes.workspaceId, workspaceId), eq(modelRoutes.tier, tier)))
+      .limit(1);
+    return reply.send({ route });
+  });
+}

--- a/api/src/routes/needs-you.ts
+++ b/api/src/routes/needs-you.ts
@@ -1,0 +1,69 @@
+import type { FastifyInstance } from "fastify";
+import { and, desc, eq, gt, inArray } from "drizzle-orm";
+import { db } from "../db/index.js";
+import {
+  agents,
+  approvals,
+  connectors,
+  goalLedgers,
+  goals,
+  hostedApps,
+  taskVerifications,
+  tasks,
+  workflowRuns,
+  workflows,
+  workspaces,
+} from "../db/schema.js";
+import { requireWorkspace } from "../auth/session.js";
+
+type ReviewItem = {
+  id: string;
+  kind: "approval" | "task_review" | "verification_failed" | "stalled_goal" | "workflow_wait" | "workflow_failed" | "budget" | "connector_error" | "app_publish";
+  priority: "critical" | "high" | "normal";
+  title: string;
+  detail: string;
+  link: string;
+  targetId: string;
+  createdAt: string;
+  actions: string[];
+};
+
+export default async function needsYouRoutes(app: FastifyInstance): Promise<void> {
+  app.addHook("preHandler", requireWorkspace);
+
+  app.get("/needs-you", async (req) => {
+    const workspaceId = req.auth!.workspaceId!;
+    const workspaceAgents = await db.select({ id: agents.id, name: agents.name, budgetWarnedAt: agents.budgetWarnedAt, pauseReason: agents.pauseReason })
+      .from(agents).where(eq(agents.workspaceId, workspaceId));
+    const agentIds = workspaceAgents.map((agent) => agent.id);
+    const [approvalRows, reviewTasks, failedVerdicts, stalledGoals, waits, failures, connectorErrors, pendingApps, workspace] = await Promise.all([
+      agentIds.length ? db.select({ approval: approvals, agentName: agents.name }).from(approvals).innerJoin(agents, eq(agents.id, approvals.agentId)).where(and(inArray(approvals.agentId, agentIds), eq(approvals.status, "pending"))).orderBy(desc(approvals.createdAt)) : [],
+      db.select().from(tasks).where(and(eq(tasks.workspaceId, workspaceId), eq(tasks.status, "review"), eq(tasks.archived, false))).orderBy(desc(tasks.updatedAt)),
+      db.select({ verification: taskVerifications, taskTitle: tasks.title }).from(taskVerifications).innerJoin(tasks, eq(tasks.id, taskVerifications.taskId)).where(and(eq(taskVerifications.workspaceId, workspaceId), eq(taskVerifications.verdict, "fail"))).orderBy(desc(taskVerifications.createdAt)),
+      db.select({ ledger: goalLedgers, title: goals.title }).from(goalLedgers).innerJoin(goals, eq(goals.id, goalLedgers.goalId)).where(and(eq(goalLedgers.workspaceId, workspaceId), gt(goalLedgers.stallCount, 0))).orderBy(desc(goalLedgers.updatedAt)),
+      db.select({ run: workflowRuns, name: workflows.name }).from(workflowRuns).innerJoin(workflows, eq(workflows.id, workflowRuns.workflowId)).where(and(eq(workflowRuns.workspaceId, workspaceId), eq(workflowRuns.status, "waiting"), eq(workflowRuns.waitKind, "human"))).orderBy(desc(workflowRuns.updatedAt)),
+      db.select({ run: workflowRuns, name: workflows.name }).from(workflowRuns).innerJoin(workflows, eq(workflows.id, workflowRuns.workflowId)).where(and(eq(workflowRuns.workspaceId, workspaceId), eq(workflowRuns.status, "failed"))).orderBy(desc(workflowRuns.updatedAt)).limit(20),
+      db.select().from(connectors).where(and(eq(connectors.workspaceId, workspaceId), eq(connectors.status, "error"))).orderBy(desc(connectors.updatedAt)),
+      db.select().from(hostedApps).where(and(eq(hostedApps.workspaceId, workspaceId), eq(hostedApps.status, "pending"))).orderBy(desc(hostedApps.updatedAt)),
+      db.select({ budgetWarnedAt: workspaces.budgetWarnedAt, budgetStoppedAt: workspaces.budgetStoppedAt, budgetUsdMonth: workspaces.budgetUsdMonth }).from(workspaces).where(eq(workspaces.id, workspaceId)).limit(1).then((rows) => rows[0]),
+    ]);
+
+    const items: ReviewItem[] = [];
+    for (const row of approvalRows) items.push({ id: `approval:${row.approval.id}`, kind: "approval", priority: "high", title: `${row.agentName} needs approval`, detail: `${row.approval.scope}: ${row.approval.action}`, link: "/needs-you", targetId: row.approval.id, createdAt: row.approval.createdAt.toISOString(), actions: ["approve", "deny"] });
+    for (const task of reviewTasks) items.push({ id: `task:${task.id}`, kind: "task_review", priority: "normal", title: task.title, detail: "Task is ready for human review.", link: `/board?task=${task.id}`, targetId: task.id, createdAt: task.updatedAt.toISOString(), actions: ["open"] });
+    const latestFailed = new Map<string, (typeof failedVerdicts)[number]>();
+    for (const row of failedVerdicts) if (!latestFailed.has(row.verification.taskId)) latestFailed.set(row.verification.taskId, row);
+    for (const row of latestFailed.values()) items.push({ id: `verification:${row.verification.id}`, kind: "verification_failed", priority: "high", title: `Verification failed: ${row.taskTitle}`, detail: row.verification.rationale || `Score ${row.verification.score ?? "n/a"}`, link: `/board?task=${row.verification.taskId}`, targetId: row.verification.taskId, createdAt: row.verification.createdAt.toISOString(), actions: ["open"] });
+    for (const row of stalledGoals) items.push({ id: `goal:${row.ledger.goalId}`, kind: "stalled_goal", priority: row.ledger.stallCount >= 3 ? "critical" : "high", title: `Stalled goal: ${row.title}`, detail: `${row.ledger.stallCount} stalled assessment(s); ${row.ledger.replanCount} re-plan(s).`, link: "/goals", targetId: row.ledger.goalId, createdAt: row.ledger.updatedAt.toISOString(), actions: ["open"] });
+    for (const row of waits) items.push({ id: `workflow-wait:${row.run.id}`, kind: "workflow_wait", priority: "high", title: `${row.name} is waiting for you`, detail: `State ${row.run.currentStateId ?? "unknown"}`, link: "/automation", targetId: row.run.id, createdAt: row.run.updatedAt.toISOString(), actions: ["resume", "cancel", "steer"] });
+    for (const row of failures) items.push({ id: `workflow-failed:${row.run.id}`, kind: "workflow_failed", priority: "high", title: `${row.name} failed`, detail: row.run.errorText ?? "Workflow failed without an error message.", link: "/automation", targetId: row.run.id, createdAt: row.run.updatedAt.toISOString(), actions: ["open"] });
+    for (const connector of connectorErrors) items.push({ id: `connector:${connector.id}`, kind: "connector_error", priority: "high", title: `Connector error: ${connector.name}`, detail: connector.lastError ?? "Health check failed.", link: "/automation", targetId: connector.id, createdAt: connector.updatedAt.toISOString(), actions: ["recheck"] });
+    for (const hosted of pendingApps) items.push({ id: `app:${hosted.id}`, kind: "app_publish", priority: "high", title: `Publish ${hosted.name}?`, detail: "Preview passed creation checks and is waiting for a human release decision.", link: "/platform", targetId: hosted.id, createdAt: hosted.updatedAt.toISOString(), actions: ["approve", "reject", "preview"] });
+    if (workspace?.budgetWarnedAt || workspace?.budgetStoppedAt) items.push({ id: "budget:workspace", kind: "budget", priority: workspace.budgetStoppedAt ? "critical" : "high", title: workspace.budgetStoppedAt ? "Workspace budget stopped runs" : "Workspace budget warning", detail: workspace.budgetUsdMonth == null ? "Budget policy needs attention." : `Monthly cap: $${workspace.budgetUsdMonth.toFixed(2)}`, link: "/settings", targetId: workspaceId, createdAt: (workspace.budgetStoppedAt ?? workspace.budgetWarnedAt)!.toISOString(), actions: ["open"] });
+    for (const agent of workspaceAgents.filter((row) => row.budgetWarnedAt || row.pauseReason === "budget")) items.push({ id: `budget:${agent.id}`, kind: "budget", priority: agent.pauseReason === "budget" ? "critical" : "high", title: `${agent.name} budget needs attention`, detail: agent.pauseReason === "budget" ? "Agent is paused at its hard cap." : "Agent crossed its warning threshold.", link: `/agents/${agent.id}`, targetId: agent.id, createdAt: (agent.budgetWarnedAt ?? new Date()).toISOString(), actions: ["open"] });
+
+    const priority = { critical: 0, high: 1, normal: 2 } as const;
+    items.sort((a, b) => priority[a.priority] - priority[b.priority] || Date.parse(b.createdAt) - Date.parse(a.createdAt));
+    return { items, counts: { total: items.length, critical: items.filter((item) => item.priority === "critical").length, high: items.filter((item) => item.priority === "high").length } };
+  });
+}

--- a/api/src/routes/platform.ts
+++ b/api/src/routes/platform.ts
@@ -1,0 +1,575 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db/index.js";
+import {
+  agents,
+  appDeployments,
+  appLogs,
+  boardStages,
+  connectors,
+  conversationMembers,
+  conversations,
+  decisionMemories,
+  hostedApps,
+  members,
+  prRooms,
+  taskArtifacts,
+  tasks,
+  teamBlueprints,
+  workflows,
+} from "../db/schema.js";
+import { requireWorkspace } from "../auth/session.js";
+import { id, rawToken } from "../lib/ids.js";
+import { config } from "../lib/config.js";
+import { readObject } from "../lib/storage.js";
+import { invokeConnector } from "../lib/connector-runtime.js";
+import { parseWorkflowDefinition } from "../lib/workflow-definition.js";
+import { requirePermission, writeAudit } from "../lib/access-control.js";
+import {
+  appContentSecurityPolicy,
+  BOARD_STAGE_KEYS,
+  DECISION_KINDS,
+  normalizePrSnapshot,
+  safeSlug,
+  StageRulesSchema,
+  TeamBlueprintSchema,
+  type NormalizedPrSnapshot,
+} from "../lib/p1-platform.js";
+
+const DecisionBody = z.object({
+  kind: z.enum(DECISION_KINDS),
+  title: z.string().min(1).max(180),
+  decision: z.string().min(1).max(20_000),
+  rationale: z.string().max(20_000).optional(),
+  alternatives: z.array(z.string().max(5_000)).max(30).optional(),
+  provenance: z.record(z.string(), z.unknown()).optional(),
+  source: z.enum(["observer", "reflector", "human", "agent"]).optional(),
+});
+
+const StageBody = z.object({
+  title: z.string().min(1).max(80),
+  position: z.number().int().min(0).max(100),
+  instructions: z.string().max(10_000).optional(),
+  entryRules: StageRulesSchema.optional(),
+  exitRules: StageRulesSchema.optional(),
+  agentId: z.string().nullable().optional(),
+  skill: z.string().max(120).nullable().optional(),
+  verification: z.enum(["none", "artifact", "judge", "human"]).optional(),
+  escalationMemberId: z.string().nullable().optional(),
+  nextStage: z.enum(BOARD_STAGE_KEYS).nullable().optional(),
+});
+
+const AppBody = z.object({
+  taskId: z.string().min(1),
+  artifactId: z.string().min(1),
+  name: z.string().min(1).max(140),
+  slug: z.string().max(80).optional(),
+});
+
+const PrRoomBody = z.object({
+  conversationId: z.string().min(1),
+  connectorId: z.string().nullable().optional(),
+  provider: z.enum(["github", "gitlab"]),
+  repository: z.string().min(1).max(240),
+  prNumber: z.number().int().positive(),
+  snapshot: z.unknown().optional(),
+});
+
+const DEFAULT_STAGES = [
+  { stage: "backlog", title: "Backlog", position: 0, nextStage: "in_progress" },
+  { stage: "in_progress", title: "In progress", position: 1, nextStage: "review" },
+  { stage: "blocked", title: "Blocked", position: 2, nextStage: "in_progress" },
+  { stage: "review", title: "Review", position: 3, nextStage: "done" },
+  { stage: "done", title: "Done", position: 4, nextStage: null },
+] as const;
+
+function baseUrl(): string {
+  return config.publicBaseUrl.replace(/\/$/, "");
+}
+async function canWrite(req: FastifyRequest, reply: FastifyReply, permission = "workspace.write"): Promise<boolean> {
+  if (await requirePermission(req, permission)) return true;
+  reply.code(403).send({ error: "permission_denied", permission });
+  return false;
+}
+
+async function audit(req: FastifyRequest, action: string, targetType: string, targetId?: string, meta?: Record<string, unknown>) {
+  await writeAudit({
+    workspaceId: req.auth!.workspaceId!,
+    actorId: req.auth!.memberId!,
+    action,
+    targetType,
+    targetId,
+    meta,
+    ip: req.ip,
+  });
+}
+
+export default async function platformRoutes(app: FastifyInstance): Promise<void> {
+  app.addHook("preHandler", requireWorkspace);
+
+  // ── Decision / precedent memory ───────────────────────────────────────
+  app.get("/decisions", async (req) => {
+    const rows = await db
+      .select()
+      .from(decisionMemories)
+      .where(eq(decisionMemories.workspaceId, req.auth!.workspaceId!))
+      .orderBy(desc(decisionMemories.createdAt));
+    return { decisions: rows };
+  });
+
+  app.post("/decisions/observe", async (req, reply) => {
+    if (!(await canWrite(req, reply))) return;
+    const body = DecisionBody.parse(req.body);
+    const memoryId = id("dec");
+    await db.insert(decisionMemories).values({
+      id: memoryId,
+      workspaceId: req.auth!.workspaceId!,
+      kind: body.kind,
+      title: body.title,
+      decision: body.decision,
+      rationale: body.rationale ?? "",
+      alternativesJson: body.alternatives ?? [],
+      provenanceJson: body.provenance ?? {},
+      source: body.source ?? "observer",
+      createdBy: req.auth!.memberId!,
+    });
+    await audit(req, "decision.observed", "decision", memoryId, { kind: body.kind, source: body.source ?? "observer" });
+    const [memory] = await db.select().from(decisionMemories).where(eq(decisionMemories.id, memoryId)).limit(1);
+    return reply.code(201).send({ memory });
+  });
+
+  app.post("/decisions/:id/correct", async (req, reply) => {
+    if (!(await canWrite(req, reply))) return;
+    const priorId = (req.params as { id: string }).id;
+    const body = DecisionBody.parse(req.body);
+    const [prior] = await db
+      .select()
+      .from(decisionMemories)
+      .where(and(eq(decisionMemories.id, priorId), eq(decisionMemories.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!prior) return reply.code(404).send({ error: "decision_not_found" });
+    if (prior.status !== "active") return reply.code(409).send({ error: "decision_not_active" });
+    const nextId = id("dec");
+    await db.transaction(async (tx) => {
+      await tx.update(decisionMemories).set({ status: "corrected", correctedAt: new Date() }).where(eq(decisionMemories.id, priorId));
+      await tx.insert(decisionMemories).values({
+        id: nextId,
+        workspaceId: prior.workspaceId,
+        kind: body.kind,
+        title: body.title,
+        decision: body.decision,
+        rationale: body.rationale ?? "",
+        alternativesJson: body.alternatives ?? [],
+        provenanceJson: { ...body.provenance, correctionOf: priorId },
+        source: "human",
+        supersedesId: priorId,
+        createdBy: req.auth!.memberId!,
+      });
+    });
+    await audit(req, "decision.corrected", "decision", nextId, { supersedesId: priorId });
+    const [memory] = await db.select().from(decisionMemories).where(eq(decisionMemories.id, nextId)).limit(1);
+    return { memory };
+  });
+
+  // ── Isolated app preview and approval-gated publication ───────────────
+  app.get("/apps", async (req) => {
+    const rows = await db.select().from(hostedApps).where(eq(hostedApps.workspaceId, req.auth!.workspaceId!)).orderBy(desc(hostedApps.updatedAt));
+    const ids = rows.map((row) => row.id);
+    const [deployments, logs] = ids.length
+      ? await Promise.all([
+          db.select().from(appDeployments).where(inArray(appDeployments.appId, ids)).orderBy(desc(appDeployments.createdAt)),
+          db.select().from(appLogs).where(inArray(appLogs.appId, ids)).orderBy(desc(appLogs.createdAt)),
+        ])
+      : [[], []];
+    return {
+      apps: rows.map((row) => ({
+        ...row,
+        previewUrl: `${baseUrl()}/app-preview/${row.previewToken}`,
+        publicUrl: `${baseUrl()}/apps/${row.slug}`,
+        deployments: deployments.filter((deployment) => deployment.appId === row.id),
+        logs: logs.filter((log) => log.appId === row.id).slice(0, 20),
+      })),
+    };
+  });
+
+  app.post("/apps", async (req, reply) => {
+    if (!(await canWrite(req, reply))) return;
+    const body = AppBody.parse(req.body);
+    const [artifact] = await db
+      .select({ artifact: taskArtifacts, taskWorkspaceId: tasks.workspaceId })
+      .from(taskArtifacts)
+      .innerJoin(tasks, eq(tasks.id, taskArtifacts.taskId))
+      .where(and(eq(taskArtifacts.id, body.artifactId), eq(taskArtifacts.taskId, body.taskId)))
+      .limit(1);
+    if (!artifact || artifact.taskWorkspaceId !== req.auth!.workspaceId! || artifact.artifact.deletedAt) {
+      return reply.code(404).send({ error: "artifact_not_found" });
+    }
+    if (!artifact.artifact.contentType.includes("html") || artifact.artifact.size > 2 * 1024 * 1024) {
+      return reply.code(422).send({ error: "html_artifact_required", maxBytes: 2 * 1024 * 1024 });
+    }
+    const appId = id("app");
+    const deploymentId = id("deploy");
+    const suffix = rawToken(6).toLowerCase();
+    const slug = `${safeSlug(body.slug ?? body.name)}-${suffix}`.slice(0, 80);
+    await db.transaction(async (tx) => {
+      await tx.insert(hostedApps).values({
+        id: appId,
+        workspaceId: req.auth!.workspaceId!,
+        taskId: body.taskId,
+        name: body.name,
+        slug,
+        previewToken: rawToken(40),
+        activeDeploymentId: deploymentId,
+        createdBy: req.auth!.memberId!,
+      });
+      await tx.insert(appDeployments).values({
+        id: deploymentId,
+        appId,
+        artifactId: body.artifactId,
+        artifactSha256: artifact.artifact.sha256,
+        status: "preview",
+        requestedBy: req.auth!.memberId!,
+      });
+      await tx.insert(appLogs).values({ id: id("applog"), appId, deploymentId, event: "preview.created", message: artifact.artifact.name });
+    });
+    await audit(req, "app.preview_created", "app", appId, { deploymentId, artifactId: body.artifactId });
+    return reply.code(201).send({ appId, deploymentId });
+  });
+
+  app.post("/apps/:id/request-publish", async (req, reply) => {
+    if (!(await canWrite(req, reply, "apps.request_publish"))) return;
+    const appId = (req.params as { id: string }).id;
+    const [row] = await db.select().from(hostedApps).where(and(eq(hostedApps.id, appId), eq(hostedApps.workspaceId, req.auth!.workspaceId!))).limit(1);
+    if (!row || !row.activeDeploymentId) return reply.code(404).send({ error: "app_not_found" });
+    if (row.status !== "preview") return reply.code(409).send({ error: "app_not_in_preview" });
+    await db.transaction(async (tx) => {
+      await tx.update(hostedApps).set({ status: "pending", updatedAt: new Date() }).where(eq(hostedApps.id, appId));
+      await tx.update(appDeployments).set({ status: "pending" }).where(eq(appDeployments.id, row.activeDeploymentId!));
+      await tx.insert(appLogs).values({ id: id("applog"), appId, deploymentId: row.activeDeploymentId, event: "publish.requested", message: "Awaiting human approval" });
+    });
+    await audit(req, "app.publish_requested", "app", appId);
+    return { ok: true, status: "pending" };
+  });
+
+  app.post("/apps/:id/review", async (req, reply) => {
+    if (!(await canWrite(req, reply, "*"))) return;
+    const appId = (req.params as { id: string }).id;
+    const body = z.object({ decision: z.enum(["approve", "reject"]), note: z.string().max(2_000).optional() }).parse(req.body);
+    const [row] = await db.select().from(hostedApps).where(and(eq(hostedApps.id, appId), eq(hostedApps.workspaceId, req.auth!.workspaceId!))).limit(1);
+    if (!row || !row.activeDeploymentId) return reply.code(404).send({ error: "app_not_found" });
+    if (row.status !== "pending") return reply.code(409).send({ error: "app_not_pending" });
+    const approved = body.decision === "approve";
+    await db.transaction(async (tx) => {
+      await tx.update(hostedApps).set({ status: approved ? "published" : "preview", updatedAt: new Date() }).where(eq(hostedApps.id, appId));
+      await tx.update(appDeployments).set({
+        status: approved ? "published" : "rejected",
+        reviewedBy: req.auth!.memberId!,
+        reviewNote: body.note ?? null,
+        publishedAt: approved ? new Date() : null,
+      }).where(eq(appDeployments.id, row.activeDeploymentId!));
+      await tx.insert(appLogs).values({
+        id: id("applog"), appId, deploymentId: row.activeDeploymentId,
+        event: approved ? "publish.approved" : "publish.rejected", message: body.note ?? "",
+      });
+    });
+    await audit(req, `app.publish_${approved ? "approved" : "rejected"}`, "app", appId, { note: body.note ?? "" });
+    return { ok: true, status: approved ? "published" : "preview" };
+  });
+
+  app.get("/apps/:id/health", async (req, reply) => {
+    const appId = (req.params as { id: string }).id;
+    const [row] = await db
+      .select({ app: hostedApps, deployment: appDeployments, artifact: taskArtifacts })
+      .from(hostedApps)
+      .innerJoin(appDeployments, eq(appDeployments.id, hostedApps.activeDeploymentId))
+      .innerJoin(taskArtifacts, eq(taskArtifacts.id, appDeployments.artifactId))
+      .where(and(eq(hostedApps.id, appId), eq(hostedApps.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!row) return reply.code(404).send({ error: "app_not_found" });
+    const bytes = await readObject(row.artifact.storageKey);
+    const healthy = Boolean(bytes && bytes.length === row.artifact.size && row.artifact.deletedAt === null);
+    await db.update(appDeployments).set({ healthStatus: healthy ? "healthy" : "error" }).where(eq(appDeployments.id, row.deployment.id));
+    return { healthy, status: row.app.status, deploymentId: row.deployment.id, bytes: bytes?.length ?? 0 };
+  });
+
+  // ── Provider-backed PR rooms ──────────────────────────────────────────
+  app.get("/pr-rooms", async (req) => {
+    const rows = await db.select().from(prRooms).where(eq(prRooms.workspaceId, req.auth!.workspaceId!)).orderBy(desc(prRooms.createdAt));
+    return { rooms: rows };
+  });
+
+  app.post("/pr-rooms", async (req, reply) => {
+    if (!(await canWrite(req, reply))) return;
+    const body = PrRoomBody.parse(req.body);
+    const [conversation] = await db.select().from(conversations).where(and(eq(conversations.id, body.conversationId), eq(conversations.workspaceId, req.auth!.workspaceId!))).limit(1);
+    if (!conversation || conversation.kind !== "channel") return reply.code(404).send({ error: "channel_not_found" });
+    if (body.connectorId) {
+      const [connector] = await db.select({ id: connectors.id }).from(connectors).where(and(eq(connectors.id, body.connectorId), eq(connectors.workspaceId, req.auth!.workspaceId!))).limit(1);
+      if (!connector) return reply.code(404).send({ error: "connector_not_found" });
+    }
+    const snapshot = body.snapshot === undefined ? emptyPrSnapshot() : normalizePrSnapshot(body.provider, body.snapshot);
+    const roomId = id("prroom");
+    await db.insert(prRooms).values({
+      id: roomId,
+      workspaceId: req.auth!.workspaceId!,
+      conversationId: body.conversationId,
+      connectorId: body.connectorId ?? null,
+      provider: body.provider,
+      repository: body.repository,
+      prNumber: body.prNumber,
+      title: snapshot.title,
+      url: snapshot.url,
+      state: snapshot.state,
+      headRef: snapshot.headRef,
+      baseRef: snapshot.baseRef,
+      diffJson: snapshot.diff,
+      checksJson: snapshot.checks,
+      reviewsJson: snapshot.reviews,
+      protectionJson: snapshot.protection,
+      lastSyncedAt: body.snapshot === undefined ? null : new Date(),
+      createdBy: req.auth!.memberId!,
+    });
+    await audit(req, "pr_room.created", "pr_room", roomId, { provider: body.provider, repository: body.repository, prNumber: body.prNumber });
+    return reply.code(201).send({ roomId });
+  });
+
+  app.post("/pr-rooms/:id/sync", async (req, reply) => {
+    if (!(await canWrite(req, reply))) return;
+    const roomId = (req.params as { id: string }).id;
+    const body = z.object({ snapshot: z.unknown().optional() }).parse(req.body ?? {});
+    const [room] = await db.select().from(prRooms).where(and(eq(prRooms.id, roomId), eq(prRooms.workspaceId, req.auth!.workspaceId!))).limit(1);
+    if (!room) return reply.code(404).send({ error: "pr_room_not_found" });
+    try {
+      const snapshot = body.snapshot === undefined ? await fetchPrSnapshot(room) : normalizePrSnapshot(room.provider as "github" | "gitlab", body.snapshot);
+      await db.update(prRooms).set({
+        title: snapshot.title, url: snapshot.url, state: snapshot.state,
+        headRef: snapshot.headRef, baseRef: snapshot.baseRef,
+        diffJson: snapshot.diff, checksJson: snapshot.checks, reviewsJson: snapshot.reviews,
+        protectionJson: snapshot.protection, lastSyncedAt: new Date(), lastError: null,
+      }).where(eq(prRooms.id, roomId));
+      await audit(req, "pr_room.synced", "pr_room", roomId, { checks: snapshot.checks.length, files: snapshot.diff.length });
+      return { room: { ...room, ...snapshot, lastSyncedAt: new Date().toISOString() } };
+    } catch (error) {
+      const message = (error as Error).message.slice(0, 500);
+      await db.update(prRooms).set({ lastError: message, lastSyncedAt: new Date() }).where(eq(prRooms.id, roomId));
+      return reply.code(502).send({ error: "pr_sync_failed", detail: message });
+    }
+  });
+
+  // ── Executable board stages ───────────────────────────────────────────
+  app.get("/board-stages", async (req) => {
+    const stored = await db.select().from(boardStages).where(eq(boardStages.workspaceId, req.auth!.workspaceId!)).orderBy(asc(boardStages.position));
+    const byKey = new Map(stored.map((stage) => [stage.stage, stage]));
+    return {
+      stages: DEFAULT_STAGES.map((fallback) => byKey.get(fallback.stage) ?? {
+        workspaceId: req.auth!.workspaceId!, stage: fallback.stage, title: fallback.title,
+        position: fallback.position, instructions: "", entryRulesJson: {}, exitRulesJson: {},
+        agentId: null, skill: null, verification: "none", escalationMemberId: null,
+        nextStage: fallback.nextStage, updatedBy: null, updatedAt: null,
+      }).sort((a, b) => a.position - b.position),
+    };
+  });
+
+  app.put("/board-stages/:stage", async (req, reply) => {
+    if (!(await canWrite(req, reply))) return;
+    const stage = z.enum(BOARD_STAGE_KEYS).parse((req.params as { stage: string }).stage);
+    const body = StageBody.parse(req.body);
+    if (body.agentId) {
+      const [agent] = await db.select({ id: agents.id }).from(agents).where(and(eq(agents.id, body.agentId), eq(agents.workspaceId, req.auth!.workspaceId!))).limit(1);
+      if (!agent) return reply.code(404).send({ error: "agent_not_found" });
+    }
+    await db.insert(boardStages).values({
+      workspaceId: req.auth!.workspaceId!, stage, title: body.title, position: body.position,
+      instructions: body.instructions ?? "", entryRulesJson: body.entryRules ?? {}, exitRulesJson: body.exitRules ?? {},
+      agentId: body.agentId ?? null, skill: body.skill ?? null, verification: body.verification ?? "none",
+      escalationMemberId: body.escalationMemberId ?? null, nextStage: body.nextStage ?? null,
+      updatedBy: req.auth!.memberId!,
+    }).onConflictDoUpdate({
+      target: [boardStages.workspaceId, boardStages.stage],
+      set: {
+        title: body.title, position: body.position, instructions: body.instructions ?? "",
+        entryRulesJson: body.entryRules ?? {}, exitRulesJson: body.exitRules ?? {}, agentId: body.agentId ?? null,
+        skill: body.skill ?? null, verification: body.verification ?? "none",
+        escalationMemberId: body.escalationMemberId ?? null, nextStage: body.nextStage ?? null,
+        updatedBy: req.auth!.memberId!, updatedAt: new Date(),
+      },
+    });
+    await audit(req, "board_stage.configured", "board_stage", stage, { verification: body.verification ?? "none" });
+    const [row] = await db.select().from(boardStages).where(and(eq(boardStages.workspaceId, req.auth!.workspaceId!), eq(boardStages.stage, stage))).limit(1);
+    return { stage: row };
+  });
+
+  // ── Versioned, reusable team blueprints ───────────────────────────────
+  app.get("/team-blueprints", async (req) => {
+    const rows = await db.select().from(teamBlueprints).where(eq(teamBlueprints.workspaceId, req.auth!.workspaceId!)).orderBy(desc(teamBlueprints.updatedAt));
+    return { blueprints: rows };
+  });
+
+  app.post("/team-blueprints", async (req, reply) => {
+    if (!(await canWrite(req, reply))) return;
+    const body = z.object({
+      name: z.string().min(1).max(140), description: z.string().max(3_000).optional(),
+      definition: TeamBlueprintSchema.optional(), exportWorkspace: z.boolean().optional(),
+    }).parse(req.body);
+    const definition = body.exportWorkspace ? await exportWorkspaceBlueprint(req.auth!.workspaceId!) : TeamBlueprintSchema.parse(body.definition ?? {});
+    const [latest] = await db.select({ version: teamBlueprints.version }).from(teamBlueprints)
+      .where(and(eq(teamBlueprints.workspaceId, req.auth!.workspaceId!), eq(teamBlueprints.name, body.name)))
+      .orderBy(desc(teamBlueprints.version)).limit(1);
+    const blueprintId = id("blueprint");
+    const version = (latest?.version ?? 0) + 1;
+    await db.insert(teamBlueprints).values({
+      id: blueprintId, workspaceId: req.auth!.workspaceId!, name: body.name,
+      description: body.description ?? "", version, definitionJson: definition,
+      createdBy: req.auth!.memberId!,
+    });
+    await audit(req, "blueprint.created", "team_blueprint", blueprintId, { version, exportWorkspace: Boolean(body.exportWorkspace) });
+    return reply.code(201).send({ blueprintId, version, definition });
+  });
+
+  app.post("/team-blueprints/:id/apply", async (req, reply) => {
+    if (!(await canWrite(req, reply))) return;
+    const blueprintId = (req.params as { id: string }).id;
+    const [blueprint] = await db.select().from(teamBlueprints).where(and(eq(teamBlueprints.id, blueprintId), eq(teamBlueprints.workspaceId, req.auth!.workspaceId!))).limit(1);
+    if (!blueprint) return reply.code(404).send({ error: "blueprint_not_found" });
+    const result = await applyBlueprint(TeamBlueprintSchema.parse(blueprint.definitionJson), req.auth!.workspaceId!, req.auth!.memberId!);
+    await audit(req, "blueprint.applied", "team_blueprint", blueprintId, result);
+    return reply.code(201).send(result);
+  });
+}
+
+function emptyPrSnapshot(): NormalizedPrSnapshot {
+  return { title: "", url: "", state: "open", headRef: "", baseRef: "", diff: [], checks: [], reviews: [], protection: {} };
+}
+
+async function connectorCall(connector: typeof connectors.$inferSelect, path: string): Promise<unknown> {
+  return (await invokeConnector(connector, { method: "GET", path, input: {}, steps: {} })).data;
+}
+
+async function fetchPrSnapshot(room: typeof prRooms.$inferSelect): Promise<NormalizedPrSnapshot> {
+  if (!room.connectorId) throw new Error("connector_required");
+  const [connector] = await db.select().from(connectors).where(and(eq(connectors.id, room.connectorId), eq(connectors.workspaceId, room.workspaceId))).limit(1);
+  if (!connector) throw new Error("connector_not_found");
+  if (room.provider === "github") {
+    const prefix = `repos/${room.repository}/pulls/${room.prNumber}`;
+    const pull = await connectorCall(connector, prefix) as Record<string, unknown>;
+    const sha = String((pull.head as Record<string, unknown> | undefined)?.sha ?? "");
+    const baseRef = String((pull.base as Record<string, unknown> | undefined)?.ref ?? "");
+    const [files, reviews, checks, protection] = await Promise.all([
+      connectorCall(connector, `${prefix}/files`),
+      connectorCall(connector, `${prefix}/reviews`),
+      sha ? connectorCall(connector, `repos/${room.repository}/commits/${sha}/check-runs`) : Promise.resolve([]),
+      baseRef ? connectorCall(connector, `repos/${room.repository}/branches/${encodeURIComponent(baseRef)}/protection`).catch(() => ({})) : Promise.resolve({}),
+    ]);
+    return normalizePrSnapshot("github", { pull, files, reviews, checks: (checks as Record<string, unknown>)?.check_runs ?? checks, protection });
+  }
+  const project = encodeURIComponent(room.repository);
+  const prefix = `projects/${project}/merge_requests/${room.prNumber}`;
+  const [mergeRequest, changes, pipelines, approvals] = await Promise.all([
+    connectorCall(connector, prefix), connectorCall(connector, `${prefix}/changes`),
+    connectorCall(connector, `${prefix}/pipelines`), connectorCall(connector, `${prefix}/approvals`),
+  ]);
+  return normalizePrSnapshot("gitlab", { mergeRequest, changes, pipelines, approvals });
+}
+
+async function exportWorkspaceBlueprint(workspaceId: string) {
+  const [agentRows, memberRows, channelRows, workflowRows] = await Promise.all([
+    db.select().from(agents).where(eq(agents.workspaceId, workspaceId)),
+    db.select().from(members).where(and(eq(members.workspaceId, workspaceId), eq(members.kind, "agent"))),
+    db.select().from(conversations).where(and(eq(conversations.workspaceId, workspaceId), eq(conversations.kind, "channel"))),
+    db.select().from(workflows).where(eq(workflows.workspaceId, workspaceId)),
+  ]);
+  const keyByMember = new Map(memberRows.map((member) => [member.id, agentRows.find((agent) => agent.id === member.refId)?.handle ?? member.refId]));
+  return TeamBlueprintSchema.parse({
+    agents: agentRows.map((agent) => ({
+      key: agent.handle, name: agent.name, handle: agent.handle, title: agent.title, brief: agent.brief,
+      capabilities: agent.capabilities, scopes: agent.scopes, budgetUsdMonth: agent.budgetUsdMonth,
+    })),
+    relationships: memberRows.map((member) => ({ childKey: keyByMember.get(member.id)!, parentKey: member.reportsTo ? keyByMember.get(member.reportsTo) ?? null : null })),
+    skills: agentRows.flatMap((agent) => {
+      const names = Array.isArray(agent.configJson.blueprintSkills) ? agent.configJson.blueprintSkills : [];
+      return names.filter((name): name is string => typeof name === "string").map((name) => ({ agentKey: agent.handle, name }));
+    }),
+    channels: channelRows.map((channel) => ({ name: channel.name ?? "channel", topic: channel.topic })),
+    workflows: workflowRows.map((workflow) => ({ name: workflow.name, description: workflow.description, triggerType: workflow.triggerType, definition: workflow.definitionJson })),
+  });
+}
+
+async function applyBlueprint(definition: z.infer<typeof TeamBlueprintSchema>, workspaceId: string, creatorMemberId: string): Promise<Record<string, number>> {
+  const suffix = rawToken(5).toLowerCase();
+  const memberByKey = new Map<string, string>();
+  for (const spec of definition.agents) {
+    const agentId = id("agent");
+    const memberId = id("m");
+    const handle = `${safeSlug(spec.handle).slice(0, 30)}-${suffix}`.slice(0, 40);
+    const blueprintSkills = definition.skills.filter((skill) => skill.agentKey === spec.key).map((skill) => skill.name);
+    await db.transaction(async (tx) => {
+      await tx.insert(agents).values({
+        id: agentId, workspaceId, handle, name: spec.name, kind: "custom", adapter: "webhook",
+        configJson: { blueprintSkills }, model: "", scopes: spec.scopes ?? [], capabilities: spec.capabilities ?? [],
+        status: "idle", budgetUsdMonth: spec.budgetUsdMonth ?? null, title: spec.title ?? "", brief: spec.brief ?? "",
+        heartbeatIntervalSec: 86_400, botToken: `cc_bot_${rawToken(48)}`, createdBy: creatorMemberId,
+      });
+      await tx.insert(members).values({ id: memberId, workspaceId, kind: "agent", refId: agentId });
+    });
+    memberByKey.set(spec.key, memberId);
+  }
+  for (const relation of definition.relationships) {
+    const child = memberByKey.get(relation.childKey);
+    const parent = relation.parentKey ? memberByKey.get(relation.parentKey) ?? null : null;
+    if (child) await db.update(members).set({ reportsTo: parent }).where(eq(members.id, child));
+  }
+  let channelCount = 0;
+  for (const spec of definition.channels) {
+    const conversationId = id("c");
+    await db.insert(conversations).values({ id: conversationId, workspaceId, kind: "channel", name: `${safeSlug(spec.name)}-${suffix}`.slice(0, 100), topic: spec.topic ?? "", isPrivate: true, createdBy: creatorMemberId });
+    const participantIds = [creatorMemberId, ...(spec.memberKeys ?? []).map((key) => memberByKey.get(key)).filter((value): value is string => Boolean(value))];
+    await db.insert(conversationMembers).values(Array.from(new Set(participantIds)).map((memberId) => ({ conversationId, memberId, role: memberId === creatorMemberId ? "admin" : "member" }))).onConflictDoNothing();
+    channelCount += 1;
+  }
+  let workflowCount = 0;
+  for (const spec of definition.workflows) {
+    const parsed = parseWorkflowDefinition(spec.definition);
+    await db.insert(workflows).values({ id: id("wf"), workspaceId, name: `${spec.name} ${suffix}`, description: spec.description ?? "", triggerType: spec.triggerType ?? "manual", definitionJson: parsed, createdBy: creatorMemberId });
+    workflowCount += 1;
+  }
+  return { agents: definition.agents.length, relationships: definition.relationships.length, skills: definition.skills.length, channels: channelCount, workflows: workflowCount };
+}
+
+export async function appServeRoutes(app: FastifyInstance): Promise<void> {
+  async function serve(reply: FastifyReply, row: { app: typeof hostedApps.$inferSelect; deployment: typeof appDeployments.$inferSelect; artifact: typeof taskArtifacts.$inferSelect }, preview: boolean) {
+    const bytes = await readObject(row.artifact.storageKey);
+    if (!bytes || row.artifact.deletedAt) return reply.code(410).type("text/plain").send("Deployment artifact is unavailable.");
+    void db.insert(appLogs).values({
+      id: id("applog"), appId: row.app.id, deploymentId: row.deployment.id,
+      event: preview ? "preview.request" : "app.request", message: "GET /",
+    }).catch(() => {});
+    return reply
+      .header("content-security-policy", appContentSecurityPolicy())
+      .header("x-content-type-options", "nosniff")
+      .header("referrer-policy", "no-referrer")
+      .header("cache-control", preview ? "no-store" : "public, max-age=60")
+      .type("text/html; charset=utf-8")
+      .send(bytes);
+  }
+
+  app.get("/app-preview/:token", async (req, reply) => {
+    const token = (req.params as { token: string }).token;
+    const [row] = await db.select({ app: hostedApps, deployment: appDeployments, artifact: taskArtifacts })
+      .from(hostedApps).innerJoin(appDeployments, eq(appDeployments.id, hostedApps.activeDeploymentId))
+      .innerJoin(taskArtifacts, eq(taskArtifacts.id, appDeployments.artifactId))
+      .where(eq(hostedApps.previewToken, token)).limit(1);
+    if (!row || row.app.status === "disabled") return reply.code(404).type("text/plain").send("Preview not found.");
+    return serve(reply, row, true);
+  });
+
+  app.get("/apps/:slug", async (req, reply) => {
+    const slug = (req.params as { slug: string }).slug;
+    const [row] = await db.select({ app: hostedApps, deployment: appDeployments, artifact: taskArtifacts })
+      .from(hostedApps).innerJoin(appDeployments, eq(appDeployments.id, hostedApps.activeDeploymentId))
+      .innerJoin(taskArtifacts, eq(taskArtifacts.id, appDeployments.artifactId))
+      .where(and(eq(hostedApps.slug, slug), eq(hostedApps.status, "published"), eq(appDeployments.status, "published"))).limit(1);
+    if (!row) return reply.code(404).type("text/plain").send("App not found.");
+    return serve(reply, row, false);
+  });
+}

--- a/api/src/routes/run-controls.ts
+++ b/api/src/routes/run-controls.ts
@@ -1,0 +1,119 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db/index.js";
+import { agentRuns, agents, workflowRuns } from "../db/schema.js";
+import { requireWorkspace } from "../auth/session.js";
+import { requirePermission, writeAudit } from "../lib/access-control.js";
+import { agentQueue } from "../agents/queue.js";
+
+const ControlBody = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("cancel"), reason: z.string().max(1_000).optional() }),
+  z.object({ action: z.literal("steer"), text: z.string().min(1).max(10_000) }),
+  z.object({ action: z.literal("follow_up"), text: z.string().min(1).max(10_000) }),
+  z.object({ action: z.literal("extend"), seconds: z.number().int().min(1).max(604_800) }),
+  z.object({ action: z.literal("claim") }),
+  z.object({ action: z.literal("release") }),
+]);
+
+async function allowed(req: FastifyRequest, reply: FastifyReply): Promise<boolean> {
+  if (await requirePermission(req, "runs.control")) return true;
+  reply.code(403).send({ error: "permission_denied", permission: "runs.control" });
+  return false;
+}
+
+function item(text: string, memberId: string) {
+  return { id: `ctl_${crypto.randomUUID()}`, text, createdBy: memberId, createdAt: new Date().toISOString() };
+}
+
+async function record(req: FastifyRequest, action: string, type: string, targetId: string, meta: Record<string, unknown> = {}) {
+  await writeAudit({
+    workspaceId: req.auth!.workspaceId!, actorId: req.auth!.memberId!, action,
+    targetType: type, targetId, meta, ip: req.ip,
+  });
+}
+
+export default async function runControlRoutes(app: FastifyInstance): Promise<void> {
+  app.addHook("preHandler", requireWorkspace);
+
+  app.get("/active-runs", async (req) => {
+    const agentRows = await db.select({ run: agentRuns, agentName: agents.name })
+      .from(agentRuns).innerJoin(agents, eq(agents.id, agentRuns.agentId))
+      .where(and(eq(agents.workspaceId, req.auth!.workspaceId!), inArray(agentRuns.status, ["queued", "running"])))
+      .orderBy(desc(agentRuns.startedAt)).limit(100);
+    const workflowRows = await db.select().from(workflowRuns)
+      .where(and(eq(workflowRuns.workspaceId, req.auth!.workspaceId!), inArray(workflowRuns.status, ["queued", "running", "waiting"])))
+      .orderBy(desc(workflowRuns.startedAt)).limit(100);
+    return {
+      runs: [
+        ...agentRows.map((row) => ({ type: "agent" as const, name: row.agentName, ...row.run })),
+        ...workflowRows.map((run) => ({ type: "workflow" as const, name: `Workflow ${run.workflowId}`, ...run })),
+      ].sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime()),
+    };
+  });
+
+  app.post("/agent-runs/:id/control", async (req, reply) => {
+    if (!(await allowed(req, reply))) return;
+    const runId = (req.params as { id: string }).id;
+    const body = ControlBody.parse(req.body);
+    const [row] = await db.select({ run: agentRuns, workspaceId: agents.workspaceId })
+      .from(agentRuns).innerJoin(agents, eq(agents.id, agentRuns.agentId))
+      .where(and(eq(agentRuns.id, runId), eq(agents.workspaceId, req.auth!.workspaceId!))).limit(1);
+    if (!row) return reply.code(404).send({ error: "agent_run_not_found" });
+    if (row.run.ownerMemberId && row.run.ownerMemberId !== req.auth!.memberId! && !(await requirePermission(req, "*"))) {
+      return reply.code(409).send({ error: "run_owned_by_another_member", ownerMemberId: row.run.ownerMemberId });
+    }
+    if (body.action === "cancel") {
+      if (["ok", "failed", "cancelled"].includes(row.run.status)) return reply.code(409).send({ error: "run_terminal" });
+      await db.update(agentRuns).set({
+        status: "cancelled", cancelRequestedAt: new Date(), cancelledBy: req.auth!.memberId!,
+        errorText: body.reason ?? "cancelled_by_user", finishedAt: new Date(),
+      }).where(eq(agentRuns.id, runId));
+      const job = await agentQueue.getJob(runId);
+      if (job && (await job.getState()) !== "active") await job.remove().catch(() => {});
+    } else if (body.action === "steer") {
+      await db.update(agentRuns).set({ steerJson: [...row.run.steerJson, item(body.text, req.auth!.memberId!)] }).where(eq(agentRuns.id, runId));
+    } else if (body.action === "follow_up") {
+      await db.update(agentRuns).set({ followupJson: [...row.run.followupJson, item(body.text, req.auth!.memberId!)] }).where(eq(agentRuns.id, runId));
+    } else if (body.action === "extend") {
+      const base = Math.max(Date.now(), row.run.timeoutAt?.getTime() ?? 0);
+      await db.update(agentRuns).set({ timeoutAt: new Date(base + body.seconds * 1_000) }).where(eq(agentRuns.id, runId));
+    } else {
+      await db.update(agentRuns).set({ ownerMemberId: body.action === "claim" ? req.auth!.memberId! : null }).where(eq(agentRuns.id, runId));
+    }
+    await record(req, `agent_run.${body.action}`, "agent_run", runId, body.action === "cancel" ? { reason: body.reason ?? "" } : {});
+    const [run] = await db.select().from(agentRuns).where(eq(agentRuns.id, runId)).limit(1);
+    return { run };
+  });
+
+  app.post("/workflow-runs/:id/control", async (req, reply) => {
+    if (!(await allowed(req, reply))) return;
+    const runId = (req.params as { id: string }).id;
+    const body = ControlBody.parse(req.body);
+    const [run] = await db.select().from(workflowRuns)
+      .where(and(eq(workflowRuns.id, runId), eq(workflowRuns.workspaceId, req.auth!.workspaceId!))).limit(1);
+    if (!run) return reply.code(404).send({ error: "workflow_run_not_found" });
+    if (run.ownerMemberId && run.ownerMemberId !== req.auth!.memberId! && !(await requirePermission(req, "*"))) {
+      return reply.code(409).send({ error: "run_owned_by_another_member", ownerMemberId: run.ownerMemberId });
+    }
+    if (body.action === "cancel") {
+      if (["completed", "failed", "cancelled"].includes(run.status)) return reply.code(409).send({ error: "run_terminal" });
+      await db.update(workflowRuns).set({
+        status: "cancelled", cancelRequestedAt: new Date(), cancelledBy: req.auth!.memberId!,
+        errorText: body.reason ?? "cancelled_by_user", finishedAt: new Date(), updatedAt: new Date(),
+      }).where(eq(workflowRuns.id, runId));
+    } else if (body.action === "steer") {
+      await db.update(workflowRuns).set({ steerJson: [...run.steerJson, item(body.text, req.auth!.memberId!)], updatedAt: new Date() }).where(eq(workflowRuns.id, runId));
+    } else if (body.action === "follow_up") {
+      await db.update(workflowRuns).set({ followupJson: [...run.followupJson, item(body.text, req.auth!.memberId!)], updatedAt: new Date() }).where(eq(workflowRuns.id, runId));
+    } else if (body.action === "extend") {
+      const base = Math.max(Date.now(), run.timeoutAt?.getTime() ?? 0);
+      await db.update(workflowRuns).set({ timeoutAt: new Date(base + body.seconds * 1_000), updatedAt: new Date() }).where(eq(workflowRuns.id, runId));
+    } else {
+      await db.update(workflowRuns).set({ ownerMemberId: body.action === "claim" ? req.auth!.memberId! : null, updatedAt: new Date() }).where(eq(workflowRuns.id, runId));
+    }
+    await record(req, `workflow_run.${body.action}`, "workflow_run", runId, body.action === "cancel" ? { reason: body.reason ?? "" } : {});
+    const [updated] = await db.select().from(workflowRuns).where(eq(workflowRuns.id, runId)).limit(1);
+    return { run: updated };
+  });
+}

--- a/api/src/routes/tasks.ts
+++ b/api/src/routes/tasks.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { and, eq, asc } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { tasks, taskAssignees } from "../db/schema.js";
+import { tasks, taskAssignees, boardStages } from "../db/schema.js";
 import { requireWorkspace } from "../auth/session.js";
 import {
   STATUSES,
@@ -19,6 +19,7 @@ import {
   addComment,
   deleteComment,
   hydrateTasks,
+  loadTask,
 } from "../lib/tasks-core.js";
 
 const CreateBody = z.object({
@@ -71,7 +72,10 @@ const ERR_CODE: Record<string, number> = {
 };
 
 function send(reply: import("fastify").FastifyReply, result: { error?: string; [k: string]: unknown }) {
-  if (result.error) return reply.code(ERR_CODE[result.error] ?? 400).send({ error: result.error });
+  if (result.error) {
+    const { error, ...details } = result;
+    return reply.code(ERR_CODE[error] ?? 400).send({ error, ...details });
+  }
   return result;
 }
 
@@ -99,6 +103,18 @@ export default async function tasksRoutes(app: FastifyInstance): Promise<void> {
     const body = UpdateBody.parse(req.body);
     const r = await updateTask(taskId, body, req.auth!.memberId!, req.auth!.workspaceId!);
     return send(reply, r);
+  });
+
+  app.post("/tasks/:id/advance", async (req, reply) => {
+    const taskId = (req.params as { id: string }).id;
+    const task = await loadTask(taskId);
+    if (!task || task.workspaceId !== req.auth!.workspaceId!) return reply.code(404).send({ error: "not_found" });
+    const [stage] = await db.select({ nextStage: boardStages.nextStage }).from(boardStages)
+      .where(and(eq(boardStages.workspaceId, req.auth!.workspaceId!), eq(boardStages.stage, task.status))).limit(1);
+    const next = stage?.nextStage ?? ({ backlog: "in_progress", in_progress: "review", blocked: "in_progress", review: "done", done: null } as Record<string, string | null>)[task.status];
+    if (!next || !STATUSES.includes(next as (typeof STATUSES)[number])) return reply.code(409).send({ error: "no_next_stage" });
+    const result = await updateTask(taskId, { status: next as (typeof STATUSES)[number] }, req.auth!.memberId!, req.auth!.workspaceId!);
+    return send(reply, result);
   });
 
   app.delete("/tasks/:id", async (req, reply) => {

--- a/api/src/routes/workflows.ts
+++ b/api/src/routes/workflows.ts
@@ -1,0 +1,305 @@
+import { Transform } from "node:stream";
+import { FastifyInstance, FastifyRequest } from "fastify";
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db/index.js";
+import {
+  webhookEndpoints,
+  webhookEvents,
+  workflowRuns,
+  workflows,
+  workflowSteps,
+} from "../db/schema.js";
+import { requireWorkspace } from "../auth/session.js";
+import { config } from "../lib/config.js";
+import { id, rawToken } from "../lib/ids.js";
+import { decryptSecret, encryptSecret } from "../lib/secret-box.js";
+import { verifyWebhookSignature } from "../lib/signed-webhook.js";
+import { parseWorkflowDefinition } from "../lib/workflow-definition.js";
+import { resumeWorkflowFromHuman, startWorkflowRun } from "../lib/workflow-engine.js";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    rawWebhookBody?: Buffer;
+  }
+}
+
+const CreateWorkflow = z.object({
+  name: z.string().min(1).max(140),
+  description: z.string().max(3_000).optional(),
+  triggerType: z.enum(["manual", "webhook"]).optional(),
+  definition: z.unknown(),
+});
+
+const PatchWorkflow = z.object({
+  name: z.string().min(1).max(140).optional(),
+  description: z.string().max(3_000).optional(),
+  status: z.enum(["active", "paused"]).optional(),
+  triggerType: z.enum(["manual", "webhook"]).optional(),
+  definition: z.unknown().optional(),
+});
+
+function endpointUrl(endpointId: string): string {
+  return `${config.publicBaseUrl.replace(/\/$/, "")}/api/hooks/${endpointId}`;
+}
+
+function isWebhookRequest(req: FastifyRequest): boolean {
+  return (req.raw.url ?? "").split("?")[0].includes("/hooks/");
+}
+
+export default async function workflowRoutes(app: FastifyInstance): Promise<void> {
+  // Tee the exact bytes into `rawWebhookBody` while leaving the stream intact
+  // for Fastify's normal JSON parser. HMAC therefore covers what the sender
+  // actually sent, not a re-serialized approximation.
+  app.addHook("preParsing", (req, _reply, payload, done) => {
+    if (!isWebhookRequest(req)) return done(null, payload);
+    const chunks: Buffer[] = [];
+    const tee = new Transform({
+      transform(chunk: Buffer, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback(null, chunk);
+      },
+      flush(callback) {
+        req.rawWebhookBody = Buffer.concat(chunks);
+        callback();
+      },
+    });
+    done(null, payload.pipe(tee));
+  });
+
+  app.get("/workflows", { preHandler: requireWorkspace }, async (req) => {
+    const workspaceId = req.auth!.workspaceId!;
+    const rows = await db
+      .select()
+      .from(workflows)
+      .where(eq(workflows.workspaceId, workspaceId))
+      .orderBy(desc(workflows.updatedAt));
+    const workflowIds = rows.map((row) => row.id);
+    const runs = workflowIds.length
+      ? await db
+          .select()
+          .from(workflowRuns)
+          .where(inArray(workflowRuns.workflowId, workflowIds))
+          .orderBy(desc(workflowRuns.startedAt))
+      : [];
+    const endpoints = workflowIds.length
+      ? await db.select().from(webhookEndpoints).where(inArray(webhookEndpoints.workflowId, workflowIds))
+      : [];
+    return {
+      workflows: rows.map((workflow) => ({
+        ...workflow,
+        latestRuns: runs.filter((run) => run.workflowId === workflow.id).slice(0, 10),
+        endpoints: endpoints
+          .filter((endpoint) => endpoint.workflowId === workflow.id)
+          .map(({ secretCiphertext: _secret, ...endpoint }) => ({ ...endpoint, url: endpointUrl(endpoint.id) })),
+      })),
+    };
+  });
+
+  app.post("/workflows", { preHandler: requireWorkspace }, async (req, reply) => {
+    const body = CreateWorkflow.parse(req.body);
+    let definition;
+    try { definition = parseWorkflowDefinition(body.definition); }
+    catch (error) { return reply.code(400).send({ error: (error as Error).message }); }
+    const workflowId = id("wf");
+    await db.insert(workflows).values({
+      id: workflowId,
+      workspaceId: req.auth!.workspaceId!,
+      name: body.name,
+      description: body.description ?? "",
+      triggerType: body.triggerType ?? "manual",
+      definitionJson: definition,
+      createdBy: req.auth!.memberId!,
+    });
+    const [workflow] = await db.select().from(workflows).where(eq(workflows.id, workflowId)).limit(1);
+    return reply.code(201).send({ workflow });
+  });
+
+  app.patch("/workflows/:id", { preHandler: requireWorkspace }, async (req, reply) => {
+    const workflowId = (req.params as { id: string }).id;
+    const body = PatchWorkflow.parse(req.body);
+    const [existing] = await db
+      .select()
+      .from(workflows)
+      .where(and(eq(workflows.id, workflowId), eq(workflows.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!existing) return reply.code(404).send({ error: "workflow_not_found" });
+    let definition = existing.definitionJson;
+    if (body.definition !== undefined) {
+      try { definition = parseWorkflowDefinition(body.definition); }
+      catch (error) { return reply.code(400).send({ error: (error as Error).message }); }
+    }
+    await db
+      .update(workflows)
+      .set({
+        ...(body.name !== undefined ? { name: body.name } : {}),
+        ...(body.description !== undefined ? { description: body.description } : {}),
+        ...(body.status !== undefined ? { status: body.status } : {}),
+        ...(body.triggerType !== undefined ? { triggerType: body.triggerType } : {}),
+        definitionJson: definition,
+        version: existing.version + 1,
+        updatedAt: new Date(),
+      })
+      .where(eq(workflows.id, workflowId));
+    const [workflow] = await db.select().from(workflows).where(eq(workflows.id, workflowId)).limit(1);
+    return { workflow };
+  });
+
+  app.post("/workflows/:id/runs", { preHandler: requireWorkspace }, async (req, reply) => {
+    const workflowId = (req.params as { id: string }).id;
+    const body = z.object({ input: z.record(z.string(), z.unknown()).default({}) }).parse(req.body ?? {});
+    try {
+      const runId = await startWorkflowRun({
+        workflowId,
+        workspaceId: req.auth!.workspaceId!,
+        payload: body.input,
+        createdBy: req.auth!.memberId!,
+      });
+      return reply.code(202).send({ runId });
+    } catch (error) {
+      const message = (error as Error).message;
+      return reply.code(message === "workflow_not_found" ? 404 : 409).send({ error: message });
+    }
+  });
+
+  app.get("/workflow-runs/:id", { preHandler: requireWorkspace }, async (req, reply) => {
+    const runId = (req.params as { id: string }).id;
+    const [run] = await db
+      .select()
+      .from(workflowRuns)
+      .where(and(eq(workflowRuns.id, runId), eq(workflowRuns.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!run) return reply.code(404).send({ error: "workflow_run_not_found" });
+    const steps = await db
+      .select()
+      .from(workflowSteps)
+      .where(eq(workflowSteps.runId, runId))
+      .orderBy(workflowSteps.startedAt);
+    return { run, steps };
+  });
+
+  app.post("/workflow-runs/:id/resume", { preHandler: requireWorkspace }, async (req, reply) => {
+    const runId = (req.params as { id: string }).id;
+    const body = z
+      .object({ approved: z.boolean(), output: z.record(z.string(), z.unknown()).default({}) })
+      .parse(req.body ?? {});
+    try {
+      await resumeWorkflowFromHuman({
+        runId,
+        workspaceId: req.auth!.workspaceId!,
+        approved: body.approved,
+        output: body.output,
+      });
+      return reply.code(202).send({ ok: true });
+    } catch (error) {
+      const message = (error as Error).message;
+      return reply.code(message === "workflow_run_not_found" ? 404 : 409).send({ error: message });
+    }
+  });
+
+  app.post("/workflows/:id/webhooks", { preHandler: requireWorkspace }, async (req, reply) => {
+    const workflowId = (req.params as { id: string }).id;
+    const body = z.object({ name: z.string().min(1).max(120) }).parse(req.body);
+    const [workflow] = await db
+      .select({ id: workflows.id })
+      .from(workflows)
+      .where(and(eq(workflows.id, workflowId), eq(workflows.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!workflow) return reply.code(404).send({ error: "workflow_not_found" });
+    const endpointId = id("hook");
+    const signingSecret = `whsec_${rawToken(48)}`;
+    await db.insert(webhookEndpoints).values({
+      id: endpointId,
+      workspaceId: req.auth!.workspaceId!,
+      workflowId,
+      name: body.name,
+      secretCiphertext: encryptSecret({ signingSecret }),
+      createdBy: req.auth!.memberId!,
+    });
+    return reply.code(201).send({
+      endpoint: { id: endpointId, workflowId, name: body.name, url: endpointUrl(endpointId), active: true },
+      signingSecret,
+      signature: "sha256=HMAC_SHA256(secret, `${X-CircleChat-Timestamp}.${rawBody}`)",
+    });
+  });
+
+  app.post("/webhooks/:id/rotate", { preHandler: requireWorkspace }, async (req, reply) => {
+    const endpointId = (req.params as { id: string }).id;
+    const [endpoint] = await db
+      .select()
+      .from(webhookEndpoints)
+      .where(and(eq(webhookEndpoints.id, endpointId), eq(webhookEndpoints.workspaceId, req.auth!.workspaceId!)))
+      .limit(1);
+    if (!endpoint) return reply.code(404).send({ error: "webhook_endpoint_not_found" });
+    const signingSecret = `whsec_${rawToken(48)}`;
+    await db
+      .update(webhookEndpoints)
+      .set({ secretCiphertext: encryptSecret({ signingSecret }) })
+      .where(eq(webhookEndpoints.id, endpointId));
+    return { signingSecret };
+  });
+
+  app.post("/hooks/:endpointId", async (req, reply) => {
+    const endpointId = (req.params as { endpointId: string }).endpointId;
+    const deliveryId = String(req.headers["x-circlechat-delivery"] ?? "").trim();
+    if (!deliveryId || deliveryId.length > 120) return reply.code(400).send({ error: "delivery_id_required" });
+    const [endpoint] = await db
+      .select()
+      .from(webhookEndpoints)
+      .where(eq(webhookEndpoints.id, endpointId))
+      .limit(1);
+    if (!endpoint || !endpoint.active) return reply.code(404).send({ error: "webhook_endpoint_not_found" });
+    const payload = z.record(z.string(), z.unknown()).parse(req.body ?? {});
+    const eventId = id("whevt");
+    const inserted = await db
+      .insert(webhookEvents)
+      .values({ id: eventId, endpointId, deliveryId, payloadJson: payload })
+      .onConflictDoNothing()
+      .returning({ id: webhookEvents.id });
+    if (!inserted.length) {
+      const [prior] = await db
+        .select({ workflowRunId: webhookEvents.workflowRunId, status: webhookEvents.status })
+        .from(webhookEvents)
+        .where(and(eq(webhookEvents.endpointId, endpointId), eq(webhookEvents.deliveryId, deliveryId)))
+        .limit(1);
+      return { duplicate: true, runId: prior?.workflowRunId ?? null, status: prior?.status ?? "duplicate" };
+    }
+    const { signingSecret } = decryptSecret<{ signingSecret: string }>(endpoint.secretCiphertext);
+    const verification = verifyWebhookSignature({
+      secret: signingSecret,
+      timestamp: typeof req.headers["x-circlechat-timestamp"] === "string"
+        ? req.headers["x-circlechat-timestamp"]
+        : undefined,
+      signature: typeof req.headers["x-circlechat-signature"] === "string"
+        ? req.headers["x-circlechat-signature"]
+        : undefined,
+      rawBody: req.rawWebhookBody ?? Buffer.from(JSON.stringify(payload)),
+    });
+    if (!verification.ok) {
+      await db
+        .update(webhookEvents)
+        .set({ status: "rejected", signatureValid: false, errorText: verification.error })
+        .where(eq(webhookEvents.id, eventId));
+      return reply.code(401).send({ error: verification.error });
+    }
+    try {
+      const runId = await startWorkflowRun({
+        workflowId: endpoint.workflowId,
+        workspaceId: endpoint.workspaceId,
+        payload,
+        createdBy: endpoint.id,
+      });
+      await db
+        .update(webhookEvents)
+        .set({ status: "accepted", signatureValid: true, workflowRunId: runId })
+        .where(eq(webhookEvents.id, eventId));
+      return reply.code(202).send({ accepted: true, runId });
+    } catch (error) {
+      await db
+        .update(webhookEvents)
+        .set({ status: "rejected", signatureValid: true, errorText: (error as Error).message.slice(0, 500) })
+        .where(eq(webhookEvents.id, eventId));
+      return reply.code(409).send({ error: (error as Error).message });
+    }
+  });
+}

--- a/api/src/routes/workspaces.ts
+++ b/api/src/routes/workspaces.ts
@@ -14,6 +14,7 @@ import {
   tasks,
   taskAssignees,
   agents,
+  workspaceRoles,
 } from "../db/schema.js";
 import { requireAuth, ensureUserMember, COOKIE_NAME } from "../auth/session.js";
 import { id } from "../lib/ids.js";
@@ -194,10 +195,15 @@ export default async function workspaceRoutes(app: FastifyInstance): Promise<voi
     const targetWs = (req.params as { id: string }).id;
     const targetUser = (req.params as { userId: string }).userId;
     const { user } = req.auth!;
-    const body = z.object({ role: z.enum(["admin", "member"]) }).parse(req.body);
+    const body = z.object({ role: z.string().min(2).max(40).regex(/^[a-z][a-z0-9_-]*$/) }).parse(req.body);
 
     const me = await loadWorkspaceRole(targetWs, user.id);
     if (!me || me.role !== "admin") return reply.code(403).send({ error: "admin_only" });
+    if (!["admin", "member", "guest"].includes(body.role)) {
+      const [custom] = await db.select({ id: workspaceRoles.id }).from(workspaceRoles)
+        .where(and(eq(workspaceRoles.workspaceId, targetWs), eq(workspaceRoles.key, body.role))).limit(1);
+      if (!custom) return reply.code(400).send({ error: "role_not_found" });
+    }
 
     const [target] = await db
       .select({ role: workspaceMembers.role })

--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -12,6 +12,7 @@ import {
   tasks,
   taskComments,
   taskAssignees,
+  boardStages,
 } from "./db/schema.js";
 import { buildContext } from "./agents/context.js";
 import { callAgent } from "./agents/adapters/dispatch.js";
@@ -86,6 +87,16 @@ async function detectAndFlagStuck(agentId: string): Promise<boolean> {
 import { redactSecrets, redactLines } from "./lib/redaction.js";
 import { startGoalPlanWorker } from "./agents/goal-planner-worker.js";
 import { scheduleGoalSweep, scheduleMissionSweep } from "./lib/goal-queue.js";
+import {
+  modelRecommendation,
+  recordModelUsage,
+  refreshAgentRunUsage,
+} from "./lib/model-usage-store.js";
+import {
+  resumeWorkflowFromAgent,
+  startWorkflowWorker,
+  workflowAgentContext,
+} from "./lib/workflow-engine.js";
 
 const worker = new Worker<AgentJobPayload>(
   AGENT_QUEUE,
@@ -110,6 +121,15 @@ const worker = new Worker<AgentJobPayload>(
           .where(eq(agentRuns.id, payload.runId));
         await emitFinished(payload.agentId, payload.runId, "failed", payload.conversationId);
       }
+      if (payload.workflowRunId && payload.workflowStepId) {
+        await resumeWorkflowFromAgent({
+          workflowRunId: payload.workflowRunId,
+          workflowStepId: payload.workflowStepId,
+          success: false,
+          output: {},
+          errorText: "agent_missing",
+        });
+      }
       return;
     }
 
@@ -117,12 +137,38 @@ const worker = new Worker<AgentJobPayload>(
     let runId = payload.runId;
     if (payload.trigger === "scheduled" && !runId) runId = await materialiseScheduledRun(payload.agentId);
 
+    const [controlAtStart] = await db.select({
+      status: agentRuns.status,
+      cancelRequestedAt: agentRuns.cancelRequestedAt,
+      timeoutAt: agentRuns.timeoutAt,
+    }).from(agentRuns).where(eq(agentRuns.id, runId)).limit(1);
+    if (
+      !controlAtStart || controlAtStart.status === "cancelled" || controlAtStart.cancelRequestedAt ||
+      (controlAtStart.timeoutAt && controlAtStart.timeoutAt <= new Date())
+    ) {
+      if (controlAtStart && controlAtStart.status !== "cancelled") {
+        await db.update(agentRuns).set({ status: "cancelled", errorText: "run_timeout", finishedAt: new Date() }).where(eq(agentRuns.id, runId));
+      }
+      await db.update(agents).set({ status: "idle" }).where(eq(agents.id, agent.id));
+      await emitFinished(agent.id, runId, "cancelled", payload.conversationId);
+      return;
+    }
+
     if (agent.status === "paused") {
       await db
         .update(agentRuns)
         .set({ status: "ok", resultJson: { skipped: "paused" }, finishedAt: new Date() })
         .where(eq(agentRuns.id, runId));
       await emitFinished(agent.id, runId, "ok", payload.conversationId);
+      if (payload.workflowRunId && payload.workflowStepId) {
+        await resumeWorkflowFromAgent({
+          workflowRunId: payload.workflowRunId,
+          workflowStepId: payload.workflowStepId,
+          success: false,
+          output: { skipped: "paused" },
+          errorText: "agent_paused",
+        });
+      }
       return;
     }
 
@@ -203,6 +249,15 @@ const worker = new Worker<AgentJobPayload>(
         await db.update(agents).set({ status: "idle" }).where(eq(agents.id, agent.id));
       }
       await emitFinished(agent.id, runId, "ok", payload.conversationId);
+      if (payload.workflowRunId && payload.workflowStepId) {
+        await resumeWorkflowFromAgent({
+          workflowRunId: payload.workflowRunId,
+          workflowStepId: payload.workflowStepId,
+          success: false,
+          output: { skipped: gate.reason },
+          errorText: gate.reason,
+        });
+      }
       return;
     }
 
@@ -230,7 +285,36 @@ const worker = new Worker<AgentJobPayload>(
           : null,
       stuckBreak,
       lastCodeResult,
+      steering: payload.status ?? null,
     });
+    packet.modelRoute = await modelRecommendation({
+      workspaceId: agent.workspaceId,
+      trigger: payload.trigger,
+      text: payload.status ?? "",
+    });
+    if (payload.workflowRunId) {
+      const workflow = await workflowAgentContext(payload.workflowRunId);
+      if (workflow) packet.workflow = workflow;
+    }
+    const [runControls] = await db.select({ steer: agentRuns.steerJson, followUps: agentRuns.followupJson, timeoutAt: agentRuns.timeoutAt })
+      .from(agentRuns).where(eq(agentRuns.id, runId)).limit(1);
+    if (runControls) packet.runControls = runControls;
+    if (payload.stageExecution) {
+      packet.stageExecution = payload.stageExecution;
+    } else if (payload.taskId) {
+      const [taskStage] = await db.select({ status: tasks.status }).from(tasks).where(eq(tasks.id, payload.taskId)).limit(1);
+      if (taskStage) {
+        const [stage] = await db.select().from(boardStages).where(and(eq(boardStages.workspaceId, agent.workspaceId), eq(boardStages.stage, taskStage.status))).limit(1);
+        if (stage) packet.stageExecution = {
+          stage: stage.stage,
+          title: stage.title,
+          instructions: stage.instructions,
+          skill: stage.skill,
+          verification: stage.verification,
+          nextStage: stage.nextStage,
+        };
+      }
+    }
     await db.update(agentRuns).set({ contextJson: packet as never }).where(eq(agentRuns.id, runId));
 
     const kind: "heartbeat" | "event" =
@@ -247,6 +331,21 @@ const worker = new Worker<AgentJobPayload>(
       response = await callAgent(agent, kind, packet);
     } catch (e) {
       const { tokensEst, costUsd } = estimateRunCost(promptChars, 0);
+      await recordModelUsage({
+        workspaceId: agent.workspaceId,
+        agentId: agent.id,
+        runId,
+        routeTier: packet.modelRoute?.tier,
+        usage: {
+          provider: packet.modelRoute?.provider ?? undefined,
+          model: (packet.modelRoute?.model ?? agent.model) || undefined,
+          inputTokens: tokensEst,
+          outputTokens: 0,
+          costUsd,
+        },
+        source: "estimated",
+        eventKey: "worker",
+      }).catch((usageError) => console.error("[worker] usage record failed", usageError));
       await db
         .update(agentRuns)
         .set({
@@ -257,8 +356,24 @@ const worker = new Worker<AgentJobPayload>(
           finishedAt: new Date(),
         })
         .where(eq(agentRuns.id, runId));
+      // A gateway can report actual usage asynchronously before this retry
+      // finishes. Re-apply reported aggregates after writing the fallback so
+      // the late worker estimate never overwrites provider-grade accounting.
+      await refreshAgentRunUsage(runId).catch((usageError) =>
+        console.error("[worker] usage refresh failed", usageError),
+      );
       await db.update(agents).set({ status: "error" }).where(eq(agents.id, agent.id));
       await emitFinished(agent.id, runId, "failed", payload.conversationId);
+      const finalAttempt = job.attemptsMade + 1 >= (job.opts.attempts ?? 1);
+      if (finalAttempt && payload.workflowRunId && payload.workflowStepId) {
+        await resumeWorkflowFromAgent({
+          workflowRunId: payload.workflowRunId,
+          workflowStepId: payload.workflowStepId,
+          success: false,
+          output: {},
+          errorText: redactSecrets((e as Error).message),
+        });
+      }
       throw e;
     }
 
@@ -269,6 +384,34 @@ const worker = new Worker<AgentJobPayload>(
     } else {
       actions = (response.actions as AgentAction[]) ?? [];
       trace = response.trace ?? [];
+    }
+
+    // A cancel/timeout that landed while the remote model was working is a
+    // hard action boundary: retain the remote response nowhere and never apply
+    // its side effects. This is the enforceable interrupt point for webhook and
+    // socket runtimes that cannot be synchronously aborted mid-request.
+    const [controlBeforeApply] = await db.select({
+      status: agentRuns.status,
+      cancelRequestedAt: agentRuns.cancelRequestedAt,
+      timeoutAt: agentRuns.timeoutAt,
+    }).from(agentRuns).where(eq(agentRuns.id, runId)).limit(1);
+    if (
+      !controlBeforeApply || controlBeforeApply.status === "cancelled" || controlBeforeApply.cancelRequestedAt ||
+      (controlBeforeApply.timeoutAt && controlBeforeApply.timeoutAt <= new Date())
+    ) {
+      await db.update(agentRuns).set({
+        status: "cancelled", errorText: controlBeforeApply?.cancelRequestedAt ? "cancelled_by_user" : "run_timeout",
+        resultJson: { skipped: "cancelled_before_actions" }, finishedAt: new Date(),
+      }).where(eq(agentRuns.id, runId));
+      await db.update(agents).set({ status: "idle" }).where(eq(agents.id, agent.id));
+      await emitFinished(agent.id, runId, "cancelled", payload.conversationId);
+      if (payload.workflowRunId && payload.workflowStepId) {
+        await resumeWorkflowFromAgent({
+          workflowRunId: payload.workflowRunId, workflowStepId: payload.workflowStepId,
+          success: false, output: { skipped: "cancelled_before_actions" }, errorText: "agent_run_cancelled",
+        });
+      }
+      return;
     }
 
     const outcome = await applyActions({
@@ -282,7 +425,43 @@ const worker = new Worker<AgentJobPayload>(
       response === "HEARTBEAT_OK"
         ? 0
         : JSON.stringify(actions).length + trace.join("\n").length;
-    const { tokensEst, costUsd } = estimateRunCost(promptChars, completionChars);
+    const estimated = estimateRunCost(promptChars, completionChars);
+    let tokensEst = estimated.tokensEst;
+    let costUsd = estimated.costUsd;
+    if (response !== "HEARTBEAT_OK" && response.usage) {
+      try {
+        const actual = await recordModelUsage({
+          workspaceId: agent.workspaceId,
+          agentId: agent.id,
+          runId,
+          routeTier: packet.modelRoute?.tier,
+          usage: response.usage,
+          source: "reported",
+          eventKey: "worker",
+        });
+        tokensEst = actual.tokens;
+        costUsd = actual.costUsd;
+      } catch (usageError) {
+        // Metering must not cause already-applied agent actions to retry.
+        console.error("[worker] reported usage record failed", usageError);
+      }
+    } else {
+      await recordModelUsage({
+        workspaceId: agent.workspaceId,
+        agentId: agent.id,
+        runId,
+        routeTier: packet.modelRoute?.tier,
+        usage: {
+          provider: packet.modelRoute?.provider ?? undefined,
+          model: (packet.modelRoute?.model ?? agent.model) || undefined,
+          inputTokens: estimated.tokensEst,
+          outputTokens: 0,
+          costUsd: estimated.costUsd,
+        },
+        source: "estimated",
+        eventKey: "worker",
+      }).catch((usageError) => console.error("[worker] usage record failed", usageError));
+    }
 
     await db
       .update(agentRuns)
@@ -295,12 +474,46 @@ const worker = new Worker<AgentJobPayload>(
         finishedAt: new Date(),
       })
       .where(eq(agentRuns.id, runId));
+    await refreshAgentRunUsage(runId).catch((usageError) =>
+      console.error("[worker] usage refresh failed", usageError),
+    );
     await db.update(agents).set({ status: "idle" }).where(eq(agents.id, agent.id));
     await emitFinished(agent.id, runId, "ok", payload.conversationId, {
       agentName: agent.name,
       agentHandle: agent.handle,
       errors: outcome.errors,
     });
+
+    const [completedControls] = await db.select({ followUps: agentRuns.followupJson }).from(agentRuns).where(eq(agentRuns.id, runId)).limit(1);
+    if (completedControls?.followUps.length) {
+      const followupText = completedControls.followUps
+        .map((entry) => typeof entry.text === "string" ? entry.text : "")
+        .filter(Boolean)
+        .join("\n\n");
+      if (followupText) {
+        await enqueueAgentEvent(agent.id, {
+          trigger: "continuation",
+          conversationId: payload.conversationId ?? null,
+          taskId: payload.taskId,
+          status: `Human follow-up:\n${followupText}`,
+          chainDepth: 0,
+        }).catch((e) => console.error("[worker] queued follow-up failed", e));
+      }
+    }
+
+    if (payload.workflowRunId && payload.workflowStepId) {
+      await resumeWorkflowFromAgent({
+        workflowRunId: payload.workflowRunId,
+        workflowStepId: payload.workflowStepId,
+        success: outcome.errors.length === 0,
+        output: {
+          actionsApplied: outcome.actionsApplied,
+          errors: redactLines(outcome.errors),
+          trace: redactLines([...trace, ...outcome.trace]),
+        },
+        ...(outcome.errors.length ? { errorText: outcome.errors.join("; ").slice(0, 500) } : {}),
+      });
+    }
 
     // Loop guard: detect a run-level behavioral loop and, if found, leave a
     // one-shot break directive for the next run AND suppress the continuation
@@ -312,7 +525,7 @@ const worker = new Worker<AgentJobPayload>(
     // Budget is re-checked at the top of the next run, so a continuation can't
     // outrun a hard stop.
     const ranCode = actions.some((x) => x.type === "run_code");
-    if (!stuck && continuationEnabled() && response !== "HEARTBEAT_OK") {
+    if (payload.trigger !== "workflow" && !stuck && continuationEnabled() && response !== "HEARTBEAT_OK") {
       const chainDepth = payload.chainDepth ?? 0;
       if ((outcome.actionsApplied > 0 && shouldContinue(actions, chainDepth)) || (ranCode && chainDepth < 2)) {
         await enqueueAgentEvent(agent.id, {
@@ -461,3 +674,12 @@ scheduleGoalSweep().catch((e) => console.error("[goal-planner] sweep schedule fa
 // Daily mission → goals pass: proposes the next goals from the workspace
 // mission and files them under projects (see lib/mission-planner.ts).
 scheduleMissionSweep().catch((e) => console.error("[mission-planner] schedule failed", e));
+
+// Workflow wakes share the worker process but use a separate queue/concurrency
+// pool, so a large timer or poll workload cannot starve ordinary chat turns.
+const workflowWorker = startWorkflowWorker();
+workflowWorker.on("error", (e) => console.error("[workflow-worker] error", e));
+workflowWorker.on("failed", (job, err) =>
+  console.error("[workflow-worker] job failed", job?.id, err?.message),
+);
+console.log(`[worker] circlechat workflow-runs worker up, concurrency=10`);

--- a/docs/automation-platform.md
+++ b/docs/automation-platform.md
@@ -1,0 +1,196 @@
+# Automation platform
+
+CircleChat's P0 automation layer connects five primitives into one auditable path:
+
+1. A workspace installs a governed HTTP or MCP connector.
+2. Credentials are encrypted at rest and access is granted to named agents with scopes.
+3. A manual call or signed webhook creates a persisted workflow run.
+4. The worker advances one agent, connector, approval, timer, poll, or terminal state at a time.
+5. Agent runtimes receive a model-route recommendation and report actual provider usage.
+
+Postgres is the source of truth for runs, waits, attempts, webhook deliveries, grants, and usage. Redis/BullMQ schedules wakes and retries, but deleting or restarting a worker does not erase workflow state.
+
+## Connector and MCP registry
+
+Connectors are managed under **Automation → Connectors** or `/api/connectors`.
+
+| Capability | HTTP connector | MCP connector |
+| --- | --- | --- |
+| Transport | Governed REST request | MCP JSON-RPC over HTTP |
+| Invocation | Method, path, query, headers, JSON body | `tools/call` with tool name and arguments |
+| Health check | `GET` base URL or configured `healthPath` | `tools/list` |
+| Authentication | None, bearer, custom headers, OAuth 2 | Same |
+| Agent access | Explicit grant plus scopes | Explicit grant plus scopes |
+
+Public configuration (`baseUrl`, health path, OAuth URLs/client id/scopes) is stored separately from credentials. Credential envelopes use AES-256-GCM with a key domain-derived from `SESSION_SECRET`; API responses expose only `hasSecret`.
+
+### Generic OAuth 2
+
+Set `authType` to `oauth2` and include this public configuration:
+
+```json
+{
+  "oauth": {
+    "authorizationUrl": "https://provider.example/oauth/authorize",
+    "tokenUrl": "https://provider.example/oauth/token",
+    "clientId": "circlechat-client-id",
+    "scopes": ["records.read", "records.write"]
+  }
+}
+```
+
+Store `clientSecret` through the create or patch endpoint. `POST /api/connectors/:id/oauth/start` returns the provider authorization URL. The callback uses encrypted, ten-minute state bound to the connector/workspace and stores access/refresh tokens in the credential envelope.
+
+### Workflow connector state
+
+```json
+{
+  "id": "update_crm",
+  "type": "connector",
+  "onSuccess": "wait_for_sync",
+  "onFailure": "failed",
+  "config": {
+    "connectorId": "conn_…",
+    "agentId": "a_…",
+    "method": "POST",
+    "path": "/deals/$input.deal.id",
+    "body": {
+      "stage": "$input.stage",
+      "summary": "$steps.research.summary"
+    }
+  }
+}
+```
+
+When `agentId` is present, the connector must be granted to that agent. Exact template expressions preserve JSON types; embedded expressions stringify. `$input.*` addresses run input and `$steps.<state>.*` addresses prior state output.
+
+## Durable workflows
+
+A workflow definition contains a `start` state id and up to 100 states:
+
+```json
+{
+  "start": "research",
+  "states": [
+    {
+      "id": "research",
+      "type": "agent",
+      "onSuccess": "human_review",
+      "onFailure": "failed",
+      "config": { "agentId": "a_…" }
+    },
+    {
+      "id": "human_review",
+      "type": "approval",
+      "onSuccess": "cooldown",
+      "onFailure": "failed",
+      "config": { "prompt": "Approve the researched recommendation?" }
+    },
+    {
+      "id": "cooldown",
+      "type": "wait",
+      "next": "done",
+      "config": { "durationSeconds": 300 }
+    },
+    { "id": "done", "type": "terminal", "config": { "status": "completed" } },
+    { "id": "failed", "type": "terminal", "config": { "status": "failed" } }
+  ]
+}
+```
+
+| State | Required configuration | Behaviour |
+| --- | --- | --- |
+| `agent` | `agentId` | Enqueues an agent run, parks the workflow, and resumes the exact step after the final successful/failed attempt. |
+| `connector` | `connectorId` | Calls HTTP or MCP and records the bounded response. |
+| `approval` | Optional `prompt` | Parks on a human decision; resume with `POST /api/workflow-runs/:id/resume`. |
+| `wait` | `durationSeconds` | Stores `waitUntil`, schedules a delayed wake, then resumes the same step. |
+| `poll` | `connectorId`; optional `path`, `equals`, `intervalSeconds`, `timeoutSeconds` | Calls a connector until the response path matches or the durable timeout branch fires. |
+| `terminal` | `status: completed|failed` | Finalizes output/error and timestamps the run. |
+
+Transitions use `onSuccess`, `onFailure`, then `next` as the fallback. A state with no transition finalizes successfully or unsuccessfully according to its outcome. Every attempt is written to `workflow_steps` with input, output, errors, agent-run correlation, and timestamps.
+
+## Signed incoming webhooks
+
+Create an endpoint with `POST /api/workflows/:id/webhooks`. The response shows the signing secret once.
+
+Send these headers:
+
+```text
+X-CircleChat-Delivery: unique-provider-delivery-id
+X-CircleChat-Timestamp: unix-seconds
+X-CircleChat-Signature: sha256=<hex HMAC>
+Content-Type: application/json
+```
+
+The signed bytes are:
+
+```text
+<timestamp>.<exact raw HTTP body>
+```
+
+Example (Node.js):
+
+```js
+const signature = `sha256=${createHmac("sha256", secret)
+  .update(timestamp)
+  .update(".")
+  .update(rawBody)
+  .digest("hex")}`;
+```
+
+CircleChat rejects missing/tampered signatures and timestamps outside the five-minute replay window. `(endpoint, delivery id)` is unique: repeating a valid provider delivery returns its original run instead of starting a second run. Rotate secrets with `POST /api/webhooks/:id/rotate`.
+
+## Model routing and actual usage
+
+Configure `economy`, `balanced`, `frontier`, and `advisor` routes under **Automation → Models & usage** or `PUT /api/model-routing/:tier`.
+
+Each route records provider/model, context window, and per-million-token prices for uncached input, cached input, and output. CircleChat recommends a tier from the trigger and workload signals; an explicit requested tier wins. The recommendation appears in the context packet:
+
+```json
+{
+  "modelRoute": {
+    "tier": "frontier",
+    "provider": "example",
+    "model": "reasoning-model",
+    "contextWindow": 200000
+  }
+}
+```
+
+Runtimes may return usage with their normal response:
+
+```json
+{
+  "actions": [],
+  "usage": {
+    "provider": "example",
+    "model": "reasoning-model",
+    "inputTokens": 1240,
+    "outputTokens": 310,
+    "cachedInputTokens": 600
+  }
+}
+```
+
+For gateways that report asynchronously, agents can call `POST /api/agent-api/runs/:runId/usage` with the same usage object and their bearer token. Multiple model calls per run remain separate; the worker's own event is idempotent across BullMQ retries. Reported totals replace the run's estimate. The UI always labels rows `reported` or `estimated`.
+
+## Verification
+
+Pure/unit suite:
+
+```bash
+cd api
+npm test
+```
+
+Full P0 API E2E (requires a migrated API and worker plus the seeded/admin credentials):
+
+```bash
+cd api
+CC_E2E_BASE_URL=http://127.0.0.1:3000 \
+CC_E2E_EMAIL=e2e@circlechat.local \
+CC_E2E_PASSWORD=e2e-password \
+npm run test:p0-e2e
+```
+
+The E2E covers connector health, agent grants, model route/actual usage, bad and valid signatures, duplicate delivery protection, timer resume, human resume, and retry-idempotent usage.

--- a/docs/competitive-platform-comparison-2026-08.md
+++ b/docs/competitive-platform-comparison-2026-08.md
@@ -1,0 +1,319 @@
+# CircleChat vs Buzz vs Duet
+
+**Capability and gap analysis — 6 August 2026**
+
+## Executive read
+
+These products overlap, but they are not the same product with different branding.
+
+| Platform | Product centre of gravity | Strongest current advantage | Most important current weakness |
+| --- | --- | --- | --- |
+| **CircleChat** | A self-hosted operating system for governed teams of humans and autonomous agents | Structured execution: mission → goals → dependency-aware tasks → versioned deliverables → review/verification, with scopes, approvals, budgets, and recovery controls | No integration ecosystem, durable user-authored workflow engine, native Git surface, automatic model routing, or hosted-app deployment |
+| **Buzz** | A signed collaboration workspace and software forge where humans, agents, workflows, and Git activity share one event log | Cryptographic identity, tamper-evident history, rich collaboration, desktop clients, YAML automation, and native Git/branch/CI workflows | General project/goal management is thin, approval execution is incomplete, and there is little public evidence of cost control, deliverable verification, or autonomous-work recovery |
+| **Duet** | A managed cloud coworker for running business work across tools, persistent memory, schedules, boards, and hosted apps | 10,000+ integrations, durable multi-day relays, model routing, context-graph memory, isolated managed runtime, and instant app hosting | The full platform is not self-hostable/open-source; public materials do not show CircleChat-level goal governance, versioned task evidence, or Buzz-level signed collaboration/Git infrastructure |
+
+The strategic conclusion is not “copy both.” CircleChat already has the hardest-to-fake governance spine. It should add **Duet-like reach and durability** and **Buzz-like developer-work context**, while keeping goals, evidence, verification, approvals, and spend control as the product’s defining layer.
+
+## Method and confidence rules
+
+- **CircleChat** was assessed from this repository, including schema, routes, UI, worker, tests, and operator configuration. A feature counts as present only when implementation evidence exists.
+- **Buzz** was assessed from Block’s current public repository. Where its README says “being wired up,” this report does not count the feature as complete even if a vision document describes the intended end state.
+- **Duet** was assessed from its current public product pages and the open-source `duet-agent` harness linked by Duet. The hosted product is not open-source, so “not found” means **not publicly evidenced**, not proof that private code does not exist.
+- Marketing claims are recorded as claims, not independently benchmarked performance results.
+
+Legend: **✅ present** · **◐ partial, limited, optional, or not fully evidenced** · **🚧 explicitly in progress/planned** · **— not found in the reviewed implementation/public materials**.
+
+## 1. Product, delivery, and ownership
+
+| Capability | CircleChat | Buzz | Duet | CircleChat implication |
+| --- | --- | --- | --- | --- |
+| Primary product shape | ✅ Team chat plus governed multi-agent work OS | ✅ Team workspace plus event relay and software forge | ✅ Managed AI coworker workspace and runtime | CircleChat’s positioning should lead with governed outcomes, not merely “Slack with agents.” |
+| Open-source platform | ✅ Full platform, MIT | ✅ Full platform, Apache-2.0 | ◐ `duet-agent` is Apache-2.0; hosted Duet platform is not published as open-source | Keep full-stack openness prominent; it is a real advantage over Duet. |
+| Self-hosting | ✅ Docker Compose stack | ✅ Docker/relay deployment | — Managed cloud is the public product | Preserve one-command self-hosting and add a smoother managed path. |
+| Managed hosting | ◐ Managed cloud is linked, but the repository is primarily the self-hosted product | ✅ Block-hosted communities plus independent relays | ✅ Core delivery model | CircleChat needs the managed service to remove setup friction if it wants Duet’s SMB market. |
+| Multi-workspace / tenant boundary | ✅ Multiple workspaces with membership and workspace-scoped data | ✅ Host-selected communities; formal multi-community isolation model | ✅ Organization-level isolated server/sandbox | CircleChat has the model, but should document and test isolation as explicitly as Buzz. |
+| Client surfaces | ✅ Browser web app | ✅ Tauri desktop on macOS, Windows, and Linux; repository web surface | ✅ Browser workspace; legal terms mention an app, but public feature detail is limited | A desktop wrapper/PWA is useful; native mobile is not yet the highest-value gap. |
+| Mobile client | — | 🚧 Flutter clients in active development | ◐ A mobile application is referenced in terms, but product coverage is not clear | Defer until notifications and integrations create enough mobile value. |
+| Pricing model | ✅ Self-hosted software is free; bring your own model/runtime | ✅ OSS self-hosting and currently free Block-hosted communities | ✅ Usage-based, model tokens passed through at cost, unlimited seats | Managed CircleChat should make model/runtime costs visible and predictable. |
+| Model-provider ownership | ✅ Bring any HTTP/WS agent runtime and its chosen model | ✅ Bring providers/agents; Buzz supplies the workspace, not the brain | ✅ Managed gateway across 900+ models plus connected subscriptions/BYO gateways in the agent harness | CircleChat needs a central optional gateway without sacrificing BYO. |
+
+## 2. Human collaboration and workspace UX
+
+| Capability | CircleChat | Buzz | Duet | CircleChat implication |
+| --- | --- | --- | --- | --- |
+| Humans and agents as first-class members | ✅ Same member directory, channels, DMs, tasks, org chart, and notifications | ✅ Same signed identity model and room affordances | ✅ AI participates as a named shared teammate; multiple agents can share workspace memory | Core parity and a continuing CircleChat strength. |
+| Open/public and private channels | ✅ Channels can be private; membership enforced | ✅ Open and hidden invite-only channels | ✅ Channels are publicly documented; permission detail is less clear | No urgent gap. |
+| Direct messages | ✅ Human/agent DMs | ✅ 1:1 and group DMs, up to nine participants | ◐ Group chats/threads are documented; DM semantics are not clear | Group DMs would close a small collaboration gap. |
+| Threads | ✅ Message threads and thread-triggered agent wakes | ✅ Mandatory topic sub-replies in Stream plus Forum replies | ✅ Threads are publicly documented | Strong parity. |
+| Long-form forum | — | ✅ Dedicated asynchronous Forum surface | — Not found | Useful for community products, but not a core execution priority. |
+| Reactions | ✅ Emoji reactions, available to agents | ✅ Signed reactions and reaction workflow triggers | — Not found in public Duet material | CircleChat already has richer social collaboration than Duet publicly shows. |
+| Mentions | ✅ Member, `@everyone`, and `@channel` mentions with agent wakes | ✅ Mentions and agent participation | ◐ Collaboration is clear, but mention behaviour is not publicly detailed | No material gap. |
+| Presence and typing | ✅ Live presence and typing indicators | ✅ Presence and typing for humans and agents | — Not publicly evidenced | CircleChat is ahead of Duet on real-time team-chat fidelity. |
+| In-app notifications | ✅ Notification centre for mentions, DMs, task events, approvals, and system events | ✅ Home/activity feed and in-app notifications | ◐ Agents post alerts to channels; a dedicated notification centre is not publicly detailed | Keep improving actionable notifications and escalation grouping. |
+| Push notifications | — | 🚧 Planned | — Not publicly evidenced | Add after a PWA/mobile surface exists. |
+| Workspace search | ✅ Permission-aware conversation search; agents have search API | ✅ One search index across conversation, workflow, approval, and Git events | ◐ Hybrid memory retrieval exists; broad end-user workspace search is not clearly documented | Expand CircleChat search beyond messages to tasks, goals, approvals, artifacts, and runs. |
+| Files and media | ✅ Upload, paste/drop, previews, file browser, deletion, and type-aware viewer | ✅ Media uploads, thumbnails, and frame-specific discussion | ✅ Persistent files shared by team and agents | CircleChat is competitive; media annotation is a Buzz edge. |
+| Collaborative channel document/canvas | — | ✅ One shared canvas per channel, writable by humans and agents | — Not found | A lightweight project brief/decision canvas would improve context without becoming a full docs suite. |
+| Voice huddles | — | ◐ Voice relay exists; README says lifecycle work is still being wired | — Not found | Low priority unless customer demand proves synchronous voice matters. |
+| Message edit and soft delete | ✅ Edit/delete with timestamps | ✅ Edit/delete; soft-deleted events remain auditable | — Public behaviour not detailed | CircleChat should retain immutable audit metadata when content is edited/deleted. |
+| Guest access | — Only admin/member workspace roles | ✅ Channel-scoped guests are designed and documented | — Public role detail is limited outside Enterprise RBAC | Add scoped guests for clients, contractors, and reviewers. |
+| Moderation/reporting | — No dedicated moderation queue | ✅ Private reports, owner/admin queue, enforcement, and audit | — Not found | Needed only if CircleChat expands beyond trusted teams. |
+| Org chart/reporting lines | ✅ Humans and agents can have `reportsTo`; agents also have titles, briefs, and capabilities | — Teams/personas exist, but a reporting hierarchy is not a core documented model | — Not publicly evidenced | Distinctive CircleChat capability; use it in routing, permissions, and roll-ups. |
+
+## 3. Work management and orchestration
+
+| Capability | CircleChat | Buzz | Duet | CircleChat implication |
+| --- | --- | --- | --- | --- |
+| General task system | ✅ Workspace task model and UI | ◐ Agent jobs/handoffs exist, but Buzz’s own current integration proposal says conversations lack a structured path into project tracking | ✅ Agent task list plus executable Boards | CircleChat has the strongest general work record today. |
+| Kanban board | ✅ Backlog, in progress, blocked, review, done; drag/drop | — No general-purpose kanban found | ✅ User-defined Board columns act as executable workflow states | Add configurable columns and per-column automation to match Duet without losing governance. |
+| Task metadata | ✅ Assignees, labels, due date, progress, source channel/message, comments, activity | ◐ Git/review jobs have domain metadata; no comparable general task schema found | ◐ Boards/cards are present; field depth is not publicly documented | CircleChat is ahead on structured task detail. |
+| Subtasks | ✅ Parent/child task hierarchy | — Not found | — Not publicly evidenced | CircleChat edge. |
+| Task links and dependencies | ✅ Relates, blocks, duplicate; unconditional and conditional branch edges | ◐ Workflow step dependencies exist, not general task dependencies | ◐ Board state transitions exist; dependency graphs are not publicly detailed | Keep dependency-aware execution central to the product story. |
+| Automatic dependency release | ✅ Blocked tasks wake their assignees only when prerequisites complete | ◐ Workflows coordinate steps | ✅ Board stages/relays advance work | Strong parity; expose the dependency graph more visibly. |
+| Goals and projects | ✅ Nested project/goal hierarchy with owners and completion roll-up | — No structured goal tree found | — No structured goal tree publicly evidenced | Major CircleChat differentiator. |
+| Goal decomposition | ✅ LLM planner validates and materialises a dependency graph of tasks | — Not found as a platform feature | ◐ Agents can plan work, but no equivalent governed goal-to-DAG surface is public | Keep planning deterministic, inspectable, and schema-validated. |
+| Capability-based routing | ✅ Planner assigns tasks using agent capabilities, titles, briefs, and org context | ◐ Personas and teams exist; agents can orchestrate other agents | ◐ Agents/skills can execute in parallel; automatic task-to-agent routing details are limited | Make routing decisions visible and editable by humans. |
+| Workspace mission → new goals | ✅ Daily mission planner proposes bounded, deduplicated goals with backpressure | — Not found | ◐ Persistent coworker runs recurring business jobs, but mission-to-goal generation is not public | Unique and powerful; add human policy controls before enabling by default at scale. |
+| Goal progress ledger | ✅ Plan, facts, guesses, progress notes, dead ends, typed loop/progress assessment | — Not found | ◐ Context graph preserves decisions and precedents; not a goal ledger | CircleChat’s ledger plus Duet-style decision memory would be a strong combination. |
+| Review queue and SLA escalation | ✅ Review state, deliverable checks, stale-review escalation | ◐ Code review surface and merge approvals | ◐ Human approval stages/blocked Board columns | Strong base; add a unified “needs me” review inbox. |
+| Reusable agent teams | ◐ Org chart, profiles, capabilities, and team export/import; no named team template UI | ✅ Built-in/operator-defined personas and named teams | ✅ Shared skills/agents; parallel channels and agent harness subagents | Add named, reusable team blueprints on top of existing export/import. |
+| Agent-authored delegation | ✅ `delegate_to` creates/assigns work with a structured brief | ✅ Agents can orchestrate other agents and create workspace resources | ✅ Relay states can invoke subagents; Boards assign AI to stages | Strong parity. |
+| Human-authored workflow builder | — Fixed product logic, no general workflow editor/DSL | ✅ YAML-as-code workflows | ✅ No-code executable Boards plus agent-authored relays | Highest-priority product gap. |
+| Long-running state machine | ◐ Heartbeats, persisted tasks/memory, and bounded continuations; no explicit timer/poll/terminal job model | ◐ Workflow runs and schedules exist; durable agent wait semantics are not a headline capability | ✅ Relays persist `agent`, `script`, `poll`, `timer`, and `terminal` states for jobs lasting days or months | Add a durable job/run state machine using the existing queue, ledger, approvals, and tasks. |
+| Trigger catalogue | ◐ Built-in mention, DM, channel, thread, task, approval, schedule, ambient, test, and continuation triggers | ✅ Message, reaction, schedule, and webhook workflow triggers | ✅ Cron, webhooks, Slack/email triggers, Boards, and polls | Expose CircleChat’s triggers to users and add webhook/integration events. |
+| Conditional workflow logic | ✅ Conditional task edges, but not a user-facing workflow language | ✅ YAML conditions | ✅ Agent-reasoned Board transitions and relay routing | Build a simple state/condition editor before a full DSL. |
+
+## 4. Agent runtime, tools, models, and extensibility
+
+| Capability | CircleChat | Buzz | Duet | CircleChat implication |
+| --- | --- | --- | --- | --- |
+| Agent connection modes | ✅ Long-lived WebSocket and webhook/HTTP adapters | ✅ Nostr relay, agent-first CLI, ACP harness, and MCP surface | ✅ Hosted agents, CLI/SDK, file protocol, MCP, and external agent connection | CircleChat’s HTTP/WS contract is simple; adding standards support would broaden adoption. |
+| Supported agent families | ✅ Hermes, OpenClaw, and custom runtimes | ✅ Goose, Codex, Claude Code, built-in Buzz agent, and custom tools | ✅ Duet agent, Codex, Claude/OpenClaw-style agents, scripts, and external file-capable agents | Add a generic ACP adapter and document external harness recipes. |
+| Agent SDK/CLI | ◐ Typed HTTP/WS contract and agent API; no polished standalone CLI/SDK | ✅ `buzz-cli`, typed SDK, ACP, MCP | ✅ Open-source CLI and SDK | Ship an official TypeScript/Python SDK and CLI. |
+| Central model catalogue | — Model selection is delegated to each external runtime | ◐ Provider can be swapped; no central multi-provider catalogue is a core feature | ✅ 900+ models and multiple gateways | Add an optional gateway/catalogue, keeping BYO agents intact. |
+| Automatic model routing | — No task-aware router | — No public automatic router | ✅ Tier-based classifier routes by task and can re-route mid-turn | High-value Duet feature to borrow. |
+| Advisor/escalation model | — No stronger-model consultation primitive | — Not found | ✅ `ask_advisor` escalates consequential decisions | Add an optional planner/reviewer escalation route before inventing a complex router. |
+| Per-message/per-task model choice | ◐ Agent profile stores a model; runtime ultimately decides | ◐ Agent persona/provider configuration | ✅ Model/tier can be chosen per message/session | Improve human visibility and override controls. |
+| Skills | ✅ Per-agent skill files, equip/quarantine/restore, UI editing, routing descriptions | ✅ Persona packs and MCP tool composition; repository carries agent skills | ✅ Shared skills library and skill allowlists | Build discovery, versioning, trust, and workspace/team assignment around the existing skills layer. |
+| MCP | ◐ CircleChat equips its own MCP/API bridge, but there is no general external MCP server catalogue | ✅ MCP is a first-class tool boundary | ✅ Remote MCP plus Composio integration layer | Make external MCP installation and scoped credentials a P0 feature. |
+| SaaS connectors | — README explicitly says there is no Gmail/GitHub/Slack/CRM catalogue | — No comparable integration catalogue; generic MCP/workflows can be wired | ✅ 10,000+ integrations via Composio plus direct/custom APIs | Biggest practical capability gap versus Duet; integrate an ecosystem rather than building every connector. |
+| Web search/browser | ✅ Agent API search/browser endpoints and installable browser skill | ◐ Can be supplied through MCP/tools; no native browser feature highlighted | ✅ Full internet, web search, scraping, and Firecrawl-powered skills | CircleChat needs first-class browser observability and domain policies. |
+| Code execution | ✅ Optional hardened throwaway Docker sandbox for Python/bash; agent containers also carry tools | ◐ Shell/file MCP runs at the operator’s trust level with bounded processes | ✅ Isolated workspace sandbox plus agent coding tools and guardrails | CircleChat has a strong sandbox story; expose results in the run UI. |
+| Persistent workspace filesystem | ✅ Shared `/workspace`, project markdown layer, object store, and agent homes | ✅ Relay media/canvases/repos; agent working directories are operator-managed | ✅ Private persistent server/filesystem per organization | Strong parity. |
+| Image/video model access | — No model-media gateway | — Not a core agent surface | ✅ Gateway includes image and video models; memory can observe images | Add only after the central gateway exists. |
+| Mid-run interruption/steering | — New events enqueue runs; no documented in-flight steering protocol | ◐ Relay steering is part of remote-agent design; implementation status is unclear | ✅ Native interrupts and queued follow-ups in the open agent harness | Add cancellable runs and user steer/follow-up semantics. |
+| Multi-turn continuation | ✅ Optional, budget-checked, action-gated, and depth-capped continuation | ✅ Agent sessions self-summarize and continue; up to eight concurrent ACP sessions | ✅ Durable turn state, relays, compaction, and process-independent resume | CircleChat should evolve continuations into explicit durable jobs. |
+| Remote agent deployment | — Operators provision runtimes themselves | 🚧 Provider-based remote deployment is specified/planned | ✅ Managed remote runtime is the product | Managed CircleChat should provision agent runtimes without taking away self-host freedom. |
+
+## 5. Memory, knowledge, and context
+
+| Capability | CircleChat | Buzz | Duet | CircleChat implication |
+| --- | --- | --- | --- | --- |
+| Shared team memory | ✅ Shared editable memory block injected into every agent | ◐ Shared channel history, canvas, project memory, and search | ✅ One workspace memory shared by every agent | Strong parity. |
+| Per-agent memory | ✅ Private editable blocks plus scoped KV memory | ◐ Agent history/memory is community-scoped; detailed structure is not prominent | ✅ Curated and observational memory persists across sessions | CircleChat has good primitives but weaker automatic curation. |
+| Conversation/task-scoped memory | ✅ KV scopes for global, conversation, and task contexts | ◐ Context is naturally room/project scoped | ◐ Channels/files scope work; lower-level memory is retrieved by relevance | CircleChat edge in explicit scope control. |
+| Semantic workspace recall | ✅ Embedding-based RAG for artifacts, messages, tasks, and notes | ◐ Permission-aware Postgres full-text search; vector recall is not documented | ✅ Hybrid pgvector and keyword retrieval fused with ranking | Upgrade CircleChat retrieval quality and show citations/receipts in the UI. |
+| Decision/precedent memory | ◐ Goal ledger records facts, guesses, progress, and dead ends, but not a general decision graph | — Signed history is auditable but not automatically distilled into precedent | ✅ Observer and reflector preserve inputs, alternatives, user steers, policies, precedents, and exceptions | Highest-value memory improvement: add observation/reflection on top of existing blocks and RAG. |
+| Automatic memory curation | ◐ Optional memory janitor plus agent-authored block edits | — Not found as a structured automatic layer | ✅ Three-layer observer/reflector system with dedicated evals | Build a conservative, inspectable memory observer with human correction. |
+| Task-thread condensation | ✅ Rolling summary of older task comments | ◐ Agent session compaction/summarization exists | ✅ Session and global reflection/compaction | Strong base. |
+| Project-file context injection | ✅ Markdown project index, lexical/semantic matching, and capped prompt injection | ✅ Repos, canvases, and unified project search | ✅ Files, skills, apps, and context loaded from the persistent server | Strong parity. |
+| Memory inspection/editing | ✅ Agent detail UI and API allow humans/agents to inspect/edit memory | ◐ Search and relay history are visible; structured memory controls are unclear | ✅ CLI commands inspect/search memory; product memory is workspace-local | Make provenance and “why this was recalled” visible. |
+| Multimodal memory | — Text-centric memory/RAG | — Not found | ✅ Screenshots and UI captures are observed into recallable text | Later enhancement after image-capable model support. |
+
+## 6. Automation and external reach
+
+| Capability | CircleChat | Buzz | Duet | CircleChat implication |
+| --- | --- | --- | --- | --- |
+| Scheduled work | ✅ Per-agent heartbeats plus daily mission and periodic goal/review sweeps | ✅ Scheduled YAML workflows | ✅ Cron jobs and durable timers | Expose schedules as user-owned objects, not only agent configuration. |
+| Event-triggered work | ✅ Rich built-in product events | ✅ Message/reaction/webhook events | ✅ Webhooks and connected-app triggers | Turn the existing event bus into a safe workflow trigger API. |
+| Incoming webhooks | — Agent webhook is an execution adapter, not a general user workflow webhook | ✅ Workflow webhook triggers | ✅ Relays/apps can receive webhooks | P0 for integrations and custom automation. |
+| Outgoing API actions | ◐ Agents can request approval and use their own tools, but CircleChat has no connector layer | ◐ Workflows/agents can call tools through MCP/CLI | ✅ Broad connector and arbitrary API reach | Connector scopes and approval policy should wrap every external action. |
+| No-code workflow authoring | — Not present | — YAML is code/config | ✅ Executable Boards described in plain English | Add stage rules to the existing board before building a separate canvas. |
+| Workflow-as-code | — No user-authored workflow files | ✅ YAML workflows in project/workspace | ◐ Relays are defined through SDK/agent logic; skills are files | A compact YAML/JSON format would aid versioning and self-hosted operators. |
+| Workflow traces | ✅ Agent run trace/action records, but no cross-step workflow run object | ✅ Every workflow step is traced in the shared event log | ✅ Relay states and current state are observable | Introduce a first-class workflow/job run that links agent runs, approvals, tasks, and artifacts. |
+| Durable wait/poll | — No explicit persisted wait/poll primitive | ◐ Scheduled workflows; no comparable long-wait agent primitive documented | ✅ Poll and timer states survive without a live process | Critical for email, CRM, approvals, and multi-day business processes. |
+| Human checkpoint | ✅ Functional approval cards and review state | 🚧 Approval infrastructure exists; executor persistence/resume is incomplete | ✅ External actions require explicit approval; Boards can surface human stages | CircleChat currently has the most complete documented in-platform approval replay. |
+| App-generated triggers | — No hosted app runtime | ◐ Webhooks can trigger workflows | ✅ Hosted apps/services and webhook endpoints share workspace context | App hosting can become a safe extension surface for CircleChat workflows. |
+
+## 7. Governance, safety, cost, and observability
+
+| Capability | CircleChat | Buzz | Duet | CircleChat implication |
+| --- | --- | --- | --- | --- |
+| Typed action allowlist | ✅ Server applies only known action shapes | — Agents receive platform tools; no equivalent output action allowlist is documented | ◐ Tool layer plus guardrails and approvals; exact hosted-platform allowlist is not public | Keep this as a core safety guarantee. |
+| Per-agent action scopes | ✅ Safe default scopes; wildcard requires explicit opt-in | ◐ Cryptographic identity and channel membership scope access, but not fine-grained action types | ◐ Enterprise RBAC and integration permissions; agent action granularity is not public | Surface scopes as understandable permission bundles. |
+| Risk-based action gating | ✅ Configurable low/medium/high action gate | — Not found; workflow approvals are partial | ✅ External actions require approval; semantic guardrails can warn/block tools | CircleChat has a strong foundation. |
+| Approval decision and resume | ✅ Approve/deny, notes, agent wake, and auto-replay of eligible stored actions | 🚧 Schema/API/MCP/UI exist, but executor does not yet suspend and resume | ✅ External actions pause for explicit approval | CircleChat edge over Buzz; add expiry, delegation, and policy templates. |
+| Secret handling | ✅ Approval-delivered values go directly to agent environment and are not stored in chat/DB; persisted output is redacted | ◐ Private keys and platform auth are well-defined; general action-secret delivery is not | ✅ Stored secrets become placeholders; real values are injected at the network layer to approved destinations | Duet’s network-layer secret broker is the stronger long-term model. |
+| Reply/output guard | ✅ Rejects tracebacks, refusals, tool JSON leaks, repetition, secret leaks, and meta-narration | — No comparable content guard documented | ◐ Pattern and semantic guardrails protect commands/file writes; response filtering is not the focus | Preserve and expand with policy-specific output validation. |
+| Sandboxed code | ✅ Networkless, read-only, non-root, capability-dropped, CPU/memory/PID/time limited container | ◐ Bounded shell process, but explicitly runs at operator trust | ✅ Firecracker-backed isolated sandbox plus language/runtime tools | Strong CircleChat security advantage over Buzz’s shell posture. |
+| Cost metering | ◐ Estimated tokens and dollars because external runtimes do not return canonical usage | — Not found | ✅ Per-message token cost, per-agent tracking, usage reports, pass-through billing | Add actual usage ingestion from runtimes/gateway while retaining estimates as fallback. |
+| Agent/workspace budget stops | ✅ Per-agent and workspace monthly caps, 80% warning, and hard stop | — Not found | ◐ Usage controls and auto-pause patterns are described; exact general product controls are not fully documented | CircleChat edge; make budget policy visible during planning. |
+| Run history | ✅ Queued/running/ok/failed records with trigger, context, result, trace, cost, errors | ✅ Signed event history and workflow traces | ✅ Observable agent/relay progress and usage | Improve CircleChat’s run viewer to show every tool/action/approval/artifact link. |
+| External observability | ✅ Optional Langfuse trace export plus Pino logs | ✅ Prometheus/configured service telemetry plus audit log | ◐ Usage reports and managed monitoring; export surface is not public | Add OpenTelemetry and admin export. |
+| Tamper-evident audit | — Ordinary database audit rows | ✅ Hash-chain audit log plus signed Nostr events | — Enterprise audit logs are listed, but not cryptographically tamper-evident | Borrow signed/hash-chained audit only if regulated buyers need it; do not rewrite the platform around Nostr by default. |
+| Deliverable existence gate | ✅ “Done” requires substantive task evidence for agent-completed work | — Not found | ◐ Board exit criteria/self-verification are described, but an enforced artifact gate is not public | CircleChat differentiator. |
+| LLM deliverable verification | ✅ Optional rubric judge checks relevance/fabrication; rationale is stored | — Not found | ◐ Duet has memory evals and agent self-verification, not a documented per-task done gate | CircleChat differentiator; add eval sets and multiple verifier types. |
+| Deterministic web render check | ✅ Optional headless Chromium observation before a web deliverable can pass | — Not found | ◐ Apps are hosted and run, but a review gate against acceptance criteria is not public | Extend to tests, PDFs, spreadsheets, links, and API health checks. |
+| Run loop detection | ✅ Detects repeated and alternating action signatures, suppresses continuation, injects a break directive | — Not found | ◐ Relays have terminal states/guardrails; explicit behavioural loop detection is not public | CircleChat edge. |
+| Goal stall recovery | ✅ Typed progress assessment, human escalation, optional capped re-plan preserving facts/dead ends | — Not found | ◐ Durable jobs persist, but stalled-goal re-plan semantics are not public | CircleChat edge. |
+| Productivity anomaly alert | ✅ Flags agents that run repeatedly with zero applied actions and estimates wasted spend | — Not found | ◐ Managed monitoring is claimed; this exact behavioural alert is not public | Productize it in Analytics and recommendations. |
+| Run reaper | ✅ Stuck running rows are closed/recovered | — Not found | ✅ Serverless/resumable turn state reduces sticky-process failure | Keep reliability controls visible to operators. |
+| RBAC and SSO | ◐ Admin/member roles; no SSO or fine-grained human roles | ✅ Owner/admin/member/guest plus channel membership; enterprise SSO not prominent | ✅ Enterprise SSO and RBAC | P1 for larger organizations. |
+| Encryption and credential isolation | ◐ TLS via Caddy; storage encryption is operator/infrastructure responsibility | ◐ TLS and storage-layer at-rest encryption; DMs are not E2EE | ✅ TLS, AES-256 at rest, isolated microVM, secret proxy | Document a hardened deployment profile and encryption responsibilities. |
+| Formal isolation/security model | ◐ Workspace guards and tests, but no formal model | ✅ Host-derived boundary with TLA+/Tamarin claims in project docs | ◐ Single-tenant compute and provider compliance attestations | Add adversarial tenant-isolation tests before enterprise claims. |
+
+## 8. Artifacts, apps, Git, and shipping work
+
+| Capability | CircleChat | Buzz | Duet | CircleChat implication |
+| --- | --- | --- | --- | --- |
+| Task deliverable namespace | ✅ Task artifacts are named, versioned, attributed, content-hashed, and soft-deletable | — No task-artifact namespace found | ◐ Persistent files/apps exist; per-task version/hash semantics are not public | Major CircleChat edge. |
+| Rich file viewer | ✅ PDF, Markdown, HTML sandbox, text/code, image, video, and audio | ✅ Media/repo/canvas views and annotations | ✅ Files and generated artifacts are inspectable; format list is not public | Strong parity. |
+| Build web apps | ◐ Agents can write artifacts/code, but CircleChat does not turn them into managed applications | ◐ Agents can edit repos and canvases, not a general app-builder/host | ✅ Core product feature | A safe preview/publish path is a high-value Duet feature to borrow. |
+| App hosting | — No application runtime | — No general user-app runtime | ✅ Apps deploy to shareable HTTPS URLs | P0/P1 depending on target segment. |
+| Custom domains | — | — | ✅ One custom domain per app, automatic TLS, unlimited apps | Add after basic preview hosting works. |
+| Native Git hosting | — Shared workspace files only | ✅ Smart HTTP Git backend | — Agents can work with repos, but Duet is not a native forge | Integrate GitHub/GitLab first; do not build a forge unless sovereignty demands it. |
+| Branch as collaboration room | — | ✅ Branch channel carries patches, CI, review, approval, merge, and archives afterward | — Not found | A linked provider-backed “PR room” would capture most of the value at far lower cost. |
+| Signed pushes/branch protection | — | ✅ Nostr-signed pushes and branch protections/approval events | — Not native | Integrate provider protections; native signed Git is a niche later bet. |
+| Inline code review and CI events | — Not a native surface | ✅ Git events, patches, review, and CI in the channel/event log | ◐ Coding agents can run tools, but no native cross-repo review surface is public | Add GitHub/GitLab PR summaries, checks, diffs, and approvals into task/channel context. |
+| Hosted webhook/service endpoint | — | ✅ Workflow webhook trigger, not arbitrary hosted app service | ✅ Agent-built app/service can expose a webhook | Useful extension point once app hosting exists. |
+| Delivery QA | ✅ Evidence, verifier, render observation, and stored rationale before done | ◐ CI/maintainer approvals for code, no general artifact rubric | ◐ Agent/Board self-checking, no public universal deliverable gate | This is CircleChat’s best horizontal differentiator; expand rather than dilute it. |
+
+## 9. CircleChat’s missing features, prioritized
+
+### P0 — required to compete for real business workflows
+
+| Missing capability | Competitor proof | Recommended CircleChat build | Why now |
+| --- | --- | --- | --- |
+| Integration/MCP catalogue with OAuth and scoped credentials | Duet advertises 10,000+ integrations; Buzz and Duet use MCP as a standard boundary | Add workspace connector registry, OAuth/secret broker, tool discovery, per-agent grants, approval policy, health status, and audit records | Without external actions, CircleChat governs work that cannot reach the systems where business work lives. |
+| Durable user-authored workflows | Buzz has YAML automation; Duet has Boards and relays | Create first-class Workflow and WorkflowRun objects with trigger, state, transition, timer, poll, agent step, human step, terminal outcome, retry, and evidence links | This converts fixed internal automation into a platform. |
+| Incoming webhooks and integration events | Buzz and Duet both accept webhook-driven work | Expose signed webhook endpoints with dedupe keys, rate limits, schemas, replay protection, and mapping to workflow starts | Necessary for CRM, inbox, CI, forms, and monitoring use cases. |
+| Real model usage and routing | Duet tracks actual usage and routes across models | Let runtimes report usage; add an optional OpenAI-compatible gateway, price table, routing tiers, human override, and advisor route | Makes existing budgets accurate and improves quality/cost automatically. |
+| Durable waits and resumable jobs | Duet relays persist timer/poll states for days or months | Persist job state separately from chat; resume on timer, webhook, approval, or poll result; link every turn to one job | Required for email follow-up, support, sales, procurement, and long-running research. |
+
+### P1 — closes the most visible product gaps
+
+| Missing capability | Competitor proof | Recommended CircleChat build | Why |
+| --- | --- | --- | --- |
+| Decision/precedent memory | Duet’s context graph preserves alternatives, steers, policies, and exceptions | Add an inspectable observer/reflector that writes typed decision memories with provenance and human correction | Existing RAG retrieves facts; this helps agents learn why decisions were made. |
+| App preview and hosting | Duet builds and hosts apps with HTTPS/custom domains | Turn a task’s web artifacts into an isolated preview, then an approval-gated published app with logs and health checks | Makes CircleChat visibly deliver outcomes, not only files. |
+| Provider-backed Git/PR rooms | Buzz’s branch-as-channel unifies conversation, patches, CI, and merge | Integrate GitHub/GitLab repositories, PRs, diffs, checks, reviews, and branch protection into channels/tasks | Captures Buzz’s developer value without building a Git server. |
+| Executable board stages | Duet assigns an AI and instructions to each Board column | Make columns configurable and attach entry/exit rules, agent/skill, verification, escalation, and next transition | Fits CircleChat’s current board and verifier naturally. |
+| Reusable team blueprints | Buzz has named persona teams; Duet shares skills/agents | Package agents, org relationships, skills, scopes, budgets, channels, and workflows as versioned templates | Existing team export/import is close; productize it. |
+| Unified review inbox | All three products surface approvals/reviews in different ways | Merge task review, approvals, failed verification, stalled jobs, budget warnings, and connector errors into “Needs you” | Reduces the human supervisor’s coordination cost. |
+| Cancellable/steerable runs | Duet supports native interrupts and follow-ups | Add cancel, steer, queued follow-up, timeout extension, and ownership controls to active runs | Essential once jobs last longer and perform external actions. |
+| Enterprise access controls | Buzz has guest/channel boundaries; Duet lists SSO/RBAC | Add guests, custom roles, SSO/OIDC, service accounts, audit export, retention, and data residency controls | Needed for larger teams and client workspaces. |
+
+Implementation status (2026-08-06): all eight P1 rows above are implemented end to end. The operator UI is under **Platform** and **Needs you**; schema/API/worker contracts are documented in [`p1-platform.md`](p1-platform.md), and `npm run test:p1-e2e` covers the release paths and isolation boundaries.
+
+### P2 — valuable after the execution platform is complete
+
+| Missing capability | Competitor proof | Recommendation |
+| --- | --- | --- |
+| Cross-object search | Buzz searches chat, workflow, approval, and Git in one index | Index tasks, goals, approvals, artifacts, runs, files, and connector objects with permission filters. |
+| Channel canvas / decision brief | Buzz has agent-writable canvases | Add a lightweight durable channel/project brief, not a full document editor. |
+| Desktop/PWA and push | Buzz ships desktop and is building mobile | Start with installable PWA, background notifications, deep links, and offline read cache. |
+| Multimodal model/memory support | Duet gateway and memory support image/video work | Add after model gateway, then ingest visual observations with provenance. |
+| Tamper-evident audit | Buzz hash-chains audit and signs events | Offer signed audit exports or chained records for regulated deployments without requiring Nostr everywhere. |
+| Voice huddles and media annotation | Buzz has voice/media collaboration | Defer unless a target customer segment needs it. |
+
+## 10. What Buzz and Duet are missing relative to CircleChat
+
+### Buzz gaps
+
+| CircleChat advantage | Buzz status | Why it matters |
+| --- | --- | --- |
+| Nested projects/goals with auto-decomposition and roll-up | No equivalent structured goal tree found | Buzz can coordinate conversation and code, but CircleChat can explain why each task exists and how it advances an objective. |
+| General kanban/tasks with subtasks, dependencies, labels, due dates, progress, and comments | General project tracking is not a complete public surface; a current Buzz proposal explicitly identifies the missing path | CircleChat can operate non-code work and mixed teams without outsourcing the system of record. |
+| Versioned, attributed, hashed task artifacts | Not found | Provides a durable evidence contract between agents and reviewers. |
+| Enforced deliverable existence and LLM/render verification | Not found | “Done” means inspected evidence, not a message or optimistic status change. |
+| Functional approval replay/resume | Buzz documents the executor gap | CircleChat’s approval is already part of execution, not only UI/schema. |
+| Per-agent/workspace budgets and hard stops | Not found | Prevents autonomous cost runaway. |
+| Reply guard, secret redaction, sandboxed code, and safe action scopes | Buzz has strong identity/channel security, but its shell runs at operator trust and equivalent output/action controls are not documented | CircleChat constrains model failure at several boundaries. |
+| Loop detection, stall assessment, capped re-plan, run reaper, productivity alerts | Not found | CircleChat detects “alive but useless” agents, not only crashed infrastructure. |
+| Org chart and capability-based task routing | Personas/teams exist, but structured reporting/routing is not the public centre | CircleChat can model accountability and delegation explicitly. |
+
+### Duet gaps
+
+| CircleChat advantage | Duet status | Why it matters |
+| --- | --- | --- |
+| Fully self-hostable/open-source collaboration platform | Only the agent harness is open-source; hosted product is managed | CircleChat operators can inspect, change, and own the entire control/data plane. |
+| Structured project/goal hierarchy and planner-created dependency DAG | Not publicly evidenced | CircleChat gives autonomous work an inspectable plan and traceability to mission. |
+| Rich general task record and versioned task deliverables | Boards/files exist; equivalent task/artifact semantics are not public | CircleChat makes review and responsibility more explicit. |
+| Enforced per-task verifier with stored rationale and deterministic render observation | Duet discusses self-verification and memory evals, not an equivalent universal done gate | CircleChat can prove why work was accepted. |
+| Server-side typed action contract and safe-default scopes | Duet has tools, approvals, guardrails, and Enterprise RBAC; equivalent hosted action typing is not public | CircleChat provides a narrow, auditable capability boundary independent of model behaviour. |
+| Agent/workspace budget hard stops in the product schema | Duet has excellent real usage reporting; exact general hard-cap controls are less publicly specified | CircleChat has a clear governance primitive, though its current cost is estimated. |
+| Real-time team-chat depth | Public Duet pages focus on channels/threads, not reactions, presence, typing, DMs, notifications, editing, or moderation | CircleChat is a more complete day-to-day team room. |
+| Org reporting lines, capabilities, and ownership roll-up | Not publicly evidenced | CircleChat can express team structure, not only shared access. |
+| Open database/audit schema and inspectable control plane | Hosted platform internals are private | Self-hosters can audit and extend CircleChat without vendor dependency. |
+
+## 11. Recommended build sequence
+
+The fastest route is to extend CircleChat’s existing primitives rather than add disconnected feature islands.
+
+1. **Connector foundation:** external MCP registry, OAuth/secret broker, per-agent grants, connector health, and signed incoming webhooks.
+2. **Durable job model:** Workflow + WorkflowRun + persisted states (`agent`, `tool`, `human`, `timer`, `poll`, `terminal`) linked to current agent runs.
+3. **Executable board:** configurable stages, stage instructions/skills, entry/exit criteria, verifier, approval, escalation, and transition rules.
+4. **Accurate model control:** optional gateway, actual token/cost ingestion, routing tiers, fallback, advisor, and budget-aware planning.
+5. **Context graph:** provenance-backed observations, decisions, alternatives, user steers, policies, exceptions, reflection, and memory evals.
+6. **App preview/publish:** isolated artifact preview, logs, health check, approval gate, stable URL, then custom domains.
+7. **Git provider rooms:** repository linking, PR/diff/check events, code review, and merge approval; build native Git hosting only if customers demand sovereignty beyond provider integration.
+8. **Supervisor experience:** one “Needs you” inbox and a job timeline joining task, agent runs, tool calls, approvals, artifacts, verification, and spend.
+
+## 12. What not to copy yet
+
+| Competitor feature | Recommendation | Reason |
+| --- | --- | --- |
+| Buzz’s Nostr protocol as the base of every object | **Do not re-platform now.** Borrow portable identities or chained audit records selectively. | Rewriting CircleChat’s data model would delay higher-value integrations and durable workflows; customers need the outcome more than the protocol. |
+| Buzz’s native Git hosting | **Integrate first.** | GitHub/GitLab integration captures most value with far less security and operational surface. |
+| Buzz voice, forums, and culture features | **Defer.** | They improve community depth but do not unblock agents doing useful governed work. |
+| Duet’s enormous model catalogue on day one | **Start curated.** | A small tested routing set is easier to price, evaluate, and support than 900 indistinguishable choices. |
+| Duet-style unrestricted app hosting | **Ship behind task evidence and approval.** | CircleChat can differentiate by treating a deployment as a governed deliverable with provenance, checks, and rollback. |
+| A general drag-and-drop automation canvas | **Build executable columns and a compact workflow schema first.** | CircleChat already has tasks, dependencies, queues, triggers, and approvals; use them before introducing another abstraction. |
+
+## Sources
+
+### CircleChat implementation evidence
+
+- [`README.md`](../README.md) — product scope and honest integration limits.
+- [`api/src/db/schema.ts`](../api/src/db/schema.ts) — workspaces, identities, conversations, runs, approvals, memory, knowledge, notifications, goals, tasks, artifacts, verification, and ledgers.
+- [`api/src/agents/executor.ts`](../api/src/agents/executor.ts) — typed actions, scopes, risks, approvals, delegation, memory, code, goals, tasks, and files.
+- [`api/src/agents/context.ts`](../api/src/agents/context.ts) — per-trigger context assembly.
+- [`api/src/worker.ts`](../api/src/worker.ts) — run lifecycle, budgets, idle gate, continuations, stuck detection, redaction, and traces.
+- [`api/src/lib/planner.ts`](../api/src/lib/planner.ts), [`mission-planner.ts`](../api/src/lib/mission-planner.ts), and [`ledger-core.ts`](../api/src/lib/ledger-core.ts) — planning and progress model.
+- [`api/src/lib/task-verifier.ts`](../api/src/lib/task-verifier.ts) and [`task-artifacts.ts`](../api/src/lib/task-artifacts.ts) — evidence and verification.
+- [`api/src/lib/code-sandbox.ts`](../api/src/lib/code-sandbox.ts), [`budgets.ts`](../api/src/lib/budgets.ts), and [`redaction.ts`](../api/src/lib/redaction.ts) — governance boundaries.
+- [`web/src/App.tsx`](../web/src/App.tsx) and page/component files — shipped UI surfaces.
+- [`docs/CONFIG.md`](CONFIG.md) — operator-visible feature flags and defaults.
+
+### Buzz primary sources
+
+- [Buzz README — current works-today / being-wired status](https://github.com/block/buzz/blob/main/README.md)
+- [Buzz platform vision and current status](https://github.com/block/buzz/blob/main/VISION.md)
+- [Buzz architecture](https://github.com/block/buzz/blob/main/ARCHITECTURE.md)
+- [Buzz agent and MCP architecture](https://github.com/block/buzz/blob/main/VISION_AGENT.md)
+- [Buzz project/Git/branch-room design](https://github.com/block/buzz/blob/main/VISION_PROJECTS.md)
+- [Buzz support: relays, invitations, agent privacy, and lack of E2EE](https://block.github.io/buzz/support.html)
+- [Current Buzz proposal describing the missing structured conversation-to-project path](https://github.com/block/buzz/issues/2647)
+
+### Duet primary sources
+
+- [Duet product overview](https://duet.so/)
+- [Duet small-business use cases and operating model](https://duet.so/use-cases)
+- [Duet command-centre guide: channels, models, integrations, automations, and apps](https://duet.so/guides/how-to-build-your-ai-command-center)
+- [Duet Boards / no-code agent workflows](https://duet.so/blog/loops-vs-duet-boards)
+- [Duet pricing, model catalogue, usage, and Enterprise controls](https://duet.so/pricing)
+- [Duet data protection and secret-isolation model](https://duet.so/data-protection)
+- [Duet context-graph memory architecture and evals](https://duet.so/blog/how-duet-builds-and-evals-context-graphs)
+- [Duet app custom domains and managed TLS](https://duet.so/blog/custom-domain-names-in-duet)
+- [`duet-agent`: open-source memory, routing, relays, MCP, guardrails, and runtime](https://github.com/dzhng/duet-agent)
+- [Duet managed agent hosting and durable wait/approval model](https://duet.so/blog/where-to-host-ai-agents)
+
+## Bottom line
+
+CircleChat does not need to become Buzz plus Duet. It needs to become the place where:
+
+1. Duet-like agents can reach every business tool and stay on a job for weeks;
+2. Buzz-like developer events can enter the same shared room; and
+3. CircleChat’s existing governance decides what the team is trying to achieve, who owns each step, what evidence counts, what requires approval, when work is stuck, and what may be spent.
+
+That third layer is the part neither competitor currently matches end to end.

--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -10,7 +10,9 @@ endpoints (webhook) or one persistent WebSocket (socket mode) and respond with a
 ```jsonc
 {
   "agent": { "id": "a_…", "handle": "research", "name": "Research", "model": "...", "scopes": ["channels.reply"], "brief": "…" },
-  "trigger": "scheduled" | "mention" | "dm" | "assigned" | "approval_response" | "test",
+  "trigger": "scheduled" | "mention" | "dm" | "assigned" | "approval_response" | "workflow" | "test",
+  "modelRoute": { "tier": "balanced", "provider": "…", "model": "…", "contextWindow": 128000 },
+  "workflow": { "runId": "wfrun_…", "workflowId": "wf_…", "stateId": "research", "input": {}, "priorStepOutputs": {} },
   "triggerConversationId": "c_…" | null,
   "triggerMessageId": "m_…" | null,
   "inbox": [
@@ -40,9 +42,22 @@ Either `"HEARTBEAT_OK"` (silent — dropped by the gateway) or a set of actions 
     { "type": "set_memory", "key": "last_summary", "value": { "any": "json" } },
     { "type": "call_tool", "name": "web.crawl", "args": { "q": "…" } }
   ],
-  "trace": ["read: thread m_…", "decide: relevant"]
+  "trace": ["read: thread m_…", "decide: relevant"],
+  "usage": {
+    "provider": "your-provider",
+    "model": "the-model-actually-used",
+    "inputTokens": 1200,
+    "outputTokens": 240,
+    "cachedInputTokens": 400
+  }
 }
 ```
+
+`modelRoute` is a recommendation; a pinned runtime may ignore it. When available,
+return `usage` for the model actually called so CircleChat replaces its estimate with
+provider-grade token/cost accounting. Gateways that report later can instead call
+`POST /api/agent-api/runs/:runId/usage` with the agent bearer token. `workflow` is
+present only for an agent state inside a durable workflow.
 
 The built-in actions executed by the platform are `post_message`, `react`, `open_thread`,
 `request_approval`, and `set_memory`. `call_tool` is recorded but not executed — the

--- a/docs/p1-platform.md
+++ b/docs/p1-platform.md
@@ -1,0 +1,81 @@
+# P1 platform capabilities
+
+CircleChat’s P1 layer turns the P0 execution primitives into an operator-facing delivery and governance platform. Open **Platform** for decisions, apps, PR rooms, stages, blueprints, run control, and access; open **Needs you** for one prioritized human review queue.
+
+## Decision and precedent memory
+
+`POST /api/decisions/observe` writes a typed `decision`, `precedent`, `policy`, `exception`, or `steer` with alternatives and arbitrary provenance. Active records are injected into every agent context packet. Human correction uses `POST /api/decisions/:id/correct`: the prior row becomes `corrected`, the replacement points to it with `supersedes_id`, and both remain inspectable.
+
+## Static app delivery
+
+An app deployment snapshots one live HTML task-artifact version and its SHA-256 identity. `POST /api/apps` creates a token-isolated preview; `POST /api/apps/:id/request-publish` moves it into **Needs you**; an admin uses `POST /api/apps/:id/review` to approve or reject it. Only an approved deployment serves at `/apps/:slug`.
+
+Both preview and published responses use a deny-by-default content security policy, no forms or network connections, no base-URL changes, `nosniff`, and no referrer. Preview URLs are unguessable and never cached. Deployment logs and `/api/apps/:id/health` expose serving and artifact health. This runtime deliberately hosts self-contained static HTML; server-side code, secrets, custom domains, and outbound browser calls are outside this safety boundary.
+
+## Provider-backed PR rooms
+
+PR rooms bind a GitHub pull request or GitLab merge request to a CircleChat channel. A governed HTTP connector supplies credentials and provider base URL. Sync normalizes:
+
+- title, URL, state, head, and base;
+- changed files;
+- checks or pipelines;
+- reviews or approvals;
+- branch-protection state.
+
+`POST /api/pr-rooms/:id/sync` can also accept a provider-shaped snapshot. That path supports deterministic fixtures, webhook-fed state, and air-gapped mirrors without weakening the connector path.
+
+## Executable board stages
+
+Every fixed task status can be configured through `/api/board-stages/:stage` with a display title/order, instructions, entry and exit rules, assigned agent, skill, verification policy, escalation owner, and next transition. Rules can require an assignee, labels, minimum progress, an artifact, or a passed verification.
+
+Both drag/drop and `POST /api/tasks/:id/advance` use the same server-side gate. A failure returns every violation and can notify the escalation owner. A successful entry assigns and wakes the configured agent. The exact stage contract is snapshotted into the queue job, so a fast subsequent card movement cannot race and replace the instructions a run was meant to execute.
+
+## Versioned team blueprints
+
+Blueprint definitions package agents, reporting relationships, skill metadata, scopes, budgets, private team channels, and durable workflows. Exporting the workspace creates a new immutable version. Applying a version creates fresh agent identities/tokens, member rows, org links, channels, and workflow rows. Secrets and callback URLs are intentionally excluded.
+
+## Needs you
+
+`GET /api/needs-you` returns a permission-scoped, prioritized union of:
+
+- pending agent approvals;
+- tasks in review and failed verifications;
+- stalled goals;
+- workflows waiting for a human or recently failed;
+- workspace and agent budget warnings/stops;
+- connector health errors;
+- app publish requests.
+
+The UI provides the native decision where one exists and links directly to the source object for deeper review.
+
+## Run control
+
+Agent and workflow runs persist ownership, timeout, steer records, and queued follow-ups. `/api/{agent|workflow}-runs/:id/control` accepts `claim`, `release`, `steer`, `follow_up`, `extend`, and `cancel`.
+
+Workflow workers refuse cancelled/expired state wakes. Agent workers check before remote execution and again immediately before applying returned actions. Therefore a cancellation received while a remote model is working cannot leak its eventual side effects. Follow-ups queued during a run become a new continuation turn after completion; workflow steers/follow-ups are injected into the next agent state.
+
+## Enterprise access and audit
+
+The enterprise surface adds:
+
+- built-in admin/member/guest roles and versioned custom role permissions;
+- guest invites limited to explicit channel IDs (guests are not auto-added to later public channels);
+- OIDC authorization-code login with state, one-use state storage, PKCE S256, issuer discovery, same-origin endpoint validation, verified-email/domain policy, and role provisioning;
+- one-time service-account tokens stored only as SHA-256 hashes, with expiry, revocation, last-use tracking, and enforced `workflows.read` / `workflows.run` scopes;
+- append-only audit rows with hashed IPs and permission-filtered JSON/CSV export;
+- retention-days and data-residency policy fields.
+
+The data-residency value records and exposes the deployment policy; the operator must place Postgres, Redis, object storage, backups, and model/connector providers in the declared region. CircleChat does not falsely infer physical residency from a label.
+
+## Verification
+
+With the API and worker running against a migrated PostgreSQL/Redis environment:
+
+```bash
+cd api
+npm test
+npm run test:p0-e2e
+npm run test:p1-e2e
+```
+
+The P1 E2E suite exercises immutable decision correction and context injection, preview/publish isolation, live provider sync, stage-rule denial and deterministic execution, blueprint instantiation, action-safe cancellation, the unified inbox, custom RBAC, guest boundaries, scoped service identities, OIDC/PKCE provisioning, audit export, and cross-workspace isolation.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,9 @@ import AnalyticsPage from "./pages/Analytics";
 import BoardPage from "./pages/Board";
 import GoalsPage from "./pages/Goals";
 import SettingsPage from "./pages/Settings";
+import AutomationPage from "./pages/Automation";
+import PlatformPage from "./pages/Platform";
+import NeedsYouPage from "./pages/NeedsYou";
 import HomeRedirect from "./pages/HomeRedirect";
 
 const qc = new QueryClient({
@@ -100,7 +103,10 @@ function Shell() {
         <Route path="/skills" element={<SkillsPage />} />
         <Route path="/agents/:id" element={<AgentPage />} />
         <Route path="/approvals" element={<ApprovalsPage />} />
+        <Route path="/needs-you" element={<NeedsYouPage />} />
         <Route path="/analytics" element={<AnalyticsPage />} />
+        <Route path="/automation" element={<AutomationPage />} />
+        <Route path="/platform" element={<PlatformPage />} />
         <Route path="/settings" element={<SettingsPage />} />
       </Route>
     </Routes>

--- a/web/src/components/Board.tsx
+++ b/web/src/components/Board.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Plus, MessageSquare, GitBranch, Link2, Calendar, Lock } from "lucide-react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTasks, useMembersDirectory, useMe, useSpectator } from "../lib/hooks";
 import { api, type Task, type TaskStatus } from "../api/client";
 import Avatar from "./Avatar";
@@ -26,6 +26,16 @@ export default function Board() {
   const me = useMe();
   const spectator = useSpectator();
   const dir = useMembersDirectory();
+  const stageQuery = useQuery<{ stages: Array<{ stage: TaskStatus; title: string; position: number }> }>({
+    queryKey: ["platform", "stages"],
+    queryFn: () => api.get("/board-stages"),
+  });
+  const columns = useMemo(() => {
+    const stored = stageQuery.data?.stages;
+    if (!stored?.length) return COLUMNS;
+    const glyph = new Map(COLUMNS.map((column) => [column.id, column.glyph]));
+    return stored.map((stage) => ({ id: stage.stage, title: stage.title, glyph: glyph.get(stage.stage) ?? "•", position: stage.position })).sort((a, b) => a.position - b.position);
+  }, [stageQuery.data]);
   // The open task lives in the URL as `/board?task=<id>`, so every task has its
   // own unique, shareable, back-button-friendly address. Opening a card (or a
   // deep-link from a notification / the Goals page) is just a URL change; the
@@ -143,7 +153,7 @@ export default function Board() {
   return (
     <div className="board-wrap">
       <div className="kanban">
-        {COLUMNS.map((col) => {
+        {columns.map((col) => {
           const cards = byCol(col.id);
           return (
             <div

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useEffect, useMemo, useState } from "react";
-import { Hash, Plus, FolderOpen, Network, BookOpen, ShieldAlert, LayoutGrid, Target, BarChart3, MoreHorizontal } from "lucide-react";
-import { useConversations, useMe, useMembersDirectory, useApprovals, useTasks, useSpectator } from "../lib/hooks";
+import { Hash, Plus, FolderOpen, Network, BookOpen, Inbox, LayoutGrid, Target, BarChart3, MoreHorizontal, Workflow, Boxes } from "lucide-react";
+import { useConversations, useMe, useMembersDirectory, useNeedsYou, useTasks, useSpectator } from "../lib/hooks";
 import { api, type Conversation, type DirMember } from "../api/client";
 import { useQueryClient } from "@tanstack/react-query";
 import { useBus } from "../state/store";
@@ -11,7 +11,7 @@ export default function Sidebar() {
   const dir = useMembersDirectory();
   const me = useMe();
   const spectator = useSpectator();
-  const approvalsQ = useApprovals();
+  const needsYouQ = useNeedsYou();
   const location = useLocation();
   const nav = useNavigate();
   const qc = useQueryClient();
@@ -21,7 +21,7 @@ export default function Sidebar() {
   // Collapsed on every load; expands for the session when asked.
   const [moreOpen, setMoreOpen] = useState(false);
   const presence = useBus((s) => s.presence);
-  const pendingApprovals = approvalsQ.data?.approvals.length ?? 0;
+  const pendingNeeds = needsYouQ.data?.counts.total ?? 0;
 
   // Board unread: count tasks updated since the user last opened /board.
   // Stored per-workspace in localStorage so it survives refreshes but stays
@@ -150,16 +150,30 @@ export default function Sidebar() {
           <span className="sb-name">Files</span>
         </Link>
         <Link
-          to="/approvals"
-          className={`sb-item ${location.pathname === "/approvals" ? "active" : ""} ${pendingApprovals > 0 ? "unread" : ""}`}
+          to="/needs-you"
+          className={`sb-item ${location.pathname === "/needs-you" ? "active" : ""} ${pendingNeeds > 0 ? "unread" : ""}`}
         >
           <span className="sb-glyph">
-            <ShieldAlert size={14} strokeWidth={2} />
+            <Inbox size={14} strokeWidth={2} />
           </span>
-          <span className="sb-name">Approvals</span>
-          {pendingApprovals > 0 && (
-            <span className="sb-badge mention">{pendingApprovals}</span>
+          <span className="sb-name">Needs you</span>
+          {pendingNeeds > 0 && (
+            <span className="sb-badge mention">{pendingNeeds}</span>
           )}
+        </Link>
+        <Link
+          to="/automation"
+          className={`sb-item ${location.pathname === "/automation" ? "active" : ""}`}
+        >
+          <span className="sb-glyph"><Workflow size={14} strokeWidth={2} /></span>
+          <span className="sb-name">Automation</span>
+        </Link>
+        <Link
+          to="/platform"
+          className={`sb-item ${location.pathname === "/platform" ? "active" : ""}`}
+        >
+          <span className="sb-glyph"><Boxes size={14} strokeWidth={2} /></span>
+          <span className="sb-name">Platform</span>
         </Link>
         {moreOpen && (
           <>

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -377,6 +377,14 @@ export function useApprovals() {
   return q;
 }
 
+export function useNeedsYou() {
+  return useQuery<{ items: unknown[]; counts: { total: number; critical: number; high: number } }>({
+    queryKey: ["needs-you"],
+    queryFn: () => api.get("/needs-you"),
+    refetchInterval: 5_000,
+  });
+}
+
 export function useAnalytics(days: number) {
   const qc = useQueryClient();
   const q = useQuery<AnalyticsData>({

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -14,7 +14,7 @@ function agentColor(i: number): string {
   return `hsl(${(i * 73 + 12) % 360} 48% 52%)`;
 }
 
-// Estimated dollars: sub-cent amounts still render as a signal (<$0.01), not $0.00.
+// Sub-cent amounts still render as a signal (<$0.01), not $0.00.
 function fmtUsd(n: number): string {
   if (n === 0) return "$0";
   if (n < 0.01) return "<$0.01";
@@ -114,7 +114,7 @@ export default function AnalyticsPage() {
               />
               <StatCard
                 icon={<Zap size={15} strokeWidth={2} />}
-                label="Est. spend this month"
+                label="Model spend this month"
                 value={fmtUsd(data.totals.costUsdMonth)}
                 sub={`${fmtUsd(data.totals.costUsdRange)} in range`}
                 tone="muted"
@@ -189,7 +189,7 @@ export default function AnalyticsPage() {
                         <th>Msgs</th>
                         <th>Comments</th>
                         <th>Approvals</th>
-                        <th title="Estimated spend this month vs the agent's monthly budget">Spend (mo)</th>
+                        <th title="Reported model spend where available; otherwise the platform estimate">Spend (mo)</th>
                         <th>Last active</th>
                       </tr>
                     </thead>
@@ -369,8 +369,8 @@ function AgentRowView({ a }: { a: AnalyticsAgent }) {
         className="ana-num"
         title={
           a.budgetUsdMonth != null
-            ? `$${a.costUsdMonth.toFixed(2)} of $${a.budgetUsdMonth.toFixed(2)} monthly budget (estimated)`
-            : "Estimated spend this month — no budget set"
+            ? `$${a.costUsdMonth.toFixed(2)} of $${a.budgetUsdMonth.toFixed(2)} monthly budget (reported where available; otherwise estimated)`
+            : "Model spend this month — reported where available; otherwise estimated"
         }
       >
         {fmtUsd(a.costUsdMonth)}

--- a/web/src/pages/Automation.tsx
+++ b/web/src/pages/Automation.tsx
@@ -1,0 +1,494 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Activity,
+  Bot,
+  Cable,
+  Check,
+  Clock3,
+  Copy,
+  Gauge,
+  KeyRound,
+  Play,
+  Plus,
+  RefreshCw,
+  ShieldCheck,
+  Webhook,
+  Workflow as WorkflowIcon,
+} from "lucide-react";
+import { api, type AgentRow } from "../api/client";
+import { useSpectator } from "../lib/hooks";
+
+type Tab = "workflows" | "connectors" | "models";
+
+type WorkflowRun = {
+  id: string;
+  workflowId: string;
+  status: string;
+  currentStateId: string | null;
+  waitKind: string | null;
+  startedAt: string;
+  finishedAt: string | null;
+};
+
+type WebhookEndpoint = { id: string; name: string; url: string; active: boolean };
+type Workflow = {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
+  triggerType: string;
+  version: number;
+  definitionJson: Record<string, unknown>;
+  latestRuns: WorkflowRun[];
+  endpoints: WebhookEndpoint[];
+};
+
+type Connector = {
+  id: string;
+  name: string;
+  description: string;
+  kind: "http" | "mcp";
+  baseUrl: string;
+  authType: string;
+  status: string;
+  hasSecret: boolean;
+  lastCheckedAt: string | null;
+  lastError: string | null;
+  grants: Array<{ agentId: string; scopes: string[] }>;
+};
+
+type ModelRoute = {
+  tier: string;
+  provider: string;
+  model: string;
+  inputCostPerMtok: number;
+  outputCostPerMtok: number;
+  cachedInputCostPerMtok: number;
+  contextWindow: number | null;
+  enabled: boolean;
+};
+
+type UsageRow = {
+  provider: string;
+  model: string;
+  routeTier: string | null;
+  source: string;
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+  costUsd: number;
+  events: number;
+};
+
+const APPROVAL_TEMPLATE = {
+  start: "review",
+  states: [
+    {
+      id: "review",
+      type: "approval",
+      name: "Human review",
+      onSuccess: "cooldown",
+      onFailure: "denied",
+      config: { prompt: "Approve this workflow run?" },
+    },
+    { id: "cooldown", type: "wait", next: "done", config: { durationSeconds: 2 } },
+    { id: "done", type: "terminal", config: { status: "completed", output: { approved: true } } },
+    { id: "denied", type: "terminal", config: { status: "failed", error: "Denied by reviewer" } },
+  ],
+};
+
+const WEBHOOK_TEMPLATE = {
+  start: "durable_wait",
+  states: [
+    { id: "durable_wait", type: "wait", next: "done", config: { durationSeconds: 2 } },
+    { id: "done", type: "terminal", config: { status: "completed", output: { accepted: true } } },
+  ],
+};
+
+function ago(value: string | null): string {
+  if (!value) return "never";
+  const seconds = Math.max(0, Math.floor((Date.now() - Date.parse(value)) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  return `${Math.floor(seconds / 3600)}h ago`;
+}
+
+function usd(value: number): string {
+  if (!value) return "$0";
+  return value < 0.01 ? "<$0.01" : `$${value.toFixed(2)}`;
+}
+
+function statusTone(status: string): string {
+  if (["healthy", "completed", "active"].includes(status)) return "text-[var(--color-ok)]";
+  if (["error", "failed", "disabled"].includes(status)) return "text-[var(--color-err)]";
+  if (["waiting", "unchecked", "queued"].includes(status)) return "text-[var(--color-warn)]";
+  return "text-[var(--color-muted)]";
+}
+
+export default function AutomationPage() {
+  const [tab, setTab] = useState<Tab>("workflows");
+  return (
+    <main className="workspace flex-1 min-w-0">
+      <header className="chan-head">
+        <div className="ch-title inline-flex items-center gap-2">
+          <WorkflowIcon size={15} strokeWidth={2} /> Automation
+        </div>
+        <div className="ml-auto inline-flex gap-0.5 rounded-md border border-[var(--color-hair)] p-0.5">
+          {(["workflows", "connectors", "models"] as Tab[]).map((value) => (
+            <button
+              key={value}
+              type="button"
+              className={`px-3 py-1 text-[12px] rounded ${tab === value ? "bg-[var(--color-surface-2)] font-semibold" : "text-[var(--color-muted)]"}`}
+              onClick={() => setTab(value)}
+            >
+              {value === "models" ? "Models & usage" : value[0].toUpperCase() + value.slice(1)}
+            </button>
+          ))}
+        </div>
+      </header>
+      <div className="flex-1 min-h-0 overflow-auto px-6 py-5">
+        {tab === "workflows" && <WorkflowsPanel />}
+        {tab === "connectors" && <ConnectorsPanel />}
+        {tab === "models" && <ModelsPanel />}
+      </div>
+    </main>
+  );
+}
+
+function WorkflowsPanel() {
+  const qc = useQueryClient();
+  const spectator = useSpectator();
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState("Webhook approval flow");
+  const [description, setDescription] = useState("Signed event intake with a durable human and timer wait.");
+  const [triggerType, setTriggerType] = useState<"manual" | "webhook">("webhook");
+  const [definition, setDefinition] = useState(JSON.stringify(APPROVAL_TEMPLATE, null, 2));
+  const [error, setError] = useState("");
+  const [revealedSecret, setRevealedSecret] = useState<{ url: string; secret: string } | null>(null);
+  const query = useQuery<{ workflows: Workflow[] }>({
+    queryKey: ["automation", "workflows"],
+    queryFn: () => api.get("/workflows"),
+    refetchInterval: 3_000,
+  });
+  const create = useMutation({
+    mutationFn: () =>
+      api.post("/workflows", { name, description, triggerType, definition: JSON.parse(definition) }),
+    onSuccess: () => {
+      setCreating(false);
+      setError("");
+      qc.invalidateQueries({ queryKey: ["automation", "workflows"] });
+    },
+    onError: (e: Error) => setError(e.message),
+  });
+
+  const workflows = query.data?.workflows ?? [];
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="flex items-start gap-4">
+        <div>
+          <h1 className="text-[20px] font-semibold">Durable workflows</h1>
+          <p className="mt-1 text-[13px] text-[var(--color-muted)] max-w-2xl">
+            Persisted state machines for agent, connector, approval, timer, poll, and terminal steps. Every wake is replayable and every attempt is recorded.
+          </p>
+        </div>
+        {!spectator && (
+          <button className="btn sm ml-auto" type="button" onClick={() => setCreating((value) => !value)}>
+            <Plus size={13} /> New workflow
+          </button>
+        )}
+      </div>
+
+      {creating && (
+        <section className="mt-5 rounded-lg border border-[var(--color-hair)] bg-[var(--color-surface)] p-4">
+          <div className="grid md:grid-cols-2 gap-3">
+            <label className="text-[12px] text-[var(--color-muted)]">
+              Name
+              <input className="input mt-1 w-full" value={name} onChange={(e) => setName(e.target.value)} />
+            </label>
+            <label className="text-[12px] text-[var(--color-muted)]">
+              Trigger
+              <select className="input mt-1 w-full" value={triggerType} onChange={(e) => setTriggerType(e.target.value as "manual" | "webhook")}>
+                <option value="manual">Manual / API</option>
+                <option value="webhook">Signed webhook</option>
+              </select>
+            </label>
+          </div>
+          <label className="block mt-3 text-[12px] text-[var(--color-muted)]">
+            Description
+            <input className="input mt-1 w-full" value={description} onChange={(e) => setDescription(e.target.value)} />
+          </label>
+          <div className="flex gap-2 mt-3">
+            <button className="btn xs ghost" type="button" onClick={() => setDefinition(JSON.stringify(APPROVAL_TEMPLATE, null, 2))}>Approval + wait</button>
+            <button className="btn xs ghost" type="button" onClick={() => setDefinition(JSON.stringify(WEBHOOK_TEMPLATE, null, 2))}>Webhook + wait</button>
+          </div>
+          <label className="block mt-3 text-[12px] text-[var(--color-muted)]">
+            Workflow definition (advanced)
+            <textarea
+              className="input mt-1 w-full min-h-[260px] font-mono text-[11.5px] leading-5"
+              value={definition}
+              onChange={(e) => setDefinition(e.target.value)}
+              spellCheck={false}
+            />
+          </label>
+          {error && <p className="mt-2 text-[12px] text-[var(--color-err)]">{error}</p>}
+          <div className="flex gap-2 mt-3">
+            <button className="btn sm" type="button" disabled={create.isPending} onClick={() => {
+              try { JSON.parse(definition); setError(""); create.mutate(); }
+              catch { setError("Definition must be valid JSON."); }
+            }}>
+              Create workflow
+            </button>
+            <button className="btn sm ghost" type="button" onClick={() => setCreating(false)}>Cancel</button>
+          </div>
+        </section>
+      )}
+
+      {revealedSecret && (
+        <section className="mt-4 rounded-lg border border-[var(--color-warn)] bg-[color-mix(in_srgb,var(--color-warn)_7%,transparent)] p-4">
+          <div className="flex items-center gap-2 text-[13px] font-semibold"><KeyRound size={14} /> Copy this signing secret now</div>
+          <p className="mt-1 text-[12px] text-[var(--color-muted)]">It is encrypted at rest and will not be shown again.</p>
+          <CopyRow label="Endpoint" value={revealedSecret.url} />
+          <CopyRow label="Secret" value={revealedSecret.secret} />
+          <button className="btn xs ghost mt-2" onClick={() => setRevealedSecret(null)}>I saved it</button>
+        </section>
+      )}
+
+      <div className="mt-5 grid gap-3">
+        {query.isLoading && <Empty text="Loading workflows…" />}
+        {!query.isLoading && workflows.length === 0 && <Empty text="No workflows yet. Start with the signed webhook template." />}
+        {workflows.map((workflow) => (
+          <WorkflowCard key={workflow.id} workflow={workflow} onSecret={setRevealedSecret} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WorkflowCard({ workflow, onSecret }: { workflow: Workflow; onSecret: (value: { url: string; secret: string }) => void }) {
+  const qc = useQueryClient();
+  const spectator = useSpectator();
+  const run = useMutation({
+    mutationFn: () => api.post<{ runId: string }>(`/workflows/${workflow.id}/runs`, { input: { source: "automation-ui", at: new Date().toISOString() } }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["automation", "workflows"] }),
+  });
+  const createHook = useMutation({
+    mutationFn: () => api.post<{ endpoint: WebhookEndpoint; signingSecret: string }>(`/workflows/${workflow.id}/webhooks`, { name: `${workflow.name} inbound` }),
+    onSuccess: (data) => {
+      onSecret({ url: data.endpoint.url, secret: data.signingSecret });
+      qc.invalidateQueries({ queryKey: ["automation", "workflows"] });
+    },
+  });
+  const resume = useMutation({
+    mutationFn: ({ id, approved }: { id: string; approved: boolean }) => api.post(`/workflow-runs/${id}/resume`, { approved, output: { decidedFrom: "automation-ui" } }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["automation", "workflows"] }),
+  });
+  return (
+    <section className="rounded-lg border border-[var(--color-hair)] bg-[var(--color-surface)] p-4">
+      <div className="flex items-start gap-3">
+        <div className="w-9 h-9 rounded-md grid place-items-center bg-[var(--color-surface-2)] text-[var(--color-accent)]">
+          {workflow.triggerType === "webhook" ? <Webhook size={17} /> : <WorkflowIcon size={17} />}
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className="font-semibold text-[14px]">{workflow.name}</h2>
+            <span className={`text-[10px] uppercase font-mono ${statusTone(workflow.status)}`}>{workflow.status}</span>
+            <span className="text-[10px] text-[var(--color-muted-2)]">v{workflow.version}</span>
+          </div>
+          <p className="text-[12px] text-[var(--color-muted)] mt-0.5">{workflow.description || "No description"}</p>
+        </div>
+        {!spectator && (
+          <div className="ml-auto flex gap-2">
+            <button className="btn xs" type="button" disabled={run.isPending} onClick={() => run.mutate()}><Play size={12} /> Run</button>
+            {workflow.triggerType === "webhook" && (
+              <button className="btn xs ghost" type="button" disabled={createHook.isPending} onClick={() => createHook.mutate()}><KeyRound size={12} /> New endpoint</button>
+            )}
+          </div>
+        )}
+      </div>
+      {workflow.endpoints.length > 0 && (
+        <div className="mt-3 rounded-md bg-[var(--color-surface-2)] px-3 py-2">
+          {workflow.endpoints.map((endpoint) => (
+            <div key={endpoint.id} className="flex items-center gap-2 text-[11.5px]">
+              <ShieldCheck size={12} className="text-[var(--color-ok)]" />
+              <span>{endpoint.name}</span>
+              <code className="truncate text-[var(--color-muted)]">{endpoint.url}</code>
+              <button className="ml-auto" title="Copy endpoint" onClick={() => navigator.clipboard.writeText(endpoint.url)}><Copy size={12} /></button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="mt-3 overflow-x-auto">
+        <table className="ana-table w-full">
+          <thead><tr><th>Run</th><th>Status</th><th>State</th><th>Wait</th><th>Started</th><th /></tr></thead>
+          <tbody>
+            {workflow.latestRuns.slice(0, 5).map((item) => (
+              <tr key={item.id}>
+                <td className="font-mono text-[11px]">{item.id.slice(-8)}</td>
+                <td className={`font-mono text-[11px] ${statusTone(item.status)}`}>{item.status}</td>
+                <td className="font-mono text-[11px]">{item.currentStateId ?? "—"}</td>
+                <td className="text-[11px]">{item.waitKind ?? "—"}</td>
+                <td className="text-[11px] text-[var(--color-muted)]">{ago(item.startedAt)}</td>
+                <td className="text-right">
+                  {!spectator && item.status === "waiting" && item.waitKind === "human" && (
+                    <span className="inline-flex gap-1">
+                      <button className="btn xs" onClick={() => resume.mutate({ id: item.id, approved: true })}><Check size={11} /> Approve</button>
+                      <button className="btn xs ghost" onClick={() => resume.mutate({ id: item.id, approved: false })}>Deny</button>
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {workflow.latestRuns.length === 0 && <tr><td colSpan={6} className="text-[12px] text-[var(--color-muted)]">No runs yet.</td></tr>}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function ConnectorsPanel() {
+  const qc = useQueryClient();
+  const spectator = useSpectator();
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState("Local HTTP service");
+  const [kind, setKind] = useState<"http" | "mcp">("http");
+  const [baseUrl, setBaseUrl] = useState("http://localhost:3000/health");
+  const [authType, setAuthType] = useState("none");
+  const [token, setToken] = useState("");
+  const connectorsQ = useQuery<{ connectors: Connector[] }>({ queryKey: ["automation", "connectors"], queryFn: () => api.get("/connectors") });
+  const agentsQ = useQuery<{ agents: AgentRow[] }>({ queryKey: ["agents"], queryFn: () => api.get("/agents") });
+  const create = useMutation({
+    mutationFn: () => api.post("/connectors", {
+      name,
+      kind,
+      baseUrl,
+      authType,
+      ...(token ? { secret: authType === "oauth2" ? { clientSecret: token } : { bearerToken: token } } : {}),
+    }),
+    onSuccess: () => { setCreating(false); setToken(""); qc.invalidateQueries({ queryKey: ["automation", "connectors"] }); },
+  });
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="flex items-start gap-4">
+        <div>
+          <h1 className="text-[20px] font-semibold">Connector & MCP registry</h1>
+          <p className="mt-1 text-[13px] text-[var(--color-muted)] max-w-2xl">Workspace-scoped integrations with encrypted credentials, OAuth, health checks, and explicit per-agent grants.</p>
+        </div>
+        {!spectator && <button className="btn sm ml-auto" onClick={() => setCreating((v) => !v)}><Plus size={13} /> Add connector</button>}
+      </div>
+      {creating && (
+        <section className="mt-5 rounded-lg border border-[var(--color-hair)] p-4">
+          <div className="grid md:grid-cols-2 gap-3">
+            <Field label="Name"><input className="input w-full" value={name} onChange={(e) => setName(e.target.value)} /></Field>
+            <Field label="Kind"><select className="input w-full" value={kind} onChange={(e) => setKind(e.target.value as "http" | "mcp")}><option value="http">HTTP / REST</option><option value="mcp">MCP (HTTP JSON-RPC)</option></select></Field>
+            <Field label="Base URL"><input className="input w-full" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} /></Field>
+            <Field label="Authentication"><select className="input w-full" value={authType} onChange={(e) => setAuthType(e.target.value)}><option value="none">None</option><option value="bearer">Bearer token</option><option value="header">Custom headers</option><option value="oauth2">OAuth 2</option></select></Field>
+            {authType !== "none" && <Field label={authType === "oauth2" ? "OAuth client secret" : "Token (encrypted)"}><input className="input w-full" type="password" value={token} onChange={(e) => setToken(e.target.value)} /></Field>}
+          </div>
+          {create.error && <p className="mt-2 text-[12px] text-[var(--color-err)]">{(create.error as Error).message}</p>}
+          <div className="flex gap-2 mt-3"><button className="btn sm" onClick={() => create.mutate()} disabled={create.isPending}>Save connector</button><button className="btn sm ghost" onClick={() => setCreating(false)}>Cancel</button></div>
+        </section>
+      )}
+      <div className="mt-5 grid md:grid-cols-2 gap-3">
+        {connectorsQ.isLoading && <Empty text="Loading connectors…" />}
+        {(connectorsQ.data?.connectors ?? []).map((connector) => (
+          <ConnectorCard key={connector.id} connector={connector} agents={agentsQ.data?.agents ?? []} />
+        ))}
+        {!connectorsQ.isLoading && (connectorsQ.data?.connectors.length ?? 0) === 0 && <Empty text="No connectors installed." />}
+      </div>
+    </div>
+  );
+}
+
+function ConnectorCard({ connector, agents }: { connector: Connector; agents: AgentRow[] }) {
+  const qc = useQueryClient();
+  const spectator = useSpectator();
+  const [agentId, setAgentId] = useState(agents[0]?.id ?? "");
+  useEffect(() => { if (!agentId && agents[0]) setAgentId(agents[0].id); }, [agents, agentId]);
+  const check = useMutation({ mutationFn: () => api.post(`/connectors/${connector.id}/check`), onSuccess: () => qc.invalidateQueries({ queryKey: ["automation", "connectors"] }) });
+  const grant = useMutation({ mutationFn: () => api.put(`/connectors/${connector.id}/grants/${agentId}`, { scopes: ["tools.call"] }), onSuccess: () => qc.invalidateQueries({ queryKey: ["automation", "connectors"] }) });
+  const oauth = useMutation({
+    mutationFn: () => api.post<{ authorizationUrl: string }>(`/connectors/${connector.id}/oauth/start`),
+    onSuccess: ({ authorizationUrl }) => { window.location.href = authorizationUrl; },
+  });
+  const handleByAgent = useMemo(() => new Map(agents.map((agent) => [agent.id, agent.handle])), [agents]);
+  return (
+    <section className="rounded-lg border border-[var(--color-hair)] p-4 bg-[var(--color-surface)]">
+      <div className="flex items-start gap-3">
+        <div className="w-9 h-9 rounded-md grid place-items-center bg-[var(--color-surface-2)] text-[var(--color-accent)]">{connector.kind === "mcp" ? <Cable size={17} /> : <Webhook size={17} />}</div>
+        <div className="min-w-0"><h2 className="font-semibold text-[14px]">{connector.name}</h2><p className="font-mono text-[11px] text-[var(--color-muted)] truncate">{connector.baseUrl}</p></div>
+        <span className={`ml-auto text-[10px] uppercase font-mono ${statusTone(connector.status)}`}>{connector.status}</span>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-[var(--color-muted)]">
+        <span>{connector.kind.toUpperCase()}</span><span>·</span><span>{connector.authType}</span><span>·</span><span>{connector.hasSecret ? "credential stored" : "no credential"}</span><span>·</span><span>checked {ago(connector.lastCheckedAt)}</span>
+      </div>
+      {connector.lastError && <p className="mt-2 text-[11px] text-[var(--color-err)] truncate" title={connector.lastError}>{connector.lastError}</p>}
+      <div className="mt-3 text-[11px] text-[var(--color-muted)]">Granted to: {connector.grants.length ? connector.grants.map((g) => `@${handleByAgent.get(g.agentId) ?? g.agentId}`).join(", ") : "nobody"}</div>
+      {!spectator && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button className="btn xs ghost" disabled={check.isPending} onClick={() => check.mutate()}><RefreshCw size={11} /> Check</button>
+          {connector.authType === "oauth2" && <button className="btn xs ghost" onClick={() => oauth.mutate()}><KeyRound size={11} /> Connect OAuth</button>}
+          {agents.length > 0 && <><select className="input h-7 text-[11px]" value={agentId} onChange={(e) => setAgentId(e.target.value)}>{agents.map((agent) => <option key={agent.id} value={agent.id}>@{agent.handle}</option>)}</select><button className="btn xs" disabled={!agentId || grant.isPending} onClick={() => grant.mutate()}><Bot size={11} /> Grant</button></>}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ModelsPanel() {
+  const query = useQuery<{ tiers: string[]; routes: ModelRoute[]; usage: UsageRow[]; totals: { inputTokens: number; outputTokens: number; cachedInputTokens: number; costUsd: number; events: number; reportedEvents: number } }>({
+    queryKey: ["automation", "models"], queryFn: () => api.get("/model-routing?days=30"),
+  });
+  const totals = query.data?.totals;
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div><h1 className="text-[20px] font-semibold">Model routing & real usage</h1><p className="mt-1 text-[13px] text-[var(--color-muted)] max-w-2xl">Choose a model for each workload tier. Runtimes receive the route recommendation and report provider usage; estimates remain visibly labelled as fallback.</p></div>
+      <div className="mt-5 grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Metric icon={<Activity size={14} />} label="Model calls" value={totals?.events ?? 0} />
+        <Metric icon={<Gauge size={14} />} label="Input tokens" value={(totals?.inputTokens ?? 0).toLocaleString()} />
+        <Metric icon={<Gauge size={14} />} label="Output tokens" value={(totals?.outputTokens ?? 0).toLocaleString()} />
+        <Metric icon={<Clock3 size={14} />} label="30-day spend" value={usd(totals?.costUsd ?? 0)} />
+      </div>
+      <section className="mt-5 rounded-lg border border-[var(--color-hair)] overflow-hidden">
+        {(query.data?.tiers ?? ["economy", "balanced", "frontier", "advisor"]).map((tier) => <ModelRouteRow key={tier} tier={tier} route={query.data?.routes.find((route) => route.tier === tier)} />)}
+      </section>
+      <section className="mt-6">
+        <h2 className="ana-h">Usage by model (30 days)</h2>
+        <div className="ana-table-wrap"><table className="ana-table w-full"><thead><tr><th>Provider / model</th><th>Tier</th><th>Source</th><th>Calls</th><th>Input</th><th>Output</th><th>Cached</th><th>Cost</th></tr></thead><tbody>
+          {(query.data?.usage ?? []).map((row, index) => <tr key={`${row.provider}-${row.model}-${row.source}-${index}`}><td><span className="font-semibold">{row.provider}</span><span className="text-[var(--color-muted)]"> / {row.model}</span></td><td>{row.routeTier ?? "—"}</td><td><span className={row.source === "reported" ? "text-[var(--color-ok)]" : "text-[var(--color-warn)]"}>{row.source}</span></td><td className="ana-num">{row.events}</td><td className="ana-num">{row.inputTokens.toLocaleString()}</td><td className="ana-num">{row.outputTokens.toLocaleString()}</td><td className="ana-num">{row.cachedInputTokens.toLocaleString()}</td><td className="ana-num">{usd(row.costUsd)}</td></tr>)}
+          {(query.data?.usage.length ?? 0) === 0 && <tr><td colSpan={8} className="text-[12px] text-[var(--color-muted)]">Usage will appear after the next agent run.</td></tr>}
+        </tbody></table></div>
+      </section>
+    </div>
+  );
+}
+
+function ModelRouteRow({ tier, route }: { tier: string; route?: ModelRoute }) {
+  const qc = useQueryClient();
+  const spectator = useSpectator();
+  const [provider, setProvider] = useState(route?.provider ?? "");
+  const [model, setModel] = useState(route?.model ?? "");
+  const [input, setInput] = useState(String(route?.inputCostPerMtok ?? 0));
+  const [output, setOutput] = useState(String(route?.outputCostPerMtok ?? 0));
+  const [cached, setCached] = useState(String(route?.cachedInputCostPerMtok ?? 0));
+  useEffect(() => { if (route) { setProvider(route.provider); setModel(route.model); setInput(String(route.inputCostPerMtok)); setOutput(String(route.outputCostPerMtok)); setCached(String(route.cachedInputCostPerMtok)); } }, [route]);
+  const save = useMutation({
+    mutationFn: () => api.put(`/model-routing/${tier}`, { provider, model, inputCostPerMtok: Number(input), outputCostPerMtok: Number(output), cachedInputCostPerMtok: Number(cached), enabled: true }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["automation", "models"] }),
+  });
+  return <div className="grid grid-cols-[110px_1fr_1.5fr_repeat(3,100px)_70px] items-end gap-2 px-4 py-3 border-b last:border-b-0 border-[var(--color-hair)] overflow-x-auto">
+    <div><div className="text-[12px] font-semibold capitalize">{tier}</div><div className="text-[10px] text-[var(--color-muted)]">routing tier</div></div>
+    <Field label="Provider"><input aria-label={`${tier} provider`} className="input w-full" value={provider} onChange={(e) => setProvider(e.target.value)} placeholder="openai" /></Field>
+    <Field label="Model"><input aria-label={`${tier} model`} className="input w-full" value={model} onChange={(e) => setModel(e.target.value)} placeholder="model id" /></Field>
+    <Field label="Input $/M"><input className="input w-full" type="number" min="0" value={input} onChange={(e) => setInput(e.target.value)} /></Field>
+    <Field label="Output $/M"><input className="input w-full" type="number" min="0" value={output} onChange={(e) => setOutput(e.target.value)} /></Field>
+    <Field label="Cached $/M"><input className="input w-full" type="number" min="0" value={cached} onChange={(e) => setCached(e.target.value)} /></Field>
+    {!spectator && <button className="btn xs" disabled={!provider || !model || save.isPending} onClick={() => save.mutate()}>Save</button>}
+  </div>;
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) { return <label className="text-[10px] uppercase tracking-wide text-[var(--color-muted)]">{label}<div className="mt-1 normal-case tracking-normal">{children}</div></label>; }
+function Empty({ text }: { text: string }) { return <div className="rounded-lg border border-dashed border-[var(--color-hair)] p-8 text-center text-[13px] text-[var(--color-muted)]">{text}</div>; }
+function Metric({ icon, label, value }: { icon: React.ReactNode; label: string; value: string | number }) { return <div className="ana-card"><div className="ana-card-top text-[var(--color-accent)]">{icon}<span>{label}</span></div><div className="ana-card-value">{value}</div></div>; }
+function CopyRow({ label, value }: { label: string; value: string }) { const [copied, setCopied] = useState(false); return <div className="mt-2 flex items-center gap-2"><span className="w-16 text-[11px] text-[var(--color-muted)]">{label}</span><code className="flex-1 rounded bg-[var(--color-surface-2)] px-2 py-1.5 text-[11px] break-all">{value}</code><button className="btn xs ghost" onClick={() => navigator.clipboard.writeText(value).then(() => { setCopied(true); setTimeout(() => setCopied(false), 1200); })}>{copied ? <Check size={11} /> : <Copy size={11} />}</button></div>; }

--- a/web/src/pages/NeedsYou.tsx
+++ b/web/src/pages/NeedsYou.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Check, ExternalLink, Inbox, RefreshCw, X } from "lucide-react";
+import { Link } from "react-router-dom";
+import { api } from "../api/client";
+import { useSpectator } from "../lib/hooks";
+
+type Item = {
+  id: string;
+  kind: string;
+  priority: "critical" | "high" | "normal";
+  title: string;
+  detail: string;
+  link: string;
+  targetId: string;
+  createdAt: string;
+  actions: string[];
+};
+
+export default function NeedsYouPage() {
+  const qc = useQueryClient();
+  const spectator = useSpectator();
+  const [working, setWorking] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const query = useQuery<{ items: Item[]; counts: { total: number; critical: number; high: number } }>({
+    queryKey: ["needs-you"],
+    queryFn: () => api.get("/needs-you"),
+    refetchInterval: 5_000,
+  });
+
+  async function action(item: Item, value: string) {
+    setWorking(item.id); setError("");
+    try {
+      if (item.kind === "approval") {
+        const note = window.prompt(`${value === "approve" ? "Approve" : "Deny"} with an optional note:`) ?? "";
+        await api.post(`/approvals/${item.targetId}`, { decision: value, ...(note ? { note } : {}) });
+      } else if (item.kind === "app_publish") {
+        await api.post(`/apps/${item.targetId}/review`, { decision: value });
+      } else if (item.kind === "workflow_wait" && value === "resume") {
+        await api.post(`/workflow-runs/${item.targetId}/resume`, { approved: true, output: { reviewedFrom: "needs-you" } });
+      } else if (item.kind === "workflow_wait" && value === "cancel") {
+        await api.post(`/workflow-runs/${item.targetId}/control`, { action: "cancel", reason: "Cancelled from Needs you" });
+      } else if (item.kind === "workflow_wait" && value === "steer") {
+        const text = window.prompt("Steer this workflow:"); if (!text) return;
+        await api.post(`/workflow-runs/${item.targetId}/control`, { action: "steer", text });
+      } else if (item.kind === "connector_error" && value === "recheck") {
+        await api.post(`/connectors/${item.targetId}/check`, {});
+      }
+      await qc.invalidateQueries({ queryKey: ["needs-you"] });
+      await qc.invalidateQueries({ queryKey: ["approvals"] });
+      await qc.invalidateQueries({ queryKey: ["platform", "apps"] });
+    } catch (cause) { setError((cause as Error).message); }
+    finally { setWorking(null); }
+  }
+
+  const items = query.data?.items ?? [];
+  return <main className="workspace flex-1 min-w-0">
+    <header className="chan-head"><div className="ch-title inline-flex items-center gap-2"><Inbox size={15} /> Needs you</div><div className="ch-meta"><span>{query.data?.counts.total ?? 0} open</span>{(query.data?.counts.critical ?? 0) > 0 && <span className="text-[var(--color-err)]">{query.data?.counts.critical} critical</span>}</div></header>
+    <div className="flex-1 min-h-0 overflow-auto">
+      {error && <div className="px-6 py-2 text-[12px] text-[var(--color-err)]">{error}</div>}
+      {items.length === 0 && !query.isLoading && <div className="px-6 py-16 text-center text-[13px] text-[var(--color-muted)]">Nothing needs you. Approvals, reviews, failed verification, stalled work, budgets, app releases, and connector errors will collect here.</div>}
+      <ul className="divide-y divide-[var(--color-hair)]">{items.map((item) => <li key={item.id} className="px-6 py-4 flex gap-4 items-start">
+        <div className={`mt-0.5 w-8 h-8 rounded grid place-items-center ${item.priority === "critical" ? "bg-red-100 text-red-700" : item.priority === "high" ? "bg-amber-100 text-amber-800" : "bg-[var(--color-surface-2)]"}`}>{item.priority === "normal" ? <Inbox size={14} /> : <AlertTriangle size={14} />}</div>
+        <div className="min-w-0 flex-1"><div className="flex gap-2 items-center"><strong className="text-[14px]">{item.title}</strong><span className="tag">{item.kind.replaceAll("_", " ")}</span><span className="tag">{item.priority}</span></div><p className="mt-1 text-[12.5px] text-[var(--color-muted)]">{item.detail}</p><p className="mt-2 text-[10.5px] font-mono text-[var(--color-muted-2)]">{new Date(item.createdAt).toLocaleString()}</p></div>
+        <div className="flex gap-1 shrink-0">{item.actions.map((value) => value === "open" || value === "preview" ? <Link key={value} className="btn xs ghost" to={item.link}>{value === "preview" ? "Preview" : "Open"} <ExternalLink size={10} /></Link> : !spectator && <button key={value} className={`btn xs ${value === "approve" || value === "resume" ? "" : "ghost"}`} disabled={working === item.id} onClick={() => action(item, value)}>{value === "approve" || value === "resume" ? <Check size={10} /> : value === "deny" || value === "reject" || value === "cancel" ? <X size={10} /> : <RefreshCw size={10} />}{value.replace("_", " ")}</button>)}</div>
+      </li>)}</ul>
+    </div>
+  </main>;
+}

--- a/web/src/pages/Platform.tsx
+++ b/web/src/pages/Platform.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Boxes, Brain, ExternalLink, GitPullRequest, LayoutGrid, PackageOpen, Play, Plus, RefreshCw, ShieldCheck, Square, Users } from "lucide-react";
+import { api } from "../api/client";
+import { useConversations, useSpectator, useTasks } from "../lib/hooks";
+
+type Tab = "memory" | "apps" | "git" | "stages" | "blueprints" | "runs" | "access";
+type Decision = { id: string; kind: string; title: string; decision: string; rationale: string; alternativesJson: string[]; provenanceJson: Record<string, unknown>; source: string; status: string; createdAt: string };
+type AppRow = { id: string; name: string; taskId: string; status: string; previewUrl: string; publicUrl: string; deployments: Array<{ id: string; status: string; healthStatus: string }>; logs: Array<{ id: string; event: string; message: string; createdAt: string }> };
+type PrRoom = { id: string; provider: string; repository: string; prNumber: number; title: string; url: string; state: string; headRef: string; baseRef: string; diffJson: unknown[]; checksJson: unknown[]; reviewsJson: unknown[]; protectionJson: Record<string, unknown>; lastSyncedAt: string | null; lastError: string | null };
+type Stage = { stage: string; title: string; position: number; instructions: string; entryRulesJson: Record<string, unknown>; exitRulesJson: Record<string, unknown>; agentId: string | null; skill: string | null; verification: string; escalationMemberId: string | null; nextStage: string | null };
+type Blueprint = { id: string; name: string; description: string; version: number; definitionJson: { agents: unknown[]; skills: unknown[]; channels: unknown[]; workflows: unknown[] }; updatedAt: string };
+type Connector = { id: string; name: string };
+type Agent = { id: string; name: string; handle: string };
+
+const tabs: Array<{ id: Tab; label: string; icon: typeof Brain }> = [
+  { id: "memory", label: "Decisions", icon: Brain },
+  { id: "apps", label: "Apps", icon: Boxes },
+  { id: "git", label: "PR rooms", icon: GitPullRequest },
+  { id: "stages", label: "Board stages", icon: LayoutGrid },
+  { id: "blueprints", label: "Blueprints", icon: PackageOpen },
+  { id: "runs", label: "Run control", icon: Play },
+  { id: "access", label: "Access", icon: ShieldCheck },
+];
+
+export default function PlatformPage() {
+  const [tab, setTab] = useState<Tab>("memory");
+  return (
+    <main className="workspace flex-1 min-w-0">
+      <header className="chan-head">
+        <div className="ch-title inline-flex items-center gap-2"><Boxes size={15} /> Platform</div>
+        <div className="ml-auto flex gap-1 overflow-auto">
+          {tabs.map(({ id, label, icon: Icon }) => (
+            <button key={id} type="button" onClick={() => setTab(id)} className={`btn xs ghost inline-flex gap-1 ${tab === id ? "font-semibold bg-[var(--color-surface-2)]" : ""}`}>
+              <Icon size={12} /> {label}
+            </button>
+          ))}
+        </div>
+      </header>
+      <div className="flex-1 min-h-0 overflow-auto px-6 py-5">
+        {tab === "memory" && <DecisionPanel />}
+        {tab === "apps" && <AppsPanel />}
+        {tab === "git" && <PrRoomsPanel />}
+        {tab === "stages" && <StagesPanel />}
+        {tab === "blueprints" && <BlueprintsPanel />}
+        {tab === "runs" && <RunControlPanel />}
+        {tab === "access" && <AccessPanel />}
+      </div>
+    </main>
+  );
+}
+
+function SectionHead({ title, description, action }: { title: string; description: string; action?: ReactNode }) {
+  return <div className="flex items-start gap-4 max-w-6xl mx-auto mb-5"><div><h1 className="text-[20px] font-semibold">{title}</h1><p className="mt-1 text-[13px] text-[var(--color-muted)] max-w-3xl">{description}</p></div>{action && <div className="ml-auto">{action}</div>}</div>;
+}
+
+function DecisionPanel() {
+  const qc = useQueryClient();
+  const spectator = useSpectator();
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ kind: "decision", title: "", decision: "", rationale: "", alternatives: "", provenance: "{}" });
+  const query = useQuery<{ decisions: Decision[] }>({ queryKey: ["platform", "decisions"], queryFn: () => api.get("/decisions") });
+  async function save(correctId?: string) {
+    let provenance: Record<string, unknown>;
+    try { provenance = JSON.parse(form.provenance); } catch { window.alert("Provenance must be valid JSON."); return; }
+    await api.post(correctId ? `/decisions/${correctId}/correct` : "/decisions/observe", {
+      kind: form.kind, title: form.title, decision: form.decision, rationale: form.rationale,
+      alternatives: form.alternatives.split("\n").map((line) => line.trim()).filter(Boolean), provenance,
+      source: correctId ? "human" : "observer",
+    });
+    setOpen(false); setForm({ kind: "decision", title: "", decision: "", rationale: "", alternatives: "", provenance: "{}" });
+    await qc.invalidateQueries({ queryKey: ["platform", "decisions"] });
+  }
+  function correct(row: Decision) { setForm({ kind: row.kind, title: row.title, decision: row.decision, rationale: row.rationale, alternatives: row.alternativesJson.join("\n"), provenance: JSON.stringify(row.provenanceJson, null, 2) }); setOpen(true); setCorrection(row.id); }
+  const [correction, setCorrection] = useState<string | undefined>();
+  return <div><SectionHead title="Decision and precedent memory" description="An inspectable observer/reflector record of choices, alternatives, policies, exceptions, and steers. Corrections preserve the superseded record and its provenance." action={!spectator && <button className="btn sm" onClick={() => { setCorrection(undefined); setOpen((value) => !value); }}><Plus size={13} /> Record decision</button>} />
+    {open && <div className="max-w-6xl mx-auto mb-5 border border-[var(--color-hair)] rounded-lg p-4 grid md:grid-cols-2 gap-3">
+      <select className="input" aria-label="Decision type" value={form.kind} onChange={(e) => setForm({ ...form, kind: e.target.value })}>{["decision", "precedent", "policy", "exception", "steer"].map((value) => <option key={value}>{value}</option>)}</select>
+      <input className="input" aria-label="Decision title" placeholder="Decision title" value={form.title} onChange={(e) => setForm({ ...form, title: e.target.value })} />
+      <textarea className="input min-h-24 md:col-span-2" aria-label="Decision" placeholder="What was decided?" value={form.decision} onChange={(e) => setForm({ ...form, decision: e.target.value })} />
+      <textarea className="input min-h-20" aria-label="Rationale" placeholder="Why?" value={form.rationale} onChange={(e) => setForm({ ...form, rationale: e.target.value })} />
+      <textarea className="input min-h-20" aria-label="Alternatives" placeholder="Alternatives, one per line" value={form.alternatives} onChange={(e) => setForm({ ...form, alternatives: e.target.value })} />
+      <textarea className="input min-h-20 md:col-span-2 font-mono text-[11px]" aria-label="Provenance" value={form.provenance} onChange={(e) => setForm({ ...form, provenance: e.target.value })} />
+      <button className="btn sm w-fit" disabled={!form.title || !form.decision} onClick={() => save(correction)}>{correction ? "Save correction" : "Save memory"}</button>
+    </div>}
+    <div className="max-w-6xl mx-auto grid gap-3">{query.data?.decisions.map((row) => <article key={row.id} className={`border rounded-lg p-4 ${row.status === "active" ? "border-[var(--color-hair)]" : "border-[var(--color-hair)] opacity-55"}`}>
+      <div className="flex gap-2 items-center"><span className="tag">{row.kind}</span><strong className="text-[14px]">{row.title}</strong><span className="ml-auto text-[11px] text-[var(--color-muted)]">{row.source} · {row.status}</span></div>
+      <p className="mt-2 text-[13px] whitespace-pre-wrap">{row.decision}</p>{row.rationale && <p className="mt-2 text-[12px] text-[var(--color-muted)]">Why: {row.rationale}</p>}
+      {row.alternativesJson.length > 0 && <p className="mt-1 text-[12px] text-[var(--color-muted)]">Alternatives: {row.alternativesJson.join(" · ")}</p>}
+      {!spectator && row.status === "active" && <button className="btn xs ghost mt-3" onClick={() => correct(row)}>Correct with provenance</button>}
+    </article>)}</div>
+  </div>;
+}
+
+function AppsPanel() {
+  const qc = useQueryClient();
+  const spectator = useSpectator();
+  const tasksQ = useTasks();
+  const [taskId, setTaskId] = useState("");
+  const [artifactId, setArtifactId] = useState("");
+  const [name, setName] = useState("");
+  const appsQ = useQuery<{ apps: AppRow[] }>({ queryKey: ["platform", "apps"], queryFn: () => api.get("/apps"), refetchInterval: 5_000 });
+  const artifactsQ = useQuery<{ artifacts: Array<{ id: string; name: string; contentType: string }> }>({ queryKey: ["task-artifacts", taskId], queryFn: () => api.get(`/tasks/${taskId}/artifacts`), enabled: Boolean(taskId) });
+  async function create() { await api.post("/apps", { taskId, artifactId, name }); setName(""); await qc.invalidateQueries({ queryKey: ["platform", "apps"] }); }
+  async function act(path: string, body?: unknown) { await api.post(path, body ?? {}); await qc.invalidateQueries({ queryKey: ["platform", "apps"] }); }
+  return <div><SectionHead title="App preview and hosting" description="Turn a task’s HTML artifact into a token-isolated preview. Publishing is a separate, auditable human decision; every deployment exposes immutable artifact identity, logs, and a health check." />
+    {!spectator && <div className="max-w-6xl mx-auto mb-5 border border-[var(--color-hair)] rounded-lg p-4 grid md:grid-cols-4 gap-2">
+      <select className="input" aria-label="App task" value={taskId} onChange={(e) => { setTaskId(e.target.value); setArtifactId(""); }}><option value="">Choose task…</option>{tasksQ.data?.tasks.map((task) => <option key={task.id} value={task.id}>{task.title}</option>)}</select>
+      <select className="input" aria-label="HTML artifact" value={artifactId} onChange={(e) => setArtifactId(e.target.value)}><option value="">Choose HTML artifact…</option>{artifactsQ.data?.artifacts.filter((artifact) => artifact.contentType.includes("html")).map((artifact) => <option key={artifact.id} value={artifact.id}>{artifact.name}</option>)}</select>
+      <input className="input" aria-label="App name" placeholder="App name" value={name} onChange={(e) => setName(e.target.value)} />
+      <button className="btn sm" disabled={!taskId || !artifactId || !name} onClick={create}><Plus size={13} /> Create preview</button>
+    </div>}
+    <div className="max-w-6xl mx-auto grid md:grid-cols-2 gap-3">{appsQ.data?.apps.map((row) => <article key={row.id} className="border border-[var(--color-hair)] rounded-lg p-4">
+      <div className="flex items-center gap-2"><strong>{row.name}</strong><span className="tag">{row.status}</span><span className="ml-auto text-[11px] text-[var(--color-muted)]">{row.deployments[0]?.healthStatus}</span></div>
+      <div className="flex gap-2 mt-3"><a className="btn xs ghost" href={row.previewUrl} target="_blank" rel="noreferrer">Preview <ExternalLink size={11} /></a>{row.status === "published" && <a className="btn xs ghost" href={row.publicUrl} target="_blank" rel="noreferrer">Public app <ExternalLink size={11} /></a>}</div>
+      {!spectator && <div className="flex gap-2 mt-3">{row.status === "preview" && <button className="btn xs" onClick={() => act(`/apps/${row.id}/request-publish`)}>Request publish</button>}{row.status === "pending" && <><button className="btn xs" onClick={() => act(`/apps/${row.id}/review`, { decision: "approve" })}>Approve</button><button className="btn xs ghost" onClick={() => act(`/apps/${row.id}/review`, { decision: "reject" })}>Reject</button></>}</div>}
+      <div className="mt-3 border-t border-[var(--color-hair)] pt-2 text-[11px] text-[var(--color-muted)]">{row.logs.slice(0, 4).map((log) => <div key={log.id}>{log.event}{log.message ? ` — ${log.message}` : ""}</div>)}</div>
+    </article>)}</div>
+  </div>;
+}
+
+function PrRoomsPanel() {
+  const qc = useQueryClient();
+  const spectator = useSpectator();
+  const conversations = useConversations();
+  const connectorsQ = useQuery<{ connectors: Connector[] }>({ queryKey: ["automation", "connectors"], queryFn: () => api.get("/connectors") });
+  const roomsQ = useQuery<{ rooms: PrRoom[] }>({ queryKey: ["platform", "pr-rooms"], queryFn: () => api.get("/pr-rooms") });
+  const channels = conversations.data?.conversations.filter((row) => row.kind === "channel") ?? [];
+  const [form, setForm] = useState({ provider: "github", repository: "", prNumber: "", conversationId: "", connectorId: "" });
+  async function create() { await api.post("/pr-rooms", { ...form, prNumber: Number(form.prNumber), connectorId: form.connectorId || null }); await qc.invalidateQueries({ queryKey: ["platform", "pr-rooms"] }); }
+  async function sync(id: string) { await api.post(`/pr-rooms/${id}/sync`, {}); await qc.invalidateQueries({ queryKey: ["platform", "pr-rooms"] }); }
+  return <div><SectionHead title="Provider-backed Git and PR rooms" description="Attach a GitHub or GitLab pull/merge request to a channel. Sync reads the provider’s PR, changed files, checks, reviews, and branch protection through a governed connector." />
+    {!spectator && <div className="max-w-6xl mx-auto mb-5 grid md:grid-cols-5 gap-2 border border-[var(--color-hair)] rounded-lg p-4">
+      <select className="input" aria-label="PR provider" value={form.provider} onChange={(e) => setForm({ ...form, provider: e.target.value })}><option value="github">GitHub</option><option value="gitlab">GitLab</option></select>
+      <input className="input" aria-label="Repository" placeholder="owner/repository" value={form.repository} onChange={(e) => setForm({ ...form, repository: e.target.value })} />
+      <input className="input" aria-label="PR number" type="number" min="1" placeholder="PR #" value={form.prNumber} onChange={(e) => setForm({ ...form, prNumber: e.target.value })} />
+      <select className="input" aria-label="PR channel" value={form.conversationId} onChange={(e) => setForm({ ...form, conversationId: e.target.value })}><option value="">Channel…</option>{channels.map((channel) => <option key={channel.id} value={channel.id}>#{channel.name}</option>)}</select>
+      <select className="input" aria-label="Git connector" value={form.connectorId} onChange={(e) => setForm({ ...form, connectorId: e.target.value })}><option value="">Connector later…</option>{connectorsQ.data?.connectors.map((connector) => <option key={connector.id} value={connector.id}>{connector.name}</option>)}</select>
+      <button className="btn sm w-fit" disabled={!form.repository || !form.prNumber || !form.conversationId} onClick={create}><Plus size={13} /> Create PR room</button>
+    </div>}
+    <div className="max-w-6xl mx-auto grid gap-3">{roomsQ.data?.rooms.map((room) => <article key={room.id} className="border border-[var(--color-hair)] rounded-lg p-4">
+      <div className="flex gap-2 items-center"><GitPullRequest size={14} /><strong>{room.title || `${room.repository} #${room.prNumber}`}</strong><span className="tag">{room.provider}</span><span className="tag">{room.state}</span>{!spectator && <button className="btn xs ghost ml-auto" onClick={() => sync(room.id)}><RefreshCw size={11} /> Sync</button>}</div>
+      <p className="mt-2 text-[12px] text-[var(--color-muted)] font-mono">{room.headRef || "head"} → {room.baseRef || "base"}</p>
+      <div className="mt-2 flex gap-4 text-[12px]"><span>{room.diffJson.length} files</span><span>{room.checksJson.length} checks</span><span>{room.reviewsJson.length} reviews</span><span>{Object.keys(room.protectionJson).length ? "protected" : "protection unknown"}</span></div>
+      {room.lastError && <p className="mt-2 text-[12px] text-[var(--color-err)]">{room.lastError}</p>}{room.url && <a href={room.url} target="_blank" rel="noreferrer" className="text-[12px] underline">Open provider PR</a>}
+    </article>)}</div>
+  </div>;
+}
+
+function StagesPanel() {
+  const qc = useQueryClient();
+  const spectator = useSpectator();
+  const agentsQ = useQuery<{ agents: Agent[] }>({ queryKey: ["agents"], queryFn: () => api.get("/agents") });
+  const stagesQ = useQuery<{ stages: Stage[] }>({ queryKey: ["platform", "stages"], queryFn: () => api.get("/board-stages") });
+  const [editing, setEditing] = useState<Stage | null>(null);
+  async function save() { if (!editing) return; await api.put(`/board-stages/${editing.stage}`, { title: editing.title, position: editing.position, instructions: editing.instructions, entryRules: editing.entryRulesJson, exitRules: editing.exitRulesJson, agentId: editing.agentId, skill: editing.skill, verification: editing.verification, escalationMemberId: editing.escalationMemberId, nextStage: editing.nextStage }); setEditing(null); await qc.invalidateQueries({ queryKey: ["platform", "stages"] }); }
+  return <div><SectionHead title="Executable board stages" description="Each stage can enforce entry/exit evidence, assign an agent and skill, carry instructions, require verification, escalate violations, and define the next transition." />
+    <div className="max-w-6xl mx-auto grid gap-3">{stagesQ.data?.stages.map((stage) => <article key={stage.stage} className="border border-[var(--color-hair)] rounded-lg p-4"><div className="flex gap-2 items-center"><strong>{stage.title}</strong><span className="tag font-mono">{stage.stage}</span><span className="ml-auto text-[11px] text-[var(--color-muted)]">next: {stage.nextStage ?? "terminal"}</span>{!spectator && <button className="btn xs ghost" onClick={() => setEditing({ ...stage })}>Configure</button>}</div><p className="mt-2 text-[12px] text-[var(--color-muted)]">{stage.instructions || "No stage instructions."}</p><div className="mt-2 flex gap-3 text-[11px]"><span>verification: {stage.verification}</span><span>agent: {agentsQ.data?.agents.find((agent) => agent.id === stage.agentId)?.name ?? "none"}</span><span>skill: {stage.skill ?? "none"}</span></div></article>)}</div>
+    {editing && <div className="fixed inset-0 z-50 grid place-items-center bg-black/35"><div className="bg-[var(--color-bg)] border border-[var(--color-hair)] rounded-lg p-5 w-[min(680px,92vw)] max-h-[85vh] overflow-auto"><h2 className="font-semibold">Configure {editing.stage}</h2><div className="grid md:grid-cols-2 gap-2 mt-4">
+      <input className="input" aria-label="Stage title" value={editing.title} onChange={(e) => setEditing({ ...editing, title: e.target.value })} /><input className="input" aria-label="Stage position" type="number" value={editing.position} onChange={(e) => setEditing({ ...editing, position: Number(e.target.value) })} />
+      <textarea className="input min-h-24 md:col-span-2" aria-label="Stage instructions" placeholder="Instructions injected into the assigned agent run" value={editing.instructions} onChange={(e) => setEditing({ ...editing, instructions: e.target.value })} />
+      <select className="input" aria-label="Stage agent" value={editing.agentId ?? ""} onChange={(e) => setEditing({ ...editing, agentId: e.target.value || null })}><option value="">No automatic agent</option>{agentsQ.data?.agents.map((agent) => <option key={agent.id} value={agent.id}>{agent.name}</option>)}</select><input className="input" aria-label="Stage skill" placeholder="Skill name" value={editing.skill ?? ""} onChange={(e) => setEditing({ ...editing, skill: e.target.value || null })} />
+      <select className="input" aria-label="Stage verification" value={editing.verification} onChange={(e) => setEditing({ ...editing, verification: e.target.value })}>{["none", "artifact", "judge", "human"].map((value) => <option key={value}>{value}</option>)}</select><select className="input" aria-label="Next stage" value={editing.nextStage ?? ""} onChange={(e) => setEditing({ ...editing, nextStage: e.target.value || null })}><option value="">Terminal</option>{stagesQ.data?.stages.map((value) => <option key={value.stage} value={value.stage}>{value.title}</option>)}</select>
+      <RuleChecks label="Entry rules" value={editing.entryRulesJson} onChange={(entryRulesJson) => setEditing({ ...editing, entryRulesJson })} /><RuleChecks label="Exit rules" value={editing.exitRulesJson} onChange={(exitRulesJson) => setEditing({ ...editing, exitRulesJson })} />
+    </div><div className="flex gap-2 mt-4"><button className="btn sm" onClick={save}>Save stage</button><button className="btn sm ghost" onClick={() => setEditing(null)}>Cancel</button></div></div></div>}
+  </div>;
+}
+
+function RuleChecks({ label, value, onChange }: { label: string; value: Record<string, unknown>; onChange: (next: Record<string, unknown>) => void }) {
+  return <fieldset className="border border-[var(--color-hair)] rounded p-3"><legend className="text-[11px] uppercase text-[var(--color-muted)]">{label}</legend>{[["requireAssignee", "Assignee"], ["requireArtifact", "Artifact"], ["requireVerification", "Passed verification"]].map(([key, text]) => <label key={key} className="flex gap-2 text-[12px] mt-1"><input type="checkbox" checked={value[key] === true} onChange={(e) => onChange({ ...value, [key]: e.target.checked })} /> Require {text}</label>)}</fieldset>;
+}
+
+function BlueprintsPanel() {
+  const qc = useQueryClient(); const spectator = useSpectator(); const [name, setName] = useState(""); const [description, setDescription] = useState("");
+  const query = useQuery<{ blueprints: Blueprint[] }>({ queryKey: ["platform", "blueprints"], queryFn: () => api.get("/team-blueprints") });
+  async function create() { await api.post("/team-blueprints", { name, description, exportWorkspace: true }); setName(""); setDescription(""); await qc.invalidateQueries({ queryKey: ["platform", "blueprints"] }); }
+  async function apply(id: string) { if (!window.confirm("Instantiate this blueprint in the current workspace?")) return; const result = await api.post<Record<string, number>>(`/team-blueprints/${id}/apply`, {}); window.alert(`Created ${result.agents} agents, ${result.channels} channels, and ${result.workflows} workflows.`); }
+  return <div><SectionHead title="Reusable team blueprints" description="Package agents, reporting lines, skills, scopes, budgets, private collaboration channels, and workflows into an immutable version. Applying a version instantiates a fresh team without copying credentials." />
+    {!spectator && <div className="max-w-6xl mx-auto mb-5 flex gap-2"><input className="input" aria-label="Blueprint name" placeholder="Blueprint name" value={name} onChange={(e) => setName(e.target.value)} /><input className="input flex-1" aria-label="Blueprint description" placeholder="Description" value={description} onChange={(e) => setDescription(e.target.value)} /><button className="btn sm" disabled={!name} onClick={create}>Export current team</button></div>}
+    <div className="max-w-6xl mx-auto grid md:grid-cols-2 gap-3">{query.data?.blueprints.map((row) => <article key={row.id} className="border border-[var(--color-hair)] rounded-lg p-4"><div className="flex items-center gap-2"><PackageOpen size={14} /><strong>{row.name}</strong><span className="tag">v{row.version}</span>{!spectator && <button className="btn xs ghost ml-auto" onClick={() => apply(row.id)}>Instantiate</button>}</div><p className="mt-2 text-[12px] text-[var(--color-muted)]">{row.description}</p><div className="flex gap-3 mt-3 text-[11px]"><span>{row.definitionJson.agents.length} agents</span><span>{row.definitionJson.skills.length} skills</span><span>{row.definitionJson.channels.length} channels</span><span>{row.definitionJson.workflows.length} workflows</span></div></article>)}</div>
+  </div>;
+}
+
+function RunControlPanel() {
+  const qc = useQueryClient(); const spectator = useSpectator();
+  const query = useQuery<{ runs: Array<{ id: string; type: "agent" | "workflow"; name: string; status: string; trigger?: string; currentStateId?: string | null; waitKind?: string | null; ownerMemberId: string | null; steerJson: unknown[]; followupJson: unknown[]; timeoutAt: string | null; startedAt: string }> }>({ queryKey: ["platform", "active-runs"], queryFn: () => api.get("/active-runs"), refetchInterval: 2_000 });
+  async function control(run: { id: string; type: "agent" | "workflow" }, action: string) { let body: Record<string, unknown> = { action }; if (action === "steer" || action === "follow_up") { const text = window.prompt(action === "steer" ? "Steer this active run:" : "Queue a follow-up turn:"); if (!text) return; body.text = text; } if (action === "extend") body.seconds = 3600; await api.post(`/${run.type}-runs/${run.id}/control`, body); await qc.invalidateQueries({ queryKey: ["platform", "active-runs"] }); }
+  return <div><SectionHead title="Cancellable and steerable runs" description="Active agent and workflow runs have persisted ownership, cancel, steer, queued follow-up, and timeout-extension controls. Cancellation is checked before any returned action can be applied." /><div className="max-w-6xl mx-auto grid gap-3">{query.data?.runs.length === 0 && <p className="text-[13px] text-[var(--color-muted)]">No active runs.</p>}{query.data?.runs.map((run) => <article key={`${run.type}:${run.id}`} className="border border-[var(--color-hair)] rounded-lg p-4 flex gap-3 items-center"><span className="tag">{run.type}</span><div><strong className="text-[13px]">{run.name}</strong><p className="text-[11px] text-[var(--color-muted)]">{run.status}{run.waitKind ? ` · waiting: ${run.waitKind}` : ""}{run.currentStateId ? ` · ${run.currentStateId}` : ""}</p></div>{!spectator && <div className="ml-auto flex gap-1"><button className="btn xs ghost" onClick={() => control(run, "claim")}>Claim</button><button className="btn xs ghost" onClick={() => control(run, "steer")}>Steer</button><button className="btn xs ghost" onClick={() => control(run, "follow_up")}>Follow up</button><button className="btn xs ghost" onClick={() => control(run, "extend")}>+1h</button><button className="btn xs ghost text-[var(--color-err)]" onClick={() => control(run, "cancel")}><Square size={10} /> Cancel</button></div>}</article>)}</div></div>;
+}
+
+function AccessPanel() {
+  const qc = useQueryClient(); const spectator = useSpectator();
+  const query = useQuery<{ workspace: { retentionDays: number | null; dataResidency: string }; access: { role: string; permissions: string[] }; roles: Array<{ id: string; key: string; name: string; permissionsJson: string[] }>; builtInRoles: Array<{ key: string; name: string; permissions: string[] }>; serviceAccounts: Array<{ id: string; name: string; scopesJson: string[]; revokedAt: string | null }>; sso: null | { issuer: string; clientId: string; domains: string[]; defaultRole: string; enabled: boolean } }>({ queryKey: ["platform", "enterprise"], queryFn: () => api.get("/enterprise") });
+  const [role, setRole] = useState({ key: "reviewer", name: "Reviewer", permissions: "workspace.read,runs.control,audit.export" });
+  const [serviceName, setServiceName] = useState("CI automation"); const [newToken, setNewToken] = useState("");
+  const [governance, setGovernance] = useState({ retentionDays: "", dataResidency: "operator" });
+  useEffect(() => { if (query.data?.workspace) setGovernance({ retentionDays: query.data.workspace.retentionDays == null ? "" : String(query.data.workspace.retentionDays), dataResidency: query.data.workspace.dataResidency }); }, [query.data?.workspace]);
+  const isAdmin = query.data?.access.permissions.includes("*") === true;
+  async function createRole() { await api.post("/enterprise/roles", { key: role.key, name: role.name, permissions: role.permissions.split(",").map((value) => value.trim()).filter(Boolean) }); await qc.invalidateQueries({ queryKey: ["platform", "enterprise"] }); }
+  async function createService() { const result = await api.post<{ token: string }>("/enterprise/service-accounts", { name: serviceName, scopes: ["workflows.read", "workflows.run"] }); setNewToken(result.token); await qc.invalidateQueries({ queryKey: ["platform", "enterprise"] }); }
+  async function saveGovernance() { await api.put("/enterprise/governance", { retentionDays: governance.retentionDays ? Number(governance.retentionDays) : null, dataResidency: governance.dataResidency }); await qc.invalidateQueries({ queryKey: ["platform", "enterprise"] }); }
+  return <div><SectionHead title="Enterprise access and governance" description="Guests and channel boundaries, custom RBAC, OIDC SSO, scoped service identities, exportable audit events, retention, and an explicit data-residency policy—without exposing stored credentials." />
+    <div className="max-w-6xl mx-auto grid md:grid-cols-2 gap-4">
+      <section className="border border-[var(--color-hair)] rounded-lg p-4"><h2 className="font-semibold text-[14px] flex gap-2"><Users size={14} /> Roles</h2><p className="text-[11px] text-[var(--color-muted)] mt-1">You are {query.data?.access.role}.</p>{[...(query.data?.builtInRoles ?? []), ...(query.data?.roles ?? []).map((value) => ({ ...value, permissions: value.permissionsJson }))].map((value) => <div key={value.key} className="mt-2 text-[12px]"><strong>{value.name}</strong> <span className="font-mono text-[10px] text-[var(--color-muted)]">{value.key}</span><div className="text-[11px] text-[var(--color-muted)]">{value.permissions.join(", ")}</div></div>)}{isAdmin && !spectator && <div className="mt-3 grid gap-2"><input className="input" aria-label="Role key" value={role.key} onChange={(e) => setRole({ ...role, key: e.target.value })} /><input className="input" aria-label="Role name" value={role.name} onChange={(e) => setRole({ ...role, name: e.target.value })} /><input className="input" aria-label="Role permissions" value={role.permissions} onChange={(e) => setRole({ ...role, permissions: e.target.value })} /><button className="btn xs w-fit" onClick={createRole}>Save custom role</button></div>}</section>
+      <section className="border border-[var(--color-hair)] rounded-lg p-4"><h2 className="font-semibold text-[14px]">Governance</h2><label className="block text-[11px] mt-3">Retention days<input className="input w-full mt-1" aria-label="Retention days" type="number" value={governance.retentionDays} onChange={(e) => setGovernance({ ...governance, retentionDays: e.target.value })} /></label><label className="block text-[11px] mt-2">Data residency label<input className="input w-full mt-1" aria-label="Data residency" value={governance.dataResidency} onChange={(e) => setGovernance({ ...governance, dataResidency: e.target.value })} /></label>{isAdmin && <button className="btn xs mt-3" onClick={saveGovernance}>Save governance</button>}<a className="btn xs ghost mt-3 ml-2" href="/api/enterprise/audit?format=csv&days=30">Export audit CSV</a></section>
+      <section className="border border-[var(--color-hair)] rounded-lg p-4"><h2 className="font-semibold text-[14px]">Service accounts</h2>{query.data?.serviceAccounts.map((account) => <div key={account.id} className="mt-2 text-[12px]"><strong>{account.name}</strong> <span className="text-[var(--color-muted)]">{account.revokedAt ? "revoked" : account.scopesJson.join(", ")}</span></div>)}{isAdmin && !spectator && <div className="mt-3 flex gap-2"><input className="input" aria-label="Service account name" value={serviceName} onChange={(e) => setServiceName(e.target.value)} /><button className="btn xs" onClick={createService}>Create</button></div>}{newToken && <div className="mt-3 p-2 border border-[var(--color-warn)] rounded text-[11px]"><strong>Copy once:</strong><code className="block break-all mt-1">{newToken}</code><button className="btn xs ghost mt-1" onClick={() => navigator.clipboard.writeText(newToken)}>Copy</button></div>}</section>
+      <section className="border border-[var(--color-hair)] rounded-lg p-4"><h2 className="font-semibold text-[14px]">OIDC SSO</h2>{query.data?.sso ? <><p className="text-[12px] mt-2">{query.data.sso.issuer}</p><p className="text-[11px] text-[var(--color-muted)]">Domains: {query.data.sso.domains.join(", ") || "any"} · default {query.data.sso.defaultRole} · {query.data.sso.enabled ? "enabled" : "disabled"}</p></> : <p className="text-[12px] mt-2 text-[var(--color-muted)]">Not configured. Use PUT /api/enterprise/sso after registering the callback URL shown in the platform docs.</p>}</section>
+    </div>
+  </div>;
+}


### PR DESCRIPTION
## What changed

- adds governed HTTP/MCP connectors, OAuth, signed webhooks, durable workflows, model routing, and real usage accounting
- adds decision memory, isolated app preview/publishing, provider-backed PR rooms, executable board stages, reusable team blueprints, unified review inbox, and steerable run controls
- adds guest boundaries, custom RBAC, OIDC/PKCE SSO, service accounts, audit export, retention, and residency policy
- ships the Platform, Automation, and Needs You operator interfaces
- includes migrations, platform documentation, unit coverage, and dedicated P0/P1 E2E suites

## Why

CircleChat needed a reliable execution substrate and a unified supervision/governance layer to close the highest-priority competitive gaps while preserving its self-hosted, approval-first model.

## Validation

- API TypeScript build
- web production build
- 24 Vitest files / 216 tests
- clean migrations through 0027 on a fresh PostgreSQL database
- P0 API E2E suite
- P1 API E2E suite, including negative paths and cross-workspace isolation
- authenticated browser E2E across Automation, Platform, Board, and Needs You with no console errors

## Notes

The Vite build reports the existing non-blocking large-chunk warning. Unrelated local Product Hunt assets, analytics injection, screenshots, database dump, and Compose edits are intentionally excluded.
