### PR TITLE
Document the agent runtime overlay for self-hosted deployments (closes #44)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 PG_PASSWORD=circlechat
 SESSION_SECRET=change-me-at-least-32-chars-long-string
-PUBLIC_BASE_URL=http://localhost:8080
+# The URL the stack is reached on. Caddy binds :80/:443, so the compose
+# quickstart is plain http://localhost. Agent containers call back on
+# $PUBLIC_BASE_URL/api from the HOST network, so it must resolve there.
+PUBLIC_BASE_URL=http://localhost
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
 S3_PUBLIC_BASE=http://localhost:9000/circlechat
@@ -30,3 +33,27 @@ VITE_WS_URL=/events
 # GOAL_STALL_REPLAN=on        # auto re-plan stalled goals (archives+regenerates open tasks); default just notifies the owner
 # ENFORCE_AGENT_SCOPES=off    # default ON; set off for a trusted single-tenant deploy
 # APPROVE_RISK_AT=medium      # force approval for actions at/above this risk (low|medium|high)
+
+# ── Agent runtime overlay (bundled Hermes / OpenClaw agents) ──────────────
+# Only needed if you run `docker compose -f compose.yml -f compose.agents.yml up`.
+# All paths are ABSOLUTE HOST paths — the host Docker daemon resolves them for
+# the agent containers it spawns, so they must be identical inside and out.
+# Full runbook: README "Agents (self-hosted runtime)"; flags: docs/CONFIG.md.
+#
+# Per-agent Hermes homes + bridge-config.json. Create it first:
+#   mkdir -p ./hermes-homes && chmod 777 ./hermes-homes
+# HERMES_HOMES_DIR=/opt/circlechat/hermes-homes
+#
+# Absolute host path of THIS repo — the equip step bind-mounts api/templates
+# and api/scripts from here into new agents. Wrong value = empty skills.
+# CC_REPO_HOST_DIR=/opt/circlechat
+#
+# Agent runtime images (pre-pull them; hermes-agent is ~4.7 GB).
+# CC_HERMES_IMAGE=nousresearch/hermes-agent:latest
+# CC_OPENCLAW_IMAGE=alpine/openclaw:latest
+# HERMES_TIMEOUT=180          # seconds per agent turn; ~200 on a Pi
+#
+# Optional shared /workspace mounted into every agent so deliverables survive
+# the per-turn `docker run --rm`. If set, also add the matching volume to the
+# api service in compose.agents.yml.
+# CC_SHARED_WORKSPACE_DIR=/opt/circlechat-workspace

--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ That's it. The first user to sign up becomes the workspace admin. Create a chann
 
 Caddy serves the web bundle at `/` and reverse-proxies `/api/*`, `/events`, `/agent-socket`, and `/uploads/*` to the API container.
 
+> **This starts the human chat stack (and webhook agents) only.** The bundled
+> **Hermes / OpenClaw** agents need one extra step — the agent runtime overlay:
+> `docker compose -f compose.yml -f compose.agents.yml up -d --build`, plus a
+> couple of host paths in `.env`. Without it a provisioned agent sits in
+> `provisioning` and the worker logs `agent_not_connected`. Full runbook:
+> **[Agents (self-hosted runtime)](#agents-self-hosted-runtime)**.
+
 ### System requirements
 
 | Resource | Minimum | Notes |
@@ -313,7 +320,7 @@ The core infrastructure vars are below. For the **agent, LLM, quality-gate, goal
 | `PG_PASSWORD` | `circlechat` | Postgres password |
 | `DATABASE_URL` | auto in compose | `postgres://…` — override to point at external PG |
 | `REDIS_URL` | auto in compose | `redis://…` |
-| `PUBLIC_BASE_URL` | `http://localhost:8080` | Used in invite URLs and OG links |
+| `PUBLIC_BASE_URL` | `http://localhost` in `.env.example` | Used in invite URLs and OG links, and as the API base agent containers call back on — must resolve **from the host** |
 | `S3_PUBLIC_BASE` | MinIO via compose | Where uploaded files are served from |
 | `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` | `minioadmin` | MinIO admin |
 | `SMTP_URL` | — (disabled) | `smtp://user:pass@host:587`. Empty → invites print to logs. |
@@ -338,18 +345,129 @@ Database migrations run automatically when the `api` container starts, so a fres
 
 ### Agents (self-hosted runtime)
 
-The base stack runs the chat app. To let CircleChat provision and run **Hermes / OpenClaw** agents, enable the agent runtime overlay:
+**`docker compose up` starts the human chat stack only.** It gives you channels,
+DMs, threads, tasks, uploads, search — and *webhook* agents, which run on your
+own infrastructure and just need a URL. It does **not** start the runtime for the
+bundled **Hermes / OpenClaw** socket agents. Provisioning one from the UI on the
+base stack will appear to succeed and then sit in `provisioning`, because nothing
+is holding its agent socket:
+
+```text
+worker-1  | [worker] job failed … agent_not_connected
+api-1     | POST /_internal/agent-dispatch → 404
+api-1     | skill ops (docker) failed: failed to connect to the docker API at unix:///var/run/docker.sock
+```
+
+Bundled agents need the **agent runtime overlay**, `compose.agents.yml`. It adds
+a `bridge` service (one WebSocket per agent to `/agent-socket`) and mounts the
+host Docker socket into `api`, `worker`, and `bridge` so they can spawn a
+short-lived agent container per turn.
+
+> **Security.** `/var/run/docker.sock` grants those containers root-equivalent
+> control of the host. Only enable the overlay on a host you own and trust.
+> The overlay is also Linux-first: agent containers run with `--network=host`,
+> which behaves differently under Docker Desktop on macOS/Windows.
+
+#### 1. Configure the host paths
+
+The overlay bind-mounts a few directories **at the same path inside the container
+as on the host**, because the host Docker daemon — not the API container —
+resolves the mounts for the agent containers it spawns. So the paths must be
+absolute host paths, and they must match your actual checkout. The defaults
+assume the reference layout (`/opt/circlechat`); if you cloned anywhere else,
+set them explicitly.
 
 ```bash
-# one-time host setup
-sudo mkdir -p /opt/hermes-homes && sudo chmod 777 /opt/hermes-homes
+cd /path/to/your/circlechat        # your clone
+mkdir -p ./hermes-homes && chmod 777 ./hermes-homes
+
+cat >> .env <<EOF
+HERMES_HOMES_DIR=$(pwd)/hermes-homes
+CC_REPO_HOST_DIR=$(pwd)
+PUBLIC_BASE_URL=http://localhost
+EOF
+```
+
+| Variable | Default | What it's for |
+| --- | --- | --- |
+| `HERMES_HOMES_DIR` | `/opt/hermes-homes` | Absolute **host** dir holding one home per agent (`.hermes-<handle>/`) plus `bridge-config.json`, the roster the bridge watches. Mounted at the identical path into `api`, `worker`, and `bridge`. Must exist and be writable by the containers (`chmod 777` is the blunt fix). |
+| `CC_REPO_HOST_DIR` | `/opt/circlechat` | Absolute **host** path of this repo. The equip step bind-mounts `api/templates/` and `api/scripts/` from here into new agents. Wrong value → agents get an empty `(missing DESCRIPTION.md)` skill and no MCP bridge. |
+| `PUBLIC_BASE_URL` | `http://localhost` (`.env.example`) | Becomes `CC_API_BASE` (`$PUBLIC_BASE_URL/api`) inside agent containers. They run on the host network, so this must be reachable **from the host** — `http://localhost` for the default Caddy stack, `https://chat.example.com` in production. Not a compose alias. |
+| `CC_HERMES_IMAGE` | `nousresearch/hermes-agent:latest` | Hermes runtime image. |
+| `CC_OPENCLAW_IMAGE` | `alpine/openclaw:latest` | OpenClaw runtime image. |
+| `HERMES_TIMEOUT` | `180` | Seconds per agent turn. Raise to ~200 on a Pi or a slow model. |
+| `CC_SHARED_WORKSPACE_DIR` | — (off) | Optional absolute **host** dir mounted at `/workspace` into every agent, so deliverables survive the per-turn `--rm` and agents can see each other's files. If you set it, also add `- ${CC_SHARED_WORKSPACE_DIR}:/workspace` to the `api` volumes in `compose.agents.yml` so `share_to_task` can read the same files back. |
+
+Every agent-runtime flag is listed in **[docs/CONFIG.md](docs/CONFIG.md#agent-runtime-hermes--openclaw)**.
+
+#### 2. Pre-pull the agent images and bring the overlay up
+
+The Hermes image is ~4.7 GB, so pull it once rather than on the first agent turn
+(which would otherwise time out).
+
+```bash
 docker pull nousresearch/hermes-agent:latest
-docker pull alpine/openclaw:latest
+docker pull alpine/openclaw:latest        # only if you'll use OpenClaw
 
 docker compose -f compose.yml -f compose.agents.yml up -d --build
 ```
 
-This adds a `bridge` service and mounts the host Docker socket into `api`/`worker`/`bridge` so they can spawn agent containers. **Security:** the Docker socket grants root-equivalent host access to those containers — only enable on a host you control. Point agents at your LLM gateway (e.g. [FreeLLMAPI](https://github.com/tashfeenahmed/freellmapi)) when provisioning them in the UI.
+Use **both** `-f` flags on every subsequent compose command for this deployment.
+A bare `docker compose up -d` doesn't know about the overlay: it recreates `api`
+and `worker` **without** the Docker socket and the agent paths, and leaves
+`bridge` behind as an orphan container — so agents keep failing in ways that look
+unrelated to the command you just ran.
+
+#### 3. Give the agents a model provider
+
+Bundled agents get their provider config **at provision time**, not from `.env`.
+In the UI (Members → Provision agent, or the signup wizard) pick a runtime
+(Hermes or OpenClaw) and a provider:
+
+- **FreeLLMAPI (self-hosted)** — the free-gateway path. Run
+  [FreeLLMAPI](https://github.com/tashfeenahmed/freellmapi) next to CircleChat,
+  then paste its base URL (e.g. `http://127.0.0.1:3001/v1`) **and** its unified
+  key. The base URL is written into the agent's `config.yaml`, so it must be
+  reachable from the *host* network, not just from the compose network.
+- **BYOK** — `anthropic`, `openai-codex`, `openrouter`, or `nous`: paste your own
+  provider key and CircleChat registers it inside that agent's home.
+
+That key configures the *agent*. The server-side planner and verification judge
+are separate and stay dormant until you set `PLANNER_BASE_URL` /
+`PLANNER_API_KEY` (see [docs/CONFIG.md](docs/CONFIG.md#llm-gateway-planner--verifier--embeddings));
+pointing them at the same FreeLLMAPI instance is the usual setup.
+
+#### 4. Verify the runtime is up
+
+```bash
+docker compose -f compose.yml -f compose.agents.yml ps bridge
+docker compose -f compose.yml -f compose.agents.yml logs -f bridge worker
+```
+
+A healthy bridge logs one connect + hello per provisioned agent:
+
+```text
+[multi-bridge] connecting <agent-handle>
+[<agent-handle>] hello → <agent-handle>
+```
+
+`$HERMES_HOMES_DIR` should now contain `bridge-config.json` (a JSON array with
+one entry per agent) and a `.hermes-<handle>/` home beside it. The agent flips
+from `provisioning` to `idle` in the member list, and `@`-mentioning it produces
+a reply.
+
+#### 5. When it doesn't work
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `agent_not_connected`, `POST /_internal/agent-dispatch → 404` | The `bridge` service isn't running — the overlay was never applied, or a later plain `docker compose up -d` recreated `api`/`worker` without it. | Bring the stack up with both `-f` files. |
+| Bridge starts but logs `bad config: ENOENT … bridge-config.json` | `HERMES_HOMES_DIR` differs between `api` and `bridge`, or the dir doesn't exist on the host. | Set `HERMES_HOMES_DIR` in `.env` (one value, absolute), create the dir, recreate the stack. |
+| `skill ops (docker) failed: … unix:///var/run/docker.sock` | The `api` container has no Docker socket — base stack only. | Apply the overlay. |
+| Agent installs but its skill is empty / `(missing DESCRIPTION.md)` | `CC_REPO_HOST_DIR` doesn't point at the real checkout, so the template bind-mount resolved to an empty dir. | Set `CC_REPO_HOST_DIR` to the real checkout, recreate the stack, then re-equip the agent from the **Skills** page (`POST /api/agents/<id>/equip`) — no need to delete it. |
+| Agent replies `No inference provider configured` | Wrong or unreachable provider base URL / key at provision time. | Re-provision the agent with a working key; for FreeLLMAPI check the base URL is reachable from the host. |
+| Agent runs but its actions never land | `PUBLIC_BASE_URL` isn't reachable from the host, so the container's `/agent-api` callbacks fail. | Set `PUBLIC_BASE_URL` to a URL that resolves from the host (with a valid cert in production). |
+| `409 hermes_home_exists` on install | A home dir from a previous install of that handle is still there. | Remove `$HERMES_HOMES_DIR/.hermes-<handle>/` (or pick a new handle). |
+| First agent turn times out | The ~4.7 GB Hermes image is still being pulled. | Pre-pull it; raise `HERMES_TIMEOUT`. |
 
 ### Deploy to a Raspberry Pi (or any bare-metal host)
 
@@ -375,6 +493,15 @@ docker compose logs -f api worker web
 
 # Reset all data (DESTRUCTIVE)
 docker compose down -v
+```
+
+If you enabled the agent runtime overlay, keep both `-f` files on every command
+(`docker compose -f compose.yml -f compose.agents.yml …`) — a bare
+`docker compose up -d` removes the `bridge` service and your agents go quiet. A
+shell alias saves the typing:
+
+```bash
+alias ccc='docker compose -f compose.yml -f compose.agents.yml'
 ```
 
 ---

--- a/compose.agents.yml
+++ b/compose.agents.yml
@@ -2,6 +2,14 @@
 #
 #   docker compose -f compose.yml -f compose.agents.yml up -d --build
 #
+# The base `compose.yml` alone runs human chat + webhook agents only. Without
+# this overlay there is no `bridge` service, so a bundled Hermes/OpenClaw agent
+# provisioned from the UI stays in `provisioning` and the worker logs
+# `agent_not_connected`. Keep BOTH -f files on every compose command for this
+# deployment — a bare `docker compose up -d` recreates api/worker WITHOUT the
+# socket and paths below, and leaves `bridge` behind as an orphan.
+# Runbook: README "Agents (self-hosted runtime)". Flags: docs/CONFIG.md.
+#
 # This mounts the host Docker socket into the api, worker, and bridge
 # containers so CircleChat can spawn ephemeral agent containers
 # (nousresearch/hermes-agent, alpine/openclaw) per message.
@@ -72,6 +80,15 @@ services:
       HERMES_HOMES_DIR: ${HERMES_HOMES_DIR:-/opt/hermes-homes}
       CC_HERMES_IMAGE: ${CC_HERMES_IMAGE:-nousresearch/hermes-agent:latest}
       CC_OPENCLAW_IMAGE: ${CC_OPENCLAW_IMAGE:-alpine/openclaw:latest}
+      # The bridge is what actually spawns the per-turn agent containers, so it
+      # needs the same shared-workspace host path the api uses. Empty = feature
+      # off (each turn's filesystem is wiped). If you set it, also add
+      #   - ${CC_SHARED_WORKSPACE_DIR}:/workspace
+      # to the api volumes above so share_to_task can read the same files back.
+      CC_SHARED_WORKSPACE_DIR: ${CC_SHARED_WORKSPACE_DIR:-}
+      # Seconds per agent turn. Set explicitly (not `:-`-empty) because the
+      # bridge does Number(env ?? 180) — an empty string would become 0.
+      HERMES_TIMEOUT: ${HERMES_TIMEOUT:-180}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${HERMES_HOMES_DIR:-/opt/hermes-homes}:${HERMES_HOMES_DIR:-/opt/hermes-homes}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -83,22 +83,54 @@ Tuning for how often idle agents wake and talk, to prevent echo-chamber loops.
 
 ---
 
-## Agent runtime (Hermes)
+## Agent runtime (Hermes / OpenClaw)
 
 Infrastructure for the per-message agent containers. Most are set once at deploy
 and rarely changed.
 
+**These only take effect under the agent runtime overlay.** The base
+`docker compose up` runs human chat and *webhook* agents; the bundled
+Hermes/OpenClaw socket agents need
+
+```bash
+docker compose -f compose.yml -f compose.agents.yml up -d --build
+```
+
+which adds the `bridge` service and mounts the host Docker socket into
+`api`/`worker`/`bridge`. Without it a provisioned agent stays in `provisioning`
+and the worker logs `agent_not_connected`. Step-by-step setup, verification, and
+failure modes: **[README → Agents (self-hosted runtime)](../README.md#agents-self-hosted-runtime)**.
+
+Every path below is an **absolute host path**. The agent containers are started
+by the *host* Docker daemon, which resolves `-v` sources host-side — so
+`compose.agents.yml` mounts these at the identical path inside the container,
+and a value that only exists inside the container silently resolves to an empty
+directory.
+
 | Var | Default | Effect |
 |-----|---------|--------|
-| `CC_HERMES_RUNTIME` | `docker` | `docker` (spawn a container per message) or `host`. |
-| `CC_HERMES_IMAGE` / `CC_OPENCLAW_IMAGE` | — | Agent runtime images. |
-| `HERMES_HOMES_DIR` | — | Host dir holding each agent's home (mounted at the same path into api/worker/bridge). |
-| `CC_SHARED_WORKSPACE_DIR` | — | Host dir mounted at `/workspace` into every agent — the shared, persistent scratch/deliverable space. |
-| `CC_SKILL_TEMPLATE` / `CC_BROWSER_SKILL_TEMPLATE` / `CC_MCP_SCRIPT` | — | Host paths to the skill templates + MCP script equipped into new agents. |
-| `HERMES_CONFIG_TEMPLATE` | — | Path to the base `hermes-config.yaml`. |
-| `HERMES_TIMEOUT` | `180` | Per-run timeout (seconds). |
-| `CC_WSS_URL` / `CC_API_BASE` | — | Internal WS URL for the bridge; public API base passed to agent containers for callbacks (must be the cert-valid host). |
+| `CC_HERMES_RUNTIME` | `docker` | `docker` (spawn a container per message) or `host` (legacy: a `hermes` binary on PATH). |
+| `CC_HERMES_IMAGE` / `CC_OPENCLAW_IMAGE` | `nousresearch/hermes-agent:latest` / `alpine/openclaw:latest` | Agent runtime images. Pre-pull them — Hermes is ~4.7 GB, and pulling on the first turn usually blows `HERMES_TIMEOUT`. |
+| `HERMES_HOMES_DIR` | `/opt/hermes-homes` (compose overlay) | Host dir holding each agent's home (`.hermes-<handle>/`) **and** `bridge-config.json`. Mounted at the same path into api/worker/bridge. Must exist and be container-writable (`chmod 777`) before the first install. |
+| `CC_REPO_HOST_DIR` | `/opt/circlechat` (compose overlay) | Host path of the CircleChat checkout. Only read by `compose.agents.yml`, where it derives `CC_SKILL_TEMPLATE`, `CC_BROWSER_SKILL_TEMPLATE`, and `CC_MCP_SCRIPT`. Set it whenever the repo isn't at `/opt/circlechat`, or new agents get an empty `(missing DESCRIPTION.md)` skill and no MCP bridge. |
+| `CC_BRIDGE_CONFIG_PATH` (api/worker) / `CC_BRIDGE_CONFIG` (bridge) | `$HERMES_HOMES_DIR/bridge-config.json` under the overlay; `./bridge-config.json` otherwise | The agent roster the bridge watches: the api appends an entry on install, the bridge reconciles its WebSockets within a second. **The two must resolve to the same file** — if they diverge, installs succeed and the agent never connects. |
+| `CC_SHARED_WORKSPACE_DIR` | — (off) | Host dir mounted at `/workspace` into every agent — the shared, persistent scratch/deliverable space that survives the per-turn `docker run --rm`. Read by both the api and the bridge. If you set it, also add `- ${CC_SHARED_WORKSPACE_DIR}:/workspace` to the `api` service volumes in `compose.agents.yml` so `share_to_task`/`share_files` can read the same files back. |
+| `CC_SKILL_TEMPLATE` / `CC_BROWSER_SKILL_TEMPLATE` / `CC_MCP_SCRIPT` | derived from `CC_REPO_HOST_DIR` | Host paths to the skill templates + MCP script equipped into new agents. Set individually only for a non-standard layout. |
+| `HERMES_CONFIG_TEMPLATE` | `api/templates/hermes-config.yaml` | Base Hermes `config.yaml` copied into each new home (`hermes setup` needs a TTY, so it is pre-seeded instead). |
+| `HERMES_TIMEOUT` | `180` | Per-run timeout (seconds). Raise to ~200 on a Pi or a slow model. |
+| `CC_WSS_URL` / `CC_API_BASE` | `ws://api:3000/agent-socket` / `$PUBLIC_BASE_URL/api` | Internal WS URL for the bridge; public API base passed to agent containers for callbacks. Agent containers run with `--network=host`, so `CC_API_BASE` must resolve **from the host** (and be cert-valid in production) — a compose alias will not work. |
 | `CC_FORCE_QUARANTINE_BUNDLED_SKILLS` | — | Quarantine the runtime's bundled skills so only CircleChat skills load. |
+
+### Where an agent's model provider comes from
+
+Not from these variables. A bundled agent's provider and key are supplied **at
+provision time** in the UI (Members → Provision agent) and written into that
+agent's own home: either a self-hosted **FreeLLMAPI** gateway (base URL +
+unified key, stored as a `custom_providers` entry) or a BYOK provider
+(`anthropic`, `openai-codex`, `openrouter`, `nous`). The server-side planner and
+verification judge are a separate backend — see
+[LLM gateway](#llm-gateway-planner--verifier--embeddings) — though pointing both
+at the same gateway is the usual setup.
 
 ---
 


### PR DESCRIPTION
## What was wrong

`@capt-marbles` followed the quickstart (#44), got a working chat stack, provisioned a bundled Hermes agent from the UI — and it sat in `provisioning` forever, with `agent_not_connected` in the worker log, `POST /_internal/agent-dispatch → 404` in the api log, and `skill ops (docker) failed: … unix:///var/run/docker.sock` from the equip step.

That's the base `compose.yml` doing exactly what it's built to do: human chat plus *webhook* agents. Bundled **Hermes / OpenClaw** socket agents need the agent runtime overlay (`compose.agents.yml`), which adds the `bridge` service and the Docker socket. The overlay did exist and was mentioned once under Deployment — but the quickstart said "that's it", the overlay snippet hardcoded the `/opt/circlechat` reference layout with no explanation of why the paths must be absolute host paths, and `HERMES_HOMES_DIR` / `CC_REPO_HOST_DIR` appeared in no `.env.example` and in no config table. A self-hoster running from a normal clone had no way to get there from the docs.

## What a self-hoster now sees

**Quickstart** ends with a callout: the base stack is human chat + webhook agents only, bundled agents need one more command, here's the link.

**README → [Agents (self-hosted runtime)](https://github.com/tashfeenahmed/circlechat/blob/main/README.md#agents-self-hosted-runtime)** is now a runbook rather than a paragraph:

1. **The symptom first** — the three exact log lines from the issue, so the next person searching them lands on the fix.
2. **Host paths** — why they must be absolute and identical inside/outside the container (the *host* daemon resolves the agent containers' mounts), a copy-pasteable `.env` snippet built from `$(pwd)`, and a table for `HERMES_HOMES_DIR`, `CC_REPO_HOST_DIR`, `PUBLIC_BASE_URL`, the two images, `HERMES_TIMEOUT`, and `CC_SHARED_WORKSPACE_DIR`.
3. **Pre-pull + up** — the ~4.7 GB Hermes image pulled once instead of on the first turn, then `docker compose -f compose.yml -f compose.agents.yml up -d --build`, plus a warning that a later bare `docker compose up -d` silently recreates `api`/`worker` without the overlay.
4. **Provider config** — where a bundled agent's model key actually comes from (the provision form: self-hosted FreeLLMAPI gateway *or* BYOK anthropic/openai-codex/openrouter/nous), and how that differs from the server-side planner/judge backend.
5. **Verification** — the `bridge` log lines that mean healthy (`[multi-bridge] connecting <handle>` / `hello →`), and what should exist in `$HERMES_HOMES_DIR`.
6. **Failure modes** — an eight-row symptom/cause/fix table keyed on real log strings: missing bridge, diverging `bridge-config.json` paths, no Docker socket, empty `(missing DESCRIPTION.md)` skill from a wrong `CC_REPO_HOST_DIR`, `No inference provider configured`, unreachable `PUBLIC_BASE_URL` callbacks, `409 hermes_home_exists`, and first-turn timeouts.

**docs/CONFIG.md** — the agent-runtime table was half-empty; it now carries `CC_REPO_HOST_DIR`, the `CC_BRIDGE_CONFIG_PATH` / `CC_BRIDGE_CONFIG` pair (the api and the bridge must resolve to the same file or installs succeed and never connect), real defaults, the `--network=host` constraint on `CC_API_BASE`, and a short section saying agent providers come from the provision form, not env.

**.env.example** — commented agent-runtime block, and `PUBLIC_BASE_URL` corrected from `http://localhost:8080` to `http://localhost`: Caddy binds `:80`, the quickstart tells you to open `http://localhost`, and agent containers call back on `$PUBLIC_BASE_URL/api` from the host network — the old value pointed at nothing.

## One real code gap found

`compose.agents.yml` never passed `CC_SHARED_WORKSPACE_DIR` or `HERMES_TIMEOUT` to the `bridge` service, which reads both. The bridge is the process that actually spawns the per-turn agent containers, so the shared `/workspace` mount was silently off for every agent even when an operator set the variable. Both are now passed through, `HERMES_TIMEOUT` with an explicit `:-180` default because the bridge does `Number(env ?? 180)` and an empty string would become `0`.

Left as documented-not-automated: the matching `- ${CC_SHARED_WORKSPACE_DIR}:/workspace` volume on `api` can't be made conditional in Compose, so it stays an opt-in instruction in the env table and in `compose.agents.yml`'s comments.

## Validation

Docs and config only, no TypeScript touched. Both compose files parse; `bridge` gains exactly the two intended env keys and no volume changes, so `docker compose -f compose.yml -f compose.agents.yml config` behaviour is unchanged for anyone not setting the new variables. All internal doc anchors checked.

Closes #44
