### PR TITLE
Announce CircleChat Cloud in the README and tag cloud links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Channels · DMs · threads · reactions · per-channel kanban boards · a real a
 [![Postgres](https://img.shields.io/badge/Postgres-16-000.svg?style=flat-square&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 [![Docker](https://img.shields.io/badge/Docker-compose-000.svg?style=flat-square&logo=docker&logoColor=white)](https://docs.docker.com/compose/)
 
-[Quickstart](#quickstart) · [Features](#features) · [Agents](#building-an-agent) · [Architecture](#architecture) · [Deploy](#deployment) · [Docs](docs/)
+[Website](https://circlechat.co/?utm_source=github&utm_medium=readme&utm_campaign=repository&utm_content=readme_top) · [Managed cloud](https://cloud.circlechat.co/signup?utm_source=github&utm_medium=readme&utm_campaign=cloud_trial&utm_content=readme_top) · [Quickstart](#quickstart) · [Features](#features) · [Agents](#building-an-agent) · [Architecture](#architecture) · [Deploy](#deployment) · [Docs](docs/)
 
 ![CircleChat — channel view with an agent reply and an in-channel kanban board](docs/screenshots/circlechat-chat.png)
 
@@ -418,7 +418,11 @@ Use the agent's scheduler settings (heartbeat interval), the reply-guard, and ap
 Yes — MIT licensed. It's Node on the backend and a standard React SPA. The API is fully typed and documented; the WS protocol is small.
 
 **Is there a hosted version?**
-Not yet. The marketing site has a "Managed Cloud" waitlist.
+Yes — [CircleChat Cloud](https://cloud.circlechat.co/signup?utm_source=github&utm_medium=readme&utm_campaign=cloud_trial&utm_content=readme_faq).
+A managed single-tenant workspace on its own server. Flat price per workspace, not per seat:
+**Starter $29/mo** (3 agents), **Team $79/mo** (10 agents, custom domain), **Scale $199/mo**
+(unlimited agents). Every plan starts with a **7-day free trial** — card required, no charge
+today, cancel anytime. Self-hosting stays free under MIT; it's the same code.
 
 ---
 

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -58,7 +58,7 @@ export default function AppShell() {
           </span>
           <span className="sb-ctas">
             <a href="https://github.com/tashfeenahmed/circlechat">Self-host free</a>
-            <a href="https://cloud.circlechat.co">Get your own team →</a>
+            <a href="https://cloud.circlechat.co/?utm_source=app&utm_medium=in_app&utm_campaign=cloud_trial&utm_content=app_shell">Get your own team →</a>
           </span>
         </div>
       )}

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -218,7 +218,7 @@ export default function Composer({ placeholder, onSend, conversationId, onTyping
           <span className="shrink-0">
             <a href="https://github.com/tashfeenahmed/circlechat" className="underline underline-offset-2 hover:text-[var(--color-ink)]">Self-host free</a>
             <span className="mx-1.5">·</span>
-            <a href="https://cloud.circlechat.co" className="underline underline-offset-2 hover:text-[var(--color-ink)]">Get your own team</a>
+            <a href="https://cloud.circlechat.co/?utm_source=app&utm_medium=in_app&utm_campaign=cloud_trial&utm_content=composer" className="underline underline-offset-2 hover:text-[var(--color-ink)]">Get your own team</a>
           </span>
         </div>
       </div>


### PR DESCRIPTION
The hosted-version FAQ said *"Not yet. The marketing site has a Managed Cloud waitlist."* — but `cloud.circlechat.co/signup` is live and selling. Visitors were being told the product doesn't exist yet.

**README**
- FAQ now names CircleChat Cloud with the real plans: Starter $29/mo (3 agents), Team $79/mo (10 agents + custom domain), Scale $199/mo (unlimited), 7-day trial, card required, cancel anytime. Prices verified against the control-plane config, the marketing site, and the live pricing page.
- Header nav gains Website + Managed cloud links.
- Deliberately **no** "live in N minutes" claim — `cloud/README.md` documents no provisioning SLA, so any number would be invented.

**Web**
- `AppShell.tsx` and `Composer.tsx` "Get your own team" links keep their existing destination (`https://cloud.circlechat.co/`) and only gain utm params, so in-app signups stop showing up as direct traffic.

**Checks**
- `npm run build` in `web/` (tsc -b && vite build) — green, 2028 modules, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)