### PR TITLE
Harden the agent loop: guard leaks, approval lifecycle, verifier config, run accounting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ VITE_WS_URL=/events
 # Agent runtime images (pre-pull them; hermes-agent is ~4.7 GB).
 # CC_HERMES_IMAGE=nousresearch/hermes-agent:latest
 # CC_OPENCLAW_IMAGE=alpine/openclaw:latest
-# HERMES_TIMEOUT=180          # seconds per agent turn; ~200 on a Pi
+# HERMES_TIMEOUT=480          # seconds per agent turn; agents with many tool turns need minutes
 #
 # Optional shared /workspace mounted into every agent so deliverables survive
 # the per-turn `docker run --rm`. If set, also add the matching volume to the

--- a/api/hermes-multi-bridge.mjs
+++ b/api/hermes-multi-bridge.mjs
@@ -15,7 +15,9 @@ import { join as joinPath } from "node:path";
 const CFG_PATH = process.env.CC_BRIDGE_CONFIG ?? "./bridge-config.json";
 const WSS = process.env.CC_WSS_URL ?? "ws://localhost:3300/agent-socket";
 const API_BASE = process.env.CC_API_BASE ?? "http://localhost:3300/api";
-const HERMES_TIMEOUT = Number(process.env.HERMES_TIMEOUT ?? 180);
+// Observed on the live fishbowl: successful Hermes runs p50 133s / p90 183s,
+// and every "empty/crashed" reply was the 180s SIGTERM. Default well above p90.
+const HERMES_TIMEOUT = Number(process.env.HERMES_TIMEOUT) || 480; // seconds; empty/invalid → default
 // Match the api process' runtime decision. "docker" is the default going
 // forward; "host" is only retained as an escape hatch.
 const HERMES_RUNTIME = process.env.CC_HERMES_RUNTIME === "host" ? "host" : "docker";
@@ -329,8 +331,73 @@ function isEntrypointNoise(line) {
   if (/^\[supervise[-\w]*\]/i.test(t)) return true;
   if (/^\[s6-/i.test(t)) return true;
   if (/^reconcile:\s/i.test(t)) return true;
+  // Agent-loop cap banner: "⚠️  Reached maximum iterations (20). Requesting
+  // summary..." — printed by Hermes when the run hits `max_turns`, then the
+  // model's wrap-up follows. 576 live posts began with this in one week.
+  if (/^\u26A0?\uFE0F?\s*Reached maximum iterations\b/i.test(t)) return true;
+  if (/^Requesting (?:a )?summary\b/i.test(t)) return true;
+  // Tool-dispatcher failure notice + its text-parser delimiter debris
+  // ("⚠ Could not execute tool(s): "target": value "files\n@@ARG_END" not in
+  // enum […]"). Multi-line variants are handled by stripRuntimeNoise().
+  if (/^\u26A0?\uFE0F?\s*Could not execute tool\(s\)/i.test(t)) return true;
+  if (/@@ARGS?_(?:START|END|BEGIN)\b/.test(t)) return true;
   return false;
 }
+
+// Multi-line runtime notices that a per-line filter can't fully catch: the
+// "Could not execute tool(s)" paragraph carries the offending argument text
+// (which may span lines) up to the next blank line. Also the iterations banner
+// when it shares a line with the wrap-up. Applied to the joined reply text.
+const RUNAWAY_BANNER_RE =
+  /(?:^|\n)[ \t]*\u26A0?\uFE0F?[ \t]*Reached maximum iterations(?:\s*\(\d+\))?\.?(?:[ \t]*Requesting (?:a )?summary(?:\.{1,3}|…)?)?[ \t]*(?:\n|$)/gi;
+const TOOL_EXEC_FAIL_RE =
+  /(?:^|\n)[ \t]*\u26A0?\uFE0F?[ \t]*Could not execute tool\(s\)[^\n]*(?:\n(?![ \t]*\n)[^\n]*)*/gi;
+function stripRuntimeNoise(text) {
+  return String(text || "")
+    .replace(RUNAWAY_BANNER_RE, "\n")
+    .replace(TOOL_EXEC_FAIL_RE, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+// Cut `text` to at most `max` chars WITHOUT slicing mid-sentence: prefer the
+// last paragraph break past half the budget, then the last sentence end, then
+// the last whitespace. Returns the text unchanged when it already fits.
+function truncateAtBoundary(text, max) {
+  const s = String(text || "");
+  if (s.length <= max) return s;
+  const window = s.slice(0, max);
+  const floor = Math.floor(max * 0.5);
+  let cut = window.lastIndexOf("\n\n");
+  if (cut < floor) {
+    // Last sentence terminator followed by whitespace/end within the window.
+    const re = /[.!?…](?=\s)/g;
+    let m;
+    let last = -1;
+    while ((m = re.exec(window))) last = m.index + 1;
+    cut = last;
+  }
+  if (cut < floor) cut = window.lastIndexOf("\n");
+  if (cut < floor) cut = window.search(/\s[^\s]*$/);
+  if (cut < floor) cut = max;
+  return s.slice(0, cut).trimEnd();
+}
+
+// The first sentence/paragraph of a body, capped — used as the short chat
+// pointer when the long form is routed to a task card.
+function leadOf(text, max) {
+  const s = String(text || "").trim();
+  const para = s.split(/\n\s*\n/)[0] || s;
+  return truncateAtBoundary(para, max);
+}
+
+// Body caps. Chat is for what humans need to see NOW; anything longer belongs
+// on a task card (which the API accepts up to 20k chars — we stop at 6k so a
+// runaway summary doesn't become a runaway comment).
+const CHAT_BODY_MAX = 2000;
+const CHAT_POINTER_MAX = 400;
+const TASK_BODY_MAX = 6000;
+const RAW_REPLY_MAX = 12000;
 
 // Final safety net before posting: after <actions>/<attachments> have been
 // pulled out, is the remaining body nothing but machinery (tool-call syntax,
@@ -404,17 +471,23 @@ function extractReply(raw) {
     if (isEntrypointNoise(content)) continue;
     out.push(content);
   }
-  const text = stripClarifyNoise(out.join("\n").replace(/\n{3,}/g, "\n\n").trim());
+  const text = stripRuntimeNoise(stripClarifyNoise(out.join("\n").replace(/\n{3,}/g, "\n\n").trim()));
   if (text) return text;
-  return stripClarifyNoise(stripAnsi
-    .replace(/[╭╰│╮╯─]+/g, "")
-    .split("\n")
-    .filter((l) => !/^session_id:/i.test(l))
-    .filter((l) => !/^\s*⚕?\s*Hermes\s*$/.test(l))
-    .filter((l) => !isEntrypointNoise(l))
-    .join("\n")
-    .trim()
-    .slice(0, 2000));
+  // No boxed reply found (quiet/compact display) — the whole stream is the
+  // reply. Cap it, but at a sentence/paragraph boundary: the old hard
+  // `.slice(0, 2000)` cut 12 of one agent's comments mid-sentence in a week.
+  // Per-surface caps are applied when the post is assembled.
+  return truncateAtBoundary(
+    stripRuntimeNoise(stripClarifyNoise(stripAnsi
+      .replace(/[╭╰│╮╯─]+/g, "")
+      .split("\n")
+      .filter((l) => !/^session_id:/i.test(l))
+      .filter((l) => !/^\s*⚕?\s*Hermes\s*$/.test(l))
+      .filter((l) => !isEntrypointNoise(l))
+      .join("\n")
+      .trim())),
+    RAW_REPLY_MAX,
+  );
 }
 
 // Pulls every @handle token out of a markdown body. Skips `@` inside code
@@ -647,12 +720,34 @@ Do NOT re-emit it — that would do it twice. It is done. Move on: take the NEXT
     return `APPROVAL DECIDED — your request ${ar.id} ("${ar.action}") was APPROVED by ${who}.${noteLine}${secretsLine}
 You may now perform the approved action. If it was a gated <actions> entry, re-emit it in your <actions> block THIS TURN — the server will let it through exactly once${ar.note ? ", adjusted per the note above if it narrows the ask" : ""}. If it was a pre-flight request_approval for outside work, do that work now. Don't thank anyone in chat for the approval — just do the thing and report the concrete outcome where the work lives (task card if there is one).`;
   }
+  if (ar.status === "expired") {
+    return `APPROVAL EXPIRED — your request ${ar.id} ("${ar.action}") waited for a human decision until its deadline and is now CLOSED without one.${noteLine}
+Hard rules now in force:
+  • Do NOT re-request or rephrase it — the server refuses equivalent requests for a week.
+  • Tasks that were blocked on it have been moved back to in_progress. Pick one up and use a route that needs NO approval: share_to_task + the in-platform app preview instead of an external host, a keyless data source instead of a paid API, or scope the deliverable down.
+  • If nothing is possible without it, hand the task back with ONE task_comment saying exactly what is missing — then work on something else. No chat post about the expiry is needed.`;
+  }
   return `APPROVAL DECIDED — your request ${ar.id} ("${ar.action}") was DENIED by ${who}. DENIED MEANS NO — it is a FINAL human answer, not a delay, not "pending", not "resolved".${noteLine}
 Hard rules now in force:
   • Do NOT perform the action, do NOT re-request it, do NOT rephrase the same ask into a new approval (the server matches by similarity and refuses it).
   • Do NOT reinterpret this as the thing being granted — no credential was provided, nothing became "available".
   • ${ar.note ? "Adjust your approach per the note above — it tells you what to do instead." : "If a task depends on this, set that task's status to \"blocked\" with ONE task_comment naming the denial, or pursue an approach that doesn't need this approval."} Then pick up different work. No chat post about the denial is needed.`;
 }
+
+// Output-hygiene rules appended to every prompt (chat and task-only). Each line
+// maps to a failure the live fishbowl produced at scale: ritual sign-offs with
+// hash footers, 1,400-char restatements of the task, the same fact posted to
+// chat + task card + tracker, and invented "proof package vNN" busywork.
+const STYLE_RULES = [
+  ``,
+  `OUTPUT HYGIENE (server-enforced where marked):`,
+  `  • NO SIGN-OFFS. Never end with "Signed", "Regards", your name/title line, or an "Artifact SHA-256" footer — the server strips them (and rejects a reply that is only a signature).`,
+  `  • ONE NEW FACT PER MESSAGE. Say the thing that changed since your last post, in 1–2 sentences. Do not restate the task, your role, the plan, or what was already on the card. A reply over ${CHAT_BODY_MAX} chars is cut at a sentence boundary — put long-form on the task card, not in chat.`,
+  `  • ONE SURFACE PER FACT. Never post the same fact to chat AND a task_comment AND project_note. Task progress → task_comment/share_to_task only. Project-level decisions/status → project_note only. Chat → only what a human needs to see right now. The server drops near-duplicate bodies across these surfaces (duplicate_of_recent) and near-duplicate tracker entries.`,
+  `  • NO INVENTED WORK. Do not manufacture "proof packages", re-verify what is already verified, bump a version number on a status doc, or re-announce a fact already on the card to have something to post. If nothing real changed: HEARTBEAT_OK.`,
+  `  • NEVER paste runtime output into a reply: "Reached maximum iterations", "Requesting summary", "Could not execute tool(s)", @@ARG markers, or a summary of your tool calls. If you ran out of tool turns, say the one concrete outcome (or HEARTBEAT_OK) — not a transcript. Do not talk to the prompt ("I read the attached history file…") — reply to the people.`,
+  `  • Scratch files (test scripts, fetch helpers) go under /workspace/tmp/, never your home or cwd, and are never shared or mentioned in chat.`,
+].join("\n");
 
 function buildPrompt(entry, packet) {
   const agent = packet.agent || {};
@@ -1057,6 +1152,16 @@ Don't repeat yourself across heartbeats: if your last task_comment said "I'll dr
       `Anything you were doing that turn may not have completed — no actions were applied. Check the task you were working on (its comments/artifacts show what actually landed) and redo the lost step rather than assuming it happened.`,
     ].join("\n");
   }
+  // Server-side refusals from the last turn (dedupe, approval dedupe, denied-is-
+  // final, guard rejections). Without this the agent never learns WHY a post or
+  // request silently vanished and simply tries again — the begging loop.
+  if (Array.isArray(packet.previousRunErrors) && packet.previousRunErrors.length) {
+    prevFailBlock += [
+      ``,
+      `FEEDBACK ON YOUR LAST TURN — the server refused these (do not retry them as-is):`,
+      ...packet.previousRunErrors.slice(0, 6).map((e) => `  • ${String(e).slice(0, 300)}`),
+    ].join("\n");
+  }
 
   // One-shot loop-break directive (run-level stuck detector). High priority —
   // the agent has been repeating itself; tell it to break the pattern.
@@ -1078,7 +1183,8 @@ Don't repeat yourself across heartbeats: if your last task_comment said "I'll dr
     const lines = aps.slice(0, 10).map((ap) => {
       const when = ap.createdAt ? ` · requested ${String(ap.createdAt).slice(0, 10)}` : "";
       const whose = ap.mine === false && ap.agentHandle ? ` · filed by @${ap.agentHandle}` : "";
-      return `  ⏳ ${ap.id} [${ap.scope}${when}${whose}] ${ap.action}`;
+      const until = ap.expiresAt ? ` · expires ${String(ap.expiresAt).slice(0, 10)}` : "";
+      return `  ⏳ ${ap.id} [${ap.scope}${when}${whose}${until}] ${ap.action}`;
     });
     approvalsBlock = [
       ``,
@@ -1265,6 +1371,7 @@ Don't repeat yourself across heartbeats: if your last task_comment said "I'll dr
         toolBlock,
         ``,
         `Your reply body will be dropped — there is no conversation to post into. The ONLY valid output this turn is either (a) an <actions>[...]</actions> block doing real work on a task, or (b) exactly "HEARTBEAT_OK". No prose, no receipts, no "I will…".`,
+        STYLE_RULES,
       ]
     : [
         identity,
@@ -1293,6 +1400,7 @@ Don't repeat yourself across heartbeats: if your last task_comment said "I'll dr
         toolBlock,
         ``,
         `Reply briefly (1–2 sentences unless asked for more). Write only the reply text — no greetings, no sign-off, no markdown code fences around your reply.`,
+        STYLE_RULES,
       ];
   return sections.join("\n");
 }
@@ -1402,8 +1510,13 @@ function connect(entry) {
       // silent rather than posting "(empty reply)" as text — always safer.
       if (!rawText.trim()) {
         console.log(`[${entry.handle}] ${trigger} → skip (empty/crashed reply)`);
-        return reply({ status: "HEARTBEAT_OK" });
+        return reply({ status: "HEARTBEAT_OK", error: "empty_reply" });
       }
+      // Hermes hit its agent-loop cap: the reply is a forced summary, not real
+      // work. Post whatever substantive remainder survives the noise strip,
+      // but tell the worker so the run is recorded as non-productive.
+      const runaway = /Reached maximum iterations/i.test(rawText);
+      const outcomeErr = runaway ? { error: "runaway_max_iterations" } : {};
       // Silence-allowed triggers: model is permitted to skip a post by returning
       // HEARTBEAT_OK. `mention` is here only for agent→agent mentions (the
       // prompt forbids it on human mentions, and the executor's reply-guard
@@ -1449,10 +1562,36 @@ function connect(entry) {
       // would have nowhere to land, so we drop it and let the side-actions
       // (task_comment / share_to_task / update_task) carry the work.
       if (postBody && conv) {
+        let chatBody = postBody;
+        if (postBody.length > CHAT_BODY_MAX) {
+          // Too long for chat. If this turn is about a task (the trigger's
+          // task, or a task the agent targeted in its own actions), the long
+          // form goes onto THAT card as a task_comment and chat gets a short
+          // pointer. Otherwise cut at a boundary and say so — never a silent
+          // mid-sentence chop.
+          const routeTaskId =
+            (p.task && typeof p.task.id === "string" && p.task.id) ||
+            sideActions.find((sa) => sa && typeof sa.task_id === "string")?.task_id ||
+            null;
+          if (routeTaskId) {
+            const full = truncateAtBoundary(postBody, TASK_BODY_MAX);
+            actions.push({
+              type: "task_comment",
+              task_id: routeTaskId,
+              body_md: full.length < postBody.length ? `${full}\n\n_(trimmed — ${postBody.length - full.length} chars cut)_` : full,
+            });
+            chatBody = `${leadOf(postBody, CHAT_POINTER_MAX)}\n\n_(full update on the task card: ${routeTaskId})_`;
+            console.log(`[${entry.handle}] ${trigger} → ${postBody.length}-char prose routed to task_comment on ${routeTaskId}; chat gets a ${chatBody.length}-char pointer`);
+          } else {
+            const cut = truncateAtBoundary(postBody, CHAT_BODY_MAX - 80);
+            chatBody = `${cut}\n\n_(trimmed — ${postBody.length - cut.length} chars cut; keep chat short, put long-form on a task card)_`;
+            console.log(`[${entry.handle}] ${trigger} → ${postBody.length}-char prose cut at a boundary to ${chatBody.length} for chat`);
+          }
+        }
         actions.push({
           type: "post_message",
           conversation_id: conv.conversationId,
-          body_md: postBody,
+          body_md: chatBody,
           ...(replyTo ? { reply_to: replyTo } : {}),
           ...(attachments.length ? { attachments } : {}),
         });
@@ -1467,11 +1606,12 @@ function connect(entry) {
           (Array.isArray(p.myTasks) && p.myTasks[0]?.id) ||
           null;
         if (targetTaskId) {
-          console.log(`[${entry.handle}] task-only: auto-wrapping ${postBody.length}-char prose into task_comment on ${targetTaskId}`);
+          const wrapped = truncateAtBoundary(postBody, TASK_BODY_MAX);
+          console.log(`[${entry.handle}] task-only: auto-wrapping ${postBody.length}-char prose into task_comment on ${targetTaskId}${wrapped.length < postBody.length ? ` (cut to ${wrapped.length} at a boundary)` : ""}`);
           actions.push({
             type: "task_comment",
             task_id: targetTaskId,
-            body_md: postBody,
+            body_md: wrapped.length < postBody.length ? `${wrapped}\n\n_(trimmed — ${postBody.length - wrapped.length} chars cut)_` : wrapped,
           });
         } else {
           console.log(`[${entry.handle}] task-only: dropping ${postBody.length}-char prose (no conv and no task to wrap into)`);
@@ -1481,10 +1621,11 @@ function connect(entry) {
       console.log(
         `[${entry.handle}] replying, len=${postBody.length}, att=${attachments.length}${sideActions.length ? `, actions=${sideActions.length} (${sideActions.map((a) => a.type).join("+")})` : ""}`,
       );
-      if (actions.length === 0) return reply({ status: "HEARTBEAT_OK" });
+      if (actions.length === 0) return reply({ status: "HEARTBEAT_OK", ...outcomeErr });
       reply({
         actions,
-        trace: [`${entry.handle} responded, len=${postBody.length}${attachments.length ? `, att=${attachments.length}` : ""}${sideActions.length ? `, actions=${sideActions.length}` : ""}`],
+        ...outcomeErr,
+        trace: [`${entry.handle} responded, len=${postBody.length}${attachments.length ? `, att=${attachments.length}` : ""}${sideActions.length ? `, actions=${sideActions.length}` : ""}${runaway ? ", runaway" : ""}`],
       });
     } catch (e) {
       console.error(`[${entry.handle}] error: ${e.message.split("\n")[0]}`);
@@ -1500,6 +1641,7 @@ function connect(entry) {
               },
             ]
           : [],
+        error: `bridge_error: ${e.message.split("\n")[0].slice(0, 200)}`,
         trace: [`${entry.handle} error: ${e.message.slice(0, 200)}`],
       });
     }
@@ -1527,7 +1669,20 @@ function connect(entry) {
 // Exported so evals/tests can build the EXACT production prompt + reuse the
 // action parser without copying. Importing the module never connects sockets
 // unless it's run as the entrypoint (or CC_BRIDGE_IMPORT_ONLY forces import-only).
-export { buildPrompt, extractActions, extractAttachments, sanitizeActions, canonicalActionType };
+export {
+  buildPrompt,
+  extractActions,
+  extractAttachments,
+  sanitizeActions,
+  canonicalActionType,
+  extractReply,
+  stripRuntimeNoise,
+  truncateAtBoundary,
+  leadOf,
+  isEntrypointNoise,
+  CHAT_BODY_MAX,
+  TASK_BODY_MAX,
+};
 
 if (!process.env.CC_BRIDGE_IMPORT_ONLY) {
   reconcile();

--- a/api/src/__tests__/approval-policy.test.ts
+++ b/api/src/__tests__/approval-policy.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  normalizeScope,
+  credentialNames,
+  isCredentialAsk,
+  scopeMatches,
+  autoApprovalFor,
+  approvalExpiresAt,
+  isApprovalExpired,
+  expiryNote,
+  denialMemoryMs,
+  pickDuplicate,
+  duplicateApprovalError,
+} from "../lib/approval-policy.js";
+import { approvalTtlHours, approvalDenialMemoryDays, autoApproveScopes } from "../lib/config.js";
+
+// Env-driven knobs: save/restore around each test.
+const ENV = ["APPROVAL_TTL_HOURS", "APPROVAL_DEFAULT_TTL", "APPROVAL_DENIAL_MEMORY_DAYS", "AUTO_APPROVE_SCOPES"];
+const saved: Record<string, string | undefined> = {};
+beforeEach(() => {
+  for (const k of ENV) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+afterEach(() => {
+  for (const k of ENV) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("config readers", () => {
+  it("default: 72h TTL, 7-day denial memory, nothing auto-approved", () => {
+    expect(approvalTtlHours()).toBe(72);
+    expect(approvalDenialMemoryDays()).toBe(7);
+    expect(autoApproveScopes()).toEqual([]);
+  });
+  it("APPROVAL_TTL_HOURS wins over the APPROVAL_DEFAULT_TTL alias; 0 disables; junk falls back", () => {
+    process.env.APPROVAL_DEFAULT_TTL = "24";
+    expect(approvalTtlHours()).toBe(24);
+    process.env.APPROVAL_TTL_HOURS = "6";
+    expect(approvalTtlHours()).toBe(6);
+    process.env.APPROVAL_TTL_HOURS = "0";
+    expect(approvalTtlHours()).toBe(0);
+    expect(approvalExpiresAt(new Date(), approvalTtlHours())).toBeNull();
+    process.env.APPROVAL_TTL_HOURS = "banana";
+    expect(approvalTtlHours()).toBe(72);
+  });
+  it("AUTO_APPROVE_SCOPES is a trimmed, lower-cased comma list", () => {
+    process.env.AUTO_APPROVE_SCOPES = " Deploy, tasks.* ,,RISK:medium ";
+    expect(autoApproveScopes()).toEqual(["deploy", "tasks.*", "risk:medium"]);
+  });
+});
+
+describe("scope + credential matching (dedupe, task a)", () => {
+  it("normalises free-form scopes to one key", () => {
+    expect(normalizeScope("Tavily API key")).toBe("tavily_api_key");
+    expect(normalizeScope("TAVILY_API_KEY")).toBe("tavily_api_key");
+    expect(normalizeScope("tavily-api-key ")).toBe("tavily_api_key");
+    expect(normalizeScope("tasks.write")).toBe("tasks.write");
+    expect(normalizeScope("risk:medium")).toBe("risk:medium");
+  });
+
+  it("extracts env-var-shaped credential names from scope and action", () => {
+    expect(credentialNames("tavily_api_key", "Need a search key")).toEqual(["TAVILY_API_KEY"]);
+    expect(credentialNames("deploy", "Please provision VERCEL_TOKEN so I can ship")).toEqual(["VERCEL_TOKEN"]);
+    expect(credentialNames("github", "a GITHUB_PAT with repo scope")).toEqual(["GITHUB_PAT"]);
+    expect(credentialNames("deploy", "publish the site")).toEqual([]);
+  });
+
+  it("flags credential asks (never auto-approvable)", () => {
+    expect(isCredentialAsk("tavily_api_key", "")).toBe(true);
+    expect(isCredentialAsk("deploy", "need the Vercel token")).toBe(true);
+    expect(isCredentialAsk("deploy", "publish the landing page to the preview host")).toBe(false);
+  });
+
+  const req = { agentId: "ag_a", scope: "tavily_api_key", action: "Provision a Tavily API key for web research" };
+  const row = (over: Partial<Parameters<typeof pickDuplicate>[0][number]>) => ({
+    id: "ap_x",
+    status: "pending",
+    agentId: "ag_a",
+    decidedAt: null,
+    decisionNote: null,
+    action: "",
+    scope: "",
+    sim: 0,
+    ...over,
+  });
+
+  it("matches the same scope even when the sentence is completely different", () => {
+    const dup = pickDuplicate([row({ scope: "TAVILY_API_KEY", action: "search backend credentials please", sim: 0.05 })], req);
+    expect(dup?.id).toBe("ap_x");
+  });
+
+  it("matches the same credential name under a different scope", () => {
+    const dup = pickDuplicate(
+      [row({ scope: "research_tools", action: "I need TAVILY_API_KEY to run searches", sim: 0.1 })],
+      { ...req, scope: "web_search", action: "unblock research: TAVILY_API_KEY" },
+    );
+    expect(dup?.id).toBe("ap_x");
+  });
+
+  it("falls back to text similarity: looser for the same agent than for a teammate", () => {
+    expect(pickDuplicate([row({ scope: "x", action: "…", sim: 0.5 })], { ...req, scope: "" })?.id).toBe("ap_x");
+    expect(pickDuplicate([row({ scope: "x", action: "…", sim: 0.5, agentId: "ag_b" })], { ...req, scope: "" })).toBeNull();
+    expect(pickDuplicate([row({ scope: "x", action: "…", sim: 0.7, agentId: "ag_b" })], { ...req, scope: "" })?.id).toBe("ap_x");
+  });
+
+  it("prefers a recent denial over a pending card for the same ask", () => {
+    const denied = row({ id: "ap_denied", status: "denied", scope: "tavily_api_key", decidedAt: new Date("2026-07-04"), decisionNote: "No paid search APIs — use DuckDuckGo." });
+    const pending = row({ id: "ap_pending", status: "pending", scope: "tavily_api_key" });
+    const dup = pickDuplicate([pending, denied], req);
+    expect(dup?.id).toBe("ap_denied");
+    const msg = duplicateApprovalError("request_approval", dup!, "ag_a");
+    expect(msg).toMatch(/DENIED/);
+    expect(msg).toContain("2026-07-04");
+    expect(msg).toContain("No paid search APIs — use DuckDuckGo.");
+    expect(msg).toMatch(/do NOT re-request/);
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(pickDuplicate([row({ scope: "vercel_token", action: "ship to vercel", sim: 0.1 })], req)).toBeNull();
+  });
+
+  it("explains expired and teammate duplicates distinctly", () => {
+    const expired = duplicateApprovalError("request_approval", { id: "ap_e", status: "expired", agentId: "ag_a", decidedAt: new Date("2026-08-01"), decisionNote: null, action: "x", scope: "s" }, "ag_a");
+    expect(expired).toMatch(/EXPIRED/);
+    expect(expired).toMatch(/Do NOT re-request/);
+    const teammate = duplicateApprovalError("request_approval", { id: "ap_t", status: "pending", agentId: "ag_b", decidedAt: null, decisionNote: null, action: "x", scope: "s" }, "ag_a");
+    expect(teammate).toMatch(/teammate/);
+    const mine = duplicateApprovalError("request_approval", { id: "ap_m", status: "pending", agentId: "ag_a", decidedAt: null, decisionNote: null, action: "x", scope: "s" }, "ag_a");
+    expect(mine).toMatch(/already pending/);
+  });
+
+  it("denial memory window is configurable", () => {
+    expect(denialMemoryMs()).toBe(7 * 86_400_000);
+    process.env.APPROVAL_DENIAL_MEMORY_DAYS = "30";
+    expect(denialMemoryMs()).toBe(30 * 86_400_000);
+  });
+});
+
+describe("expiry (task b)", () => {
+  it("computes the deadline from created_at + TTL and detects expiry", () => {
+    const created = new Date("2026-07-05T10:00:00Z");
+    expect(approvalExpiresAt(created, 72)?.toISOString()).toBe("2026-07-08T10:00:00.000Z");
+    expect(isApprovalExpired(created, new Date("2026-07-08T09:59:59Z"), 72)).toBe(false);
+    expect(isApprovalExpired(created, new Date("2026-07-08T10:00:00Z"), 72)).toBe(true);
+    expect(isApprovalExpired(created, new Date("2030-01-01"), 0)).toBe(false); // TTL 0 = never
+  });
+  it("the expiry note tells the agent not to re-request and to find another route", () => {
+    const n = expiryNote(72);
+    expect(n).toMatch(/EXPIRED/);
+    expect(n).toMatch(/do NOT re-request/);
+    expect(n).toMatch(/in-platform app preview/);
+    expect(n).toMatch(/in_progress/);
+  });
+});
+
+describe("auto-approval policy (task d)", () => {
+  it("scopeMatches: exact, prefix wildcard, bare star", () => {
+    expect(scopeMatches("deploy", "Deploy")).toBe(true);
+    expect(scopeMatches("tasks.*", "tasks.write")).toBe(true);
+    expect(scopeMatches("tasks.*", "channels.reply")).toBe(false);
+    expect(scopeMatches("risk:*", "risk:medium")).toBe(true);
+    expect(scopeMatches("*", "anything")).toBe(true);
+    expect(scopeMatches("", "x")).toBe(false);
+  });
+
+  it("nothing is auto-approved by default", () => {
+    expect(autoApprovalFor("deploy", "publish preview", [])).toBeNull();
+    expect(autoApprovalFor("tasks.write", "create_task \"x\"", ["channels.reply"])).toBeNull();
+  });
+
+  it("AUTO_APPROVE_SCOPES covers matching scopes for every agent", () => {
+    process.env.AUTO_APPROVE_SCOPES = "tasks.*,external_post";
+    expect(autoApprovalFor("tasks.write", "task_comment on task_1", [])).toEqual({ by: "policy", rule: "tasks.*" });
+    expect(autoApprovalFor("external_post", "post the changelog to the blog", [])).toEqual({ by: "policy", rule: "external_post" });
+    expect(autoApprovalFor("risk:high", "share_files in c_1", [])).toBeNull();
+  });
+
+  it("per-agent trust via approve:<scope> / approve:* scopes", () => {
+    expect(autoApprovalFor("deploy", "ship the preview", ["channels.reply", "approve:deploy"])).toEqual({ by: "agent_scope", rule: "approve:deploy" });
+    expect(autoApprovalFor("anything_else", "do it", ["approve:*"])).toEqual({ by: "agent_scope", rule: "approve:*" });
+    expect(autoApprovalFor("deploy", "ship", ["approve:tasks.*"])).toBeNull();
+  });
+
+  it("credential requests are never auto-approved, whatever the policy says", () => {
+    process.env.AUTO_APPROVE_SCOPES = "*";
+    expect(autoApprovalFor("tavily_api_key", "need a search key", ["approve:*"])).toBeNull();
+    expect(autoApprovalFor("deploy", "please provide the VERCEL_TOKEN", ["approve:*"])).toBeNull();
+    // …but a non-credential ask under the same wildcard is.
+    expect(autoApprovalFor("deploy", "publish to the in-platform preview", [])).toEqual({ by: "policy", rule: "*" });
+  });
+});

--- a/api/src/__tests__/bridge-reply.test.ts
+++ b/api/src/__tests__/bridge-reply.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll } from "vitest";
+
+// The bridge is plain ESM (.mjs) with no type declarations; import it
+// dynamically in import-only mode so it never opens sockets.
+type Bridge = {
+  extractReply: (raw: string) => string;
+  stripRuntimeNoise: (s: string) => string;
+  truncateAtBoundary: (s: string, max: number) => string;
+  leadOf: (s: string, max: number) => string;
+  isEntrypointNoise: (line: string) => boolean;
+  CHAT_BODY_MAX: number;
+};
+let bridge: Bridge;
+beforeAll(async () => {
+  process.env.CC_BRIDGE_IMPORT_ONLY = "1";
+  // @ts-ignore — untyped .mjs module
+  bridge = (await import("../../hermes-multi-bridge.mjs")) as Bridge;
+});
+
+const BANNER = "⚠️  Reached maximum iterations (20). Requesting summary...";
+const TOOL_FAIL =
+  '⚠ Could not execute tool(s): "target": value "files\n@@ARG_END" not in enum ["messages", "tasks", "members"]';
+
+describe("bridge extractReply — runtime noise", () => {
+  it("drops the runaway-iterations banner line and keeps the wrap-up", () => {
+    const out = bridge.extractReply(`${BANNER}\nRelay verified at https://relay.test/live.m3u8 — 3/3 streams up.`);
+    expect(out).not.toMatch(/Reached maximum iterations/);
+    expect(out).toContain("Relay verified");
+  });
+
+  it("drops the multi-line 'Could not execute tool(s)' paragraph", () => {
+    const out = bridge.extractReply(`${TOOL_FAIL}\n\nHere is the file list you asked for: a.md, b.md.`);
+    expect(out).not.toMatch(/Could not execute|@@ARG_END|not in enum/);
+    expect(out).toContain("file list");
+  });
+
+  it("returns empty when the stream is only the banner", () => {
+    expect(bridge.extractReply(BANNER)).toBe("");
+  });
+
+  it("treats banner/parser-debris lines as entrypoint noise", () => {
+    expect(bridge.isEntrypointNoise(BANNER)).toBe(true);
+    expect(bridge.isEntrypointNoise("Requesting summary...")).toBe(true);
+    expect(bridge.isEntrypointNoise('@@ARG_END" not in enum')).toBe(true);
+    expect(bridge.isEntrypointNoise("Verified the relay is live.")).toBe(false);
+  });
+});
+
+describe("bridge truncateAtBoundary", () => {
+  it("returns short text unchanged", () => {
+    expect(bridge.truncateAtBoundary("short", 100)).toBe("short");
+  });
+
+  it("cuts at a paragraph break when one sits past half the budget", () => {
+    const p1 = "First paragraph. ".repeat(10).trim();
+    const p2 = "Second paragraph. ".repeat(10).trim();
+    const text = `${p1}\n\n${p2}`;
+    const out = bridge.truncateAtBoundary(text, p1.length + 40);
+    expect(out).toBe(p1);
+  });
+
+  it("cuts at a sentence end, never mid-word, when there is no paragraph break", () => {
+    const text = "Alpha is done. Beta is next in the queue. Gamma still failing on the manifest path check.";
+    const out = bridge.truncateAtBoundary(text, 60);
+    expect(out).toBe("Alpha is done. Beta is next in the queue.");
+    expect(out.length).toBeLessThanOrEqual(60);
+  });
+
+  it("never exceeds the cap", () => {
+    const text = "x".repeat(5000);
+    expect(bridge.truncateAtBoundary(text, 2000).length).toBeLessThanOrEqual(2000);
+  });
+
+  it("no longer hard-slices the fallback reply at 2000 chars", () => {
+    const sentence = "The relay is verified live and the manifest resolves. ";
+    const long = sentence.repeat(60); // ~3300 chars
+    const out = bridge.extractReply(long);
+    expect(out.length).toBeGreaterThan(2000);
+    expect(out.endsWith(".")).toBe(true);
+  });
+});
+
+describe("bridge leadOf", () => {
+  it("takes the first paragraph, capped at a boundary", () => {
+    const out = bridge.leadOf("Backend is live on port 3000. Health returns 200.\n\nDetails: lots more.", 400);
+    expect(out).toBe("Backend is live on port 3000. Health returns 200.");
+  });
+});

--- a/api/src/__tests__/completion.test.ts
+++ b/api/src/__tests__/completion.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveJudgeTarget,
+  resolvePlannerTarget,
+  plannerUsesEmbeddingsFallback,
+  extractJson,
+} from "../lib/completion.js";
+
+// The live fishbowl had ONLY EMBEDDINGS_BASE_URL/EMBEDDINGS_MODEL set. The old
+// resolver silently pointed the judge at that URL with model=auto and logged
+// an "outage" on every flip. The judge must now require an explicit chat URL.
+const embeddingsOnly = {
+  EMBEDDINGS_BASE_URL: "https://freellm.example/v1/",
+  EMBEDDINGS_MODEL: "gemini-embedding-001",
+  EMBEDDINGS_API_KEY: "ek",
+};
+
+describe("resolveJudgeTarget", () => {
+  it("is NOT configured when only an embeddings endpoint exists", () => {
+    expect(resolveJudgeTarget(embeddingsOnly)).toBeNull();
+  });
+
+  it("uses PLANNER_BASE_URL / PLANNER_MODEL when set", () => {
+    const t = resolveJudgeTarget({ ...embeddingsOnly, PLANNER_BASE_URL: "http://gw/v1/", PLANNER_MODEL: "gemini-2.5-pro" });
+    expect(t).toEqual({ baseUrl: "http://gw/v1", apiKey: "ek", model: "gemini-2.5-pro" });
+  });
+
+  it("prefers VERIFY_JUDGE_* over PLANNER_*", () => {
+    const t = resolveJudgeTarget({
+      PLANNER_BASE_URL: "http://planner/v1",
+      PLANNER_MODEL: "auto",
+      PLANNER_API_KEY: "pk",
+      VERIFY_JUDGE_BASE_URL: "http://judge/v1",
+      VERIFY_JUDGE_MODEL: "gpt-x",
+      VERIFY_JUDGE_API_KEY: "jk",
+    });
+    expect(t).toEqual({ baseUrl: "http://judge/v1", apiKey: "jk", model: "gpt-x" });
+  });
+
+  it("defaults the model to auto", () => {
+    expect(resolveJudgeTarget({ PLANNER_BASE_URL: "http://gw/v1" })?.model).toBe("auto");
+  });
+});
+
+describe("resolvePlannerTarget", () => {
+  it("keeps the legacy embeddings fallback but flags it", () => {
+    const t = resolvePlannerTarget(embeddingsOnly);
+    expect(t?.baseUrl).toBe("https://freellm.example/v1");
+    expect(plannerUsesEmbeddingsFallback(embeddingsOnly)).toBe(true);
+    expect(plannerUsesEmbeddingsFallback({ ...embeddingsOnly, PLANNER_BASE_URL: "http://gw/v1" })).toBe(false);
+  });
+
+  it("is null with nothing configured", () => {
+    expect(resolvePlannerTarget({})).toBeNull();
+  });
+});
+
+describe("extractJson", () => {
+  it("returns the last parseable candidate after reasoning prose", () => {
+    const text = 'Thinking about {"verdict":"fail"} as an example… final answer:\n{"verdict":"pass","score":0.9}';
+    expect(extractJson<{ verdict: string }>(text)?.verdict).toBe("pass");
+  });
+  it("prefers a fenced block", () => {
+    expect(extractJson('```json\n{"a":1}\n``` trailing {"a":2}')).toEqual({ a: 1 });
+  });
+  it("returns null for null/no JSON", () => {
+    expect(extractJson(null)).toBeNull();
+    expect(extractJson("no json here")).toBeNull();
+  });
+});

--- a/api/src/__tests__/internal-request.test.ts
+++ b/api/src/__tests__/internal-request.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { isInternalRequest, isPrivateAddress } from "../lib/internal-request.js";
+
+const SECRET = "test-secret";
+const req = (headers: Record<string, string>, peer?: string) => ({
+  headers,
+  raw: { socket: { remoteAddress: peer } },
+});
+
+describe("isPrivateAddress", () => {
+  it("accepts loopback and RFC1918 / link-local ranges, including v4-mapped v6", () => {
+    for (const ip of ["127.0.0.1", "::1", "::ffff:127.0.0.1", "10.0.0.7", "172.18.0.5", "192.168.1.17", "169.254.1.1", "fd12:3456::1", "fe80::1"]) {
+      expect(isPrivateAddress(ip), ip).toBe(true);
+    }
+  });
+  it("rejects public addresses and blanks", () => {
+    for (const ip of ["8.8.8.8", "172.32.0.1", "62.238.2.66", "2a00:1450::1", "", undefined]) {
+      expect(isPrivateAddress(ip), String(ip)).toBe(false);
+    }
+  });
+});
+
+describe("isInternalRequest", () => {
+  it("accepts a direct request from a private peer with no proxy headers", () => {
+    expect(isInternalRequest(req({}, "172.18.0.4"), SECRET)).toBe(true);
+  });
+  it("rejects anything that arrived through the reverse proxy, even from a private peer", () => {
+    expect(isInternalRequest(req({ "x-forwarded-for": "203.0.113.9" }, "172.18.0.2"), SECRET)).toBe(false);
+    expect(isInternalRequest(req({ "x-real-ip": "10.0.0.1" }, "172.18.0.2"), SECRET)).toBe(false);
+  });
+  it("rejects a public peer hitting the port directly", () => {
+    expect(isInternalRequest(req({}, "203.0.113.9"), SECRET)).toBe(false);
+    expect(isInternalRequest(req({}, undefined), SECRET)).toBe(false);
+  });
+  it("accepts the shared internal token regardless of network position", () => {
+    expect(isInternalRequest(req({ "x-internal-token": SECRET, "x-forwarded-for": "203.0.113.9" }, "203.0.113.9"), SECRET)).toBe(true);
+    expect(isInternalRequest(req({ "x-internal-token": "wrong" }, "203.0.113.9"), SECRET)).toBe(false);
+    expect(isInternalRequest(req({ "x-internal-token": "" }, "203.0.113.9"), "")).toBe(false);
+  });
+});

--- a/api/src/__tests__/model-routing.test.ts
+++ b/api/src/__tests__/model-routing.test.ts
@@ -45,4 +45,30 @@ describe("model routing", () => {
       cachedInputTokens: 0,
     });
   });
+
+  it("accepts OpenAI / Anthropic / camelCase usage key spellings", () => {
+    expect(normalizeUsage({ prompt_tokens: 120, completion_tokens: 30 })).toMatchObject({ inputTokens: 120, outputTokens: 30 });
+    expect(normalizeUsage({ input_tokens: 120, output_tokens: 30, cache_read_input_tokens: 20 })).toMatchObject({
+      inputTokens: 120,
+      outputTokens: 30,
+      cachedInputTokens: 20,
+    });
+    expect(normalizeUsage({ promptTokens: 5, completionTokens: 7, cost_usd: 0.01 })).toMatchObject({
+      inputTokens: 5,
+      outputTokens: 7,
+      costUsd: 0.01,
+    });
+  });
+
+  it("derives output from total when only total + input are reported", () => {
+    expect(normalizeUsage({ prompt_tokens: 100, total_tokens: 140 })).toMatchObject({ inputTokens: 100, outputTokens: 40 });
+  });
+
+  it("canonical keys win over aliases and still clamp/floor", () => {
+    expect(normalizeUsage({ inputTokens: 10.9, outputTokens: -3, prompt_tokens: 999, cachedInputTokens: 50 })).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 0,
+      cachedInputTokens: 10,
+    });
+  });
 });

--- a/api/src/__tests__/project-files.test.ts
+++ b/api/src/__tests__/project-files.test.ts
@@ -356,3 +356,138 @@ describe("writeProjectFile + loadProjectIndex (temp mount)", () => {
     expect(index[0].files.map((f) => f.name)).not.toContain("INDEX.md");
   });
 });
+
+// ── append dedupe + rolling compaction + tail-first injection ──
+import { splitEntries, compactEntries, excerptForInjection, KEEP_ENTRIES, COMPACT_AT_CHARS } from "../lib/project-files.js";
+
+function buildLog(n: number, noteFor: (i: number) => string, head = ""): string {
+  let cur: string | null = head ? serializeProjectFile({ summary: "", owner: "rachel", updatedBy: "rachel", triggers: [], always: false }, head) : null;
+  for (let i = 0; i < n; i++) {
+    const r = applyProjectWrite(cur, { mode: "append", note: noteFor(i), actorHandle: i % 2 ? "iris" : "nova", dateLabel: `2026-09-0${(i % 9) + 1} 10:${String(i % 60).padStart(2, "0")}` });
+    if (!("content" in r)) throw new Error(`append ${i} failed: ${(r as { error: string }).error}`);
+    cur = r.content;
+  }
+  return cur as string;
+}
+
+describe("splitEntries", () => {
+  it("separates a free-form head from dated provenance entries", () => {
+    const body = "Brief: showcase site.\n\n## 2026-09-01 10:00 · @nova\nRelay live.\n\n## 2026-09-02 11:00 · @iris\nHashes recomputed.";
+    const { head, entries } = splitEntries(body);
+    expect(head).toBe("Brief: showcase site.");
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toContain("Hashes recomputed.");
+  });
+  it("treats a body without provenance headers as head only", () => {
+    expect(splitEntries("## Goals\nShip it.").entries).toHaveLength(0);
+  });
+});
+
+describe("applyProjectWrite — append dedupe", () => {
+  it("refuses a near-duplicate of a recent entry, even from another agent", () => {
+    const first = applyProjectWrite(null, {
+      mode: "append",
+      note: "Self-hosted HLS relay verified live — all three streams resolve and the manifest is cached at the edge.",
+      actorHandle: "nova",
+      dateLabel: "2026-09-04 09:00",
+    });
+    if (!("content" in first)) throw new Error("expected content");
+    const dup = applyProjectWrite(first.content, {
+      mode: "append",
+      note: "**Self-hosted HLS relay verified live** — all three streams resolve and the manifest is cached at the edge (cc @iris).",
+      actorHandle: "iris",
+      dateLabel: "2026-09-04 11:30",
+    });
+    expect("error" in dup).toBe(true);
+    if ("error" in dup) expect(dup.error).toMatch(/near-duplicate.*@nova/);
+  });
+
+  it("accepts a genuinely new fact", () => {
+    const first = applyProjectWrite(null, {
+      mode: "append",
+      note: "Self-hosted HLS relay verified live — all three streams resolve and the manifest is cached at the edge.",
+      actorHandle: "nova",
+      dateLabel: "d1",
+    });
+    if (!("content" in first)) throw new Error("expected content");
+    const next = applyProjectWrite(first.content, {
+      mode: "append",
+      note: "Decision: drop the CDN fallback; the relay alone meets the latency budget (p95 1.8s).",
+      actorHandle: "iris",
+      dateLabel: "d2",
+    });
+    expect("content" in next).toBe(true);
+  });
+
+  it("caps a single appended entry at half the file limit", () => {
+    const r = applyProjectWrite(null, { mode: "append", note: "y".repeat(PROJECT_FILE_MAX_CHARS / 2 + 1), actorHandle: "nova", dateLabel: "d" });
+    expect("error" in r).toBe(true);
+  });
+});
+
+describe("rolling compaction", () => {
+  it("keeps at most KEEP_ENTRIES entries and reports the archived ones", () => {
+    const content = buildLog(KEEP_ENTRIES + 5, (i) => `Distinct milestone number ${i}: ${["alpha", "beta", "gamma", "delta", "epsilon"][i % 5]} stage ${i * 7} reached with ${i * 3} checks passing.`);
+    const { entries } = splitEntries(parseProjectFile(content).body);
+    expect(entries.length).toBe(KEEP_ENTRIES);
+    // newest survives, oldest is gone
+    expect(content).toContain(`Distinct milestone number ${KEEP_ENTRIES + 4}:`);
+    expect(content).not.toContain("Distinct milestone number 0:");
+  });
+
+  it("compacts by size when entries are long, never below the minimum", () => {
+    const head = "Brief: keep me.";
+    const long = (i: number) => `Entry ${i} ` + `unique-${i}-word `.repeat(30); // ~450 chars each
+    const entries = Array.from({ length: 20 }, (_, i) => `## d${i} · @nova\n${long(i)}`);
+    const { body, archived } = compactEntries(head, entries);
+    expect(body.length).toBeLessThanOrEqual(COMPACT_AT_CHARS);
+    expect(archived.length).toBeGreaterThan(0);
+    expect(archived.length + splitEntries(body).entries.length).toBe(20);
+    // Never below the minimum even when entries are huge.
+    const huge = Array.from({ length: 12 }, (_, i) => `## d${i} · @nova\nEntry ${i} ` + "w ".repeat(1500));
+    expect(splitEntries(compactEntries("", huge).body).entries.length).toBe(8);
+    expect(body.startsWith(head)).toBe(true);
+    expect(body).toContain("Entry 19 ");
+  });
+
+  it("writes archived entries to <project>/archive/<file> on disk and keeps them out of the index", async () => {
+    const mount = join(tmpdir(), `cc-proj-archive-${process.pid}-${Date.now()}`);
+    process.env.CC_WORKSPACE_MOUNT = mount;
+    try {
+      for (let i = 0; i < KEEP_ENTRIES + 2; i++) {
+        const r = await writeProjectFile({
+          project: "arch-test",
+          file: "status.md",
+          note: `Milestone ${i}: ${["alpha", "beta", "gamma"][i % 3]} stage ${i * 11} done, ${i + 2} checks green.`,
+          actorHandle: "nova",
+        });
+        expect("ok" in r).toBe(true);
+      }
+      const arch = await fsp.readFile(join(mount, "projects", "arch-test", "archive", "status.md"), "utf8");
+      expect(arch).toContain("Milestone 0:");
+      const live = await fsp.readFile(join(mount, "projects", "arch-test", "status.md"), "utf8");
+      expect(live).not.toContain("Milestone 0:");
+      const idx = await loadProjectIndex();
+      expect(idx.find((p) => p.slug === "arch-test")?.files.map((f) => f.name)).toEqual(["status.md"]);
+    } finally {
+      delete process.env.CC_WORKSPACE_MOUNT;
+      await fsp.rm(mount, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("excerptForInjection", () => {
+  it("injects the NEWEST entries (plus head) when a log exceeds the cap", () => {
+    const body = ["Brief: showcase site.", ...Array.from({ length: 40 }, (_, i) => `## 2026-09-01 10:${String(i).padStart(2, "0")} · @nova\nEntry ${i} ` + "filler ".repeat(20))].join("\n\n");
+    const out = excerptForInjection(body, 1600);
+    expect(out.length).toBeLessThanOrEqual(1600);
+    expect(out.startsWith("Brief: showcase site.")).toBe(true);
+    expect(out).toContain("Entry 39 ");
+    expect(out).not.toContain("Entry 0 ");
+    expect(out).toMatch(/older entries omitted/);
+  });
+  it("returns a short body untouched and head-slices a plain document", () => {
+    expect(excerptForInjection("short body", 100)).toBe("short body");
+    expect(excerptForInjection("a".repeat(300), 100)).toBe("a".repeat(100));
+  });
+});

--- a/api/src/__tests__/reply-guard.test.ts
+++ b/api/src/__tests__/reply-guard.test.ts
@@ -225,3 +225,96 @@ describe("checkReplyBody — provider/gateway error echoes on the reply path", (
     expect(guardRejectHint("provider_error_echo")).toContain("HEARTBEAT_OK");
   });
 });
+
+describe("checkReplyBody — Hermes runtime scaffolding leaks (live.circlechat.co, Sep 2026)", () => {
+  const BANNER = "⚠️  Reached maximum iterations (20). Requesting summary...";
+  const TOOL_FAIL =
+    '⚠ Could not execute tool(s): "target": value "files\n@@ARG_END" not in enum ["messages", "tasks", "members"]';
+
+  it("strips the runaway banner + lead-in and keeps the substantive remainder", () => {
+    const r = checkReplyBody(
+      `${BANNER}\nHere's what I found and did this turn:\nThe HLS relay is live at https://relay.test/live.m3u8 and all three streams resolve.`,
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.bodyMd).not.toMatch(/Reached maximum iterations|Requesting summary|Here's what I found/);
+      expect(r.bodyMd).toContain("HLS relay is live");
+    }
+  });
+
+  it("rejects when the banner is all there is", () => {
+    const r = checkReplyBody(BANNER);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("runaway_banner");
+  });
+
+  it("strips a tool-dispatch failure paragraph (with @@ARG_END debris) and keeps the rest", () => {
+    const r = checkReplyBody(`${TOOL_FAIL}\n\nPulled the task list — two cards are in review, none blocked.`);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.bodyMd).not.toMatch(/Could not execute|@@ARG_END|not in enum/);
+      expect(r.bodyMd).toContain("two cards are in review");
+    }
+  });
+
+  it("rejects a body that is only the tool failure notice", () => {
+    const r = checkReplyBody(TOOL_FAIL);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("tool_exec_failure");
+  });
+
+  it("rejects stray @@ARG parser debris in otherwise-prose", () => {
+    const r = checkReplyBody("Sharing the report now. target=files\n@@ARG_END and the rest of the summary follows here.");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("tool_parse_debris");
+  });
+
+  it("rejects the model talking to the prompt scaffolding", () => {
+    const r = checkReplyBody(
+      "I've read the attached conversation history file in full. However, I don't see a section titled \"CURRENT REQUEST (full text)\" so I cannot determine what you want me to do.",
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("scaffold_talk");
+  });
+
+  it("strips a ritual sign-off with a SHA footer", () => {
+    const r = checkReplyBody(
+      "Relay verified live — 3/3 streams resolve, manifest cached.\n\n*Signed,* **@iris** — Researcher & Writer, Circle Labs — *Artifact SHA-256 (compute with `sha256sum`)*",
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.bodyMd).toBe("Relay verified live — 3/3 streams resolve, manifest cached.");
+  });
+
+  it("strips a 'Best regards, Name' closer and a trailing '— @handle — Title' line", () => {
+    const r = checkReplyBody("Draft is on the card.\n\nBest regards,\nIris\n— @iris — Researcher");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.bodyMd).toBe("Draft is on the card.");
+    const r2 = checkReplyBody("Draft is on the card.\n**@iris** — Researcher & Writer");
+    expect(r2.ok).toBe(true);
+    if (r2.ok) expect(r2.bodyMd).toBe("Draft is on the card.");
+  });
+
+  it("rejects a reply that is only a signature", () => {
+    const r = checkReplyBody("*Signed,* **@iris** — Researcher & Writer, Circle Labs");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("signoff_only");
+  });
+
+  it("does not strip legitimate prose that uses closer words mid-sentence or a lone @mention", () => {
+    const a = checkReplyBody("The contract was signed yesterday, so we can start the build.");
+    expect(a.ok).toBe(true);
+    if (a.ok) expect(a.bodyMd).toContain("signed yesterday");
+    const b = checkReplyBody("@bob — can you take the relay check?");
+    expect(b.ok).toBe(true);
+    if (b.ok) expect(b.bodyMd).toBe("@bob — can you take the relay check?");
+    const c = checkReplyBody("Cheers to the team for shipping the relay — three streams live now.");
+    expect(c.ok).toBe(true);
+    if (c.ok) expect(c.bodyMd).toContain("Cheers to the team");
+  });
+
+  it("has teaching hints for the new reasons", () => {
+    for (const reason of ["runaway_banner", "tool_exec_failure", "tool_parse_debris", "scaffold_talk", "signoff_only"]) {
+      expect(guardRejectHint(reason).length).toBeGreaterThan(20);
+    }
+  });
+});

--- a/api/src/__tests__/run-outcome.test.ts
+++ b/api/src/__tests__/run-outcome.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { classifyRunOutcome, heartbeatBackoffMs, RUNAWAY_BANNER_RE } from "../lib/run-outcome.js";
+
+// On the fishbowl every one of 1,466 runs/week was status=ok, error_text=null,
+// while the bridge logged "skip (empty/crashed reply)" and agents posted
+// "⚠️ Reached maximum iterations (20)". These classify those outcomes.
+
+const post = (body_md: string) => ({ type: "post_message", conversation_id: "c_1", body_md });
+
+describe("classifyRunOutcome", () => {
+  it("HEARTBEAT_OK is an idle ok run, not productive", () => {
+    const c = classifyRunOutcome("HEARTBEAT_OK", { actionsApplied: 0, errors: [] });
+    expect(c.status).toBe("ok");
+    expect(c.productive).toBe(false);
+  });
+
+  it("applied actions → productive ok", () => {
+    const c = classifyRunOutcome({ actions: [post("hello")] }, { actionsApplied: 1, errors: [] });
+    expect(c).toEqual({ status: "ok", productive: true, errorText: null });
+  });
+
+  it("an explicit runtime error (e.g. empty_reply from the bridge) fails the run", () => {
+    const c = classifyRunOutcome({ actions: [], error: "empty_reply" }, { actionsApplied: 0, errors: [] });
+    expect(c.status).toBe("failed");
+    expect(c.errorText).toBe("empty_reply");
+  });
+
+  it("the bridge's catch-all error trace fails the run even though it posted a banner", () => {
+    const c = classifyRunOutcome(
+      {
+        actions: [post("⚠️ Ben error: `spawn hermes ENOENT`")],
+        trace: ["ben error: spawn hermes ENOENT"],
+      },
+      { actionsApplied: 1, errors: [] },
+    );
+    expect(c.status).toBe("failed");
+    expect(c.errorText).toBe("bridge_error: spawn hermes ENOENT");
+  });
+
+  it("a runaway max-iterations banner fails the run", () => {
+    expect(RUNAWAY_BANNER_RE.test("⚠️ Reached maximum iterations (20)")).toBe(true);
+    const c = classifyRunOutcome(
+      { actions: [post("Progress so far…\n\n⚠️ Reached maximum iterations (20)")] },
+      { actionsApplied: 1, errors: [] },
+    );
+    expect(c.status).toBe("failed");
+    expect(c.errorText).toBe("runaway_max_iterations");
+  });
+
+  it("every action rejected → failed with the first rejection reason", () => {
+    const c = classifyRunOutcome(
+      { actions: [post("x"), post("y")] },
+      { actionsApplied: 0, errors: ["post_message rejected: cot_leak. hint", "post_message rejected: duplicate_of_recent"] },
+    );
+    expect(c.status).toBe("failed");
+    expect(c.errorText).toBe("all_actions_rejected: post_message rejected: cot_leak. hint");
+  });
+
+  it("some rejected but some applied is still ok (errors stay in result_json)", () => {
+    const c = classifyRunOutcome(
+      { actions: [post("x"), post("y")] },
+      { actionsApplied: 1, errors: ["post_message rejected: duplicate_of_recent"] },
+    );
+    expect(c.status).toBe("ok");
+    expect(c.productive).toBe(true);
+  });
+
+  it("no actions at all (bridge returned an empty list) is idle, not failed", () => {
+    const c = classifyRunOutcome({ actions: [] }, { actionsApplied: 0, errors: [] });
+    expect(c.status).toBe("ok");
+    expect(c.productive).toBe(false);
+  });
+});
+
+describe("heartbeatBackoffMs", () => {
+  const base = 60 * 60 * 1000; // hourly heartbeat
+  const cap = 6 * 60 * 60 * 1000;
+
+  it("does not back off on the first quiet beat", () => {
+    expect(heartbeatBackoffMs(0, base, cap)).toBe(0);
+    expect(heartbeatBackoffMs(1, base, cap)).toBe(0);
+  });
+
+  it("doubles from the second consecutive non-productive run", () => {
+    expect(heartbeatBackoffMs(2, base, cap)).toBe(2 * base);
+    expect(heartbeatBackoffMs(3, base, cap)).toBe(4 * base);
+  });
+
+  it("caps", () => {
+    expect(heartbeatBackoffMs(4, base, cap)).toBe(cap);
+    expect(heartbeatBackoffMs(50, base, cap)).toBe(cap);
+  });
+
+  it("a cap below the base interval clamps to the base, never below it", () => {
+    expect(heartbeatBackoffMs(2, 5_000, 1_000)).toBe(5_000);
+  });
+});

--- a/api/src/__tests__/stuck-detector.test.ts
+++ b/api/src/__tests__/stuck-detector.test.ts
@@ -26,6 +26,22 @@ describe("normalizeRunSignature", () => {
   });
 });
 
+describe("failed-run accounting feeds the detector", () => {
+  it("three runaway runs in a row (error_text as the only signal) are a repeat loop", () => {
+    // Worker passes agent_runs.error_text as an error line for failed runs; before
+    // failures were recorded, these were three status=ok runs with null signatures.
+    const sig = normalizeRunSignature([], ["runaway_max_iterations"]);
+    expect(sig).toBe("runaway_max_iterations");
+    const r = detectStuck([sig, sig, sig]);
+    expect(r.stuck).toBe(true);
+  });
+  it("all_actions_rejected with different ids still matches", () => {
+    const a = normalizeRunSignature([], ["all_actions_rejected: post_message rejected: duplicate_of_recent vs m_abc"]);
+    const b = normalizeRunSignature([], ["all_actions_rejected: post_message rejected: duplicate_of_recent vs m_xyz"]);
+    expect(a).toBe(b);
+  });
+});
+
 describe("detectStuck", () => {
   const S = (s: string) => s; // readability
 

--- a/api/src/__tests__/text-similarity.test.ts
+++ b/api/src/__tests__/text-similarity.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { findNearDuplicate, normalizeText, textSimilarity } from "../lib/text-similarity.js";
+
+// Pure core behind the cross-message dedupe (agents/dedupe.ts) and the
+// project-tracker append dedupe (lib/project-files.ts). Cases are the real
+// repeats seen on live.circlechat.co.
+
+describe("normalizeText", () => {
+  it("drops URLs, @mentions, punctuation and case", () => {
+    expect(normalizeText("Ping @nova — see https://x.test/a, OK?")).toBe("ping see ok");
+  });
+});
+
+describe("findNearDuplicate", () => {
+  const backend = "Backend is live and verified — `node server.js` on port 3000, health endpoint returns 200.";
+
+  it("flags the same body reposted verbatim by another agent", () => {
+    const hit = findNearDuplicate(backend, [{ id: "tc_2", bodyMd: "unrelated comment about the landing page copy" }, { id: "tc_1", bodyMd: backend }]);
+    expect(hit?.candidate.id).toBe("tc_1");
+    expect(hit?.score).toBe(1);
+  });
+
+  it("flags a near-identical restatement (different mention/punctuation)", () => {
+    const hit = findNearDuplicate(
+      "Backend is live and verified: node server.js on port 3000; health endpoint returns 200 @iris",
+      [{ id: "tc_1", bodyMd: backend }],
+    );
+    expect(hit).not.toBeNull();
+  });
+
+  it("flags 'Proof package vNN shipped' repeats regardless of the version number token", () => {
+    const a = "Proof package v28 shipped: hashes recomputed, HLS relay re-verified live, status.md updated with the new checksums.";
+    const b = "Proof package v30 shipped: hashes recomputed, HLS relay re-verified live, status.md updated with the new checksums.";
+    expect(textSimilarity(a, b)).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it("does not flag genuinely different progress", () => {
+    const hit = findNearDuplicate(
+      "Switched the relay to the new origin and re-ran the smoke test — three of five streams still 404, digging into the manifest paths.",
+      [{ id: "tc_1", bodyMd: backend }],
+    );
+    expect(hit).toBeNull();
+  });
+
+  it("skips short bodies on either side (acks repeat naturally)", () => {
+    expect(findNearDuplicate("ok thanks", [{ id: "m1", bodyMd: "ok thanks" }])).toBeNull();
+    expect(findNearDuplicate(backend, [{ id: "m1", bodyMd: "on it" }])).toBeNull();
+  });
+
+  it("returns the FIRST match in the given order (callers pass newest first)", () => {
+    const hit = findNearDuplicate(backend, [{ id: "new", bodyMd: backend }, { id: "old", bodyMd: backend }]);
+    expect(hit?.candidate.id).toBe("new");
+  });
+});

--- a/api/src/__tests__/verifier-gate.test.ts
+++ b/api/src/__tests__/verifier-gate.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { classifyRenderForGate } from "../lib/task-verifier.js";
+import {
+  classifyRenderForGate,
+  resolveFailMode,
+  decideOnJudgeOutage,
+  shouldReuseVerdict,
+} from "../lib/task-verifier.js";
 import type { RenderObservation } from "../lib/deliverable-render.js";
 
 // The deterministic (fail-CLOSED) tier of the verification gate. It must block
@@ -44,5 +49,48 @@ describe("classifyRenderForGate", () => {
       expect(d.reason).toContain("2 load/JS error");
       expect(d.reason).toContain("net::ERR_FILE_NOT_FOUND");
     }
+  });
+});
+
+// What a judge OUTAGE does to the done-flip is an operator choice. The default
+// must stay fail-open (a gateway hiccup never freezes the board), `closed`
+// blocks, `hold` blocks and asks the caller to leave one comment.
+describe("VERIFY_FAIL_MODE", () => {
+  it("defaults to open on unset/garbage", () => {
+    expect(resolveFailMode(undefined)).toBe("open");
+    expect(resolveFailMode("")).toBe("open");
+    expect(resolveFailMode("banana")).toBe("open");
+  });
+  it("parses closed/hold case-insensitively", () => {
+    expect(resolveFailMode("CLOSED")).toBe("closed");
+    expect(resolveFailMode(" hold ")).toBe("hold");
+  });
+  it("open allows, closed blocks silently, hold blocks and comments", () => {
+    expect(decideOnJudgeOutage("open")).toEqual({ block: false, comment: false });
+    expect(decideOnJudgeOutage("closed")).toEqual({ block: true, comment: false });
+    expect(decideOnJudgeOutage("hold")).toEqual({ block: true, comment: true });
+  });
+});
+
+// Re-judging the SAME artifact on every retried flip is what hammered the
+// gateway into "unreachable". Reuse a fresh real verdict; never reuse an outage.
+describe("shouldReuseVerdict", () => {
+  const now = 1_000_000_000;
+  const row = (over: Partial<{ artifactId: string | null; verdict: string; createdAt: Date }>) => ({
+    artifactId: "art_1",
+    verdict: "fail",
+    createdAt: new Date(now - 60_000),
+    ...over,
+  });
+  it("reuses a recent pass/fail on the same artifact", () => {
+    expect(shouldReuseVerdict(row({ verdict: "fail" }), "art_1", now, 600_000)).toBe(true);
+    expect(shouldReuseVerdict(row({ verdict: "pass" }), "art_1", now, 600_000)).toBe(true);
+  });
+  it("does not reuse for a different artifact, an error row, or a stale row", () => {
+    expect(shouldReuseVerdict(row({}), "art_2", now, 600_000)).toBe(false);
+    expect(shouldReuseVerdict(row({ verdict: "error" }), "art_1", now, 600_000)).toBe(false);
+    expect(shouldReuseVerdict(row({ createdAt: new Date(now - 601_000) }), "art_1", now, 600_000)).toBe(false);
+    expect(shouldReuseVerdict(null, "art_1", now, 600_000)).toBe(false);
+    expect(shouldReuseVerdict(row({ artifactId: null }), "art_1", now, 600_000)).toBe(false);
   });
 });

--- a/api/src/agents/adapters/dispatch.ts
+++ b/api/src/agents/adapters/dispatch.ts
@@ -10,6 +10,10 @@ export interface AgentCallResponse {
   actions: unknown[];
   trace?: string[];
   usage?: ReportedModelUsage;
+  // Explicit failure reason from the runtime/bridge (e.g. "empty_reply",
+  // "runaway_max_iterations"). The worker records it as a FAILED run instead
+  // of a silent ok; actions (if any) are still applied.
+  error?: string;
 }
 
 export async function callAgent(

--- a/api/src/agents/adapters/hermes.ts
+++ b/api/src/agents/adapters/hermes.ts
@@ -11,7 +11,7 @@ export async function callHermesSocket(params: {
   const url = `${config.apiInternalUrl.replace(/\/$/, "")}/_internal/agent-dispatch`;
   const res = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", "x-internal-token": config.sessionSecret },
     body: JSON.stringify({ agentId: params.agentId, kind: params.kind, packet: params.packet }),
   });
   if (res.status === 404) throw new Error("agent_not_connected");
@@ -20,7 +20,13 @@ export async function callHermesSocket(params: {
     reply: AgentCallResponse & { status?: string } | undefined;
   };
   if (!reply) return { actions: [] };
-  if (reply.status === "HEARTBEAT_OK") return "HEARTBEAT_OK";
-  if (Array.isArray(reply.actions)) return { actions: reply.actions, trace: reply.trace, usage: reply.usage };
-  return { actions: [] };
+  const error = typeof reply.error === "string" && reply.error ? reply.error.slice(0, 200) : undefined;
+  // A bridge that skipped because the runtime produced nothing may say so via
+  // `error` (e.g. {status:"HEARTBEAT_OK", error:"empty_reply"}); surface it
+  // rather than folding it into a healthy idle beat.
+  if (reply.status === "HEARTBEAT_OK") return error ? { actions: [], error } : "HEARTBEAT_OK";
+  if (Array.isArray(reply.actions)) {
+    return { actions: reply.actions, trace: reply.trace, usage: reply.usage, ...(error ? { error } : {}) };
+  }
+  return error ? { actions: [], error } : { actions: [] };
 }

--- a/api/src/agents/ambient.ts
+++ b/api/src/agents/ambient.ts
@@ -8,6 +8,7 @@ import {
   messages,
 } from "../db/schema.js";
 import { enqueueAgentEvent } from "./enqueue.js";
+import { heartbeatBackoffRemainingMs } from "./scheduler.js";
 
 // Background "water-cooler" loop: picks one random active agent + one of
 // their channels every MIN..MAX minutes and enqueues an `ambient` trigger.
@@ -27,6 +28,11 @@ const PER_AGENT_COOLDOWN_MS = Number(process.env.AMBIENT_AGENT_COOLDOWN_MS ?? 15
 // last CHANNEL_QUIET_MS window — active humans don't want ambient noise
 // piled on top.
 const CHANNEL_QUIET_MS = Number(process.env.AMBIENT_CHANNEL_QUIET_MS ?? 6 * 60 * 1000);
+// A water-cooler needs people at it. Only fire into a channel where a HUMAN
+// has posted within this window — otherwise agents chat to each other in a
+// room nobody reads (505 ambient runs/week on the fishbowl, every one of them
+// an LLM call producing filler nobody asked for). 0 disables the check.
+const HUMAN_ACTIVE_MS = Number(process.env.AMBIENT_HUMAN_ACTIVE_MS ?? 24 * 60 * 60 * 1000);
 
 const lastFiredByAgent = new Map<string, number>();
 let timer: NodeJS.Timeout | null = null;
@@ -110,6 +116,21 @@ async function tick(): Promise<void> {
   // channel next cycle.
   const lastTs = picked.lastTs instanceof Date ? picked.lastTs.getTime() : 0;
   if (lastTs && now - lastTs < CHANNEL_QUIET_MS) return;
+
+  // No human has spoken here recently → nobody to be ambient FOR. Skip.
+  if (HUMAN_ACTIVE_MS > 0) {
+    const [h] = await db
+      .select({ ts: dsql<Date | null>`max(${messages.ts})` })
+      .from(messages)
+      .innerJoin(members, eq(members.id, messages.memberId))
+      .where(and(eq(messages.conversationId, picked.id), eq(members.kind, "user")));
+    const lastHuman = h?.ts instanceof Date ? h.ts.getTime() : h?.ts ? new Date(h.ts as unknown as string).getTime() : 0;
+    if (!lastHuman || now - lastHuman > HUMAN_ACTIVE_MS) return;
+  }
+
+  // An agent whose heartbeats keep coming back empty/failed is backing off —
+  // don't hand it an ambient turn to burn instead.
+  if ((await heartbeatBackoffRemainingMs(chosen.agentId)) > 0) return;
 
   lastFiredByAgent.set(chosen.agentId, now);
   await enqueueAgentEvent(chosen.agentId, {

--- a/api/src/agents/context.ts
+++ b/api/src/agents/context.ts
@@ -24,6 +24,7 @@ import { ensureAndLoadBlocks } from "../lib/memory-blocks.js";
 import { loadTaskSummary, maybeSummarizeTaskThread } from "../lib/task-condenser.js";
 import { latestVerdictSummary } from "../lib/task-verifier.js";
 import { buildProjectContext } from "../lib/project-files.js";
+import { approvalExpiresAt } from "../lib/approval-policy.js";
 
 export interface MemberInfo {
   memberId: string;
@@ -142,6 +143,10 @@ export interface ContextPacket {
   // reaped after a worker death). Continuity: without this the agent has
   // amnesia about its own dead run and silently drops whatever it was doing.
   previousRunFailure?: { errorText: string; finishedAt: string | null } | null;
+  // Server-side refusals recorded on the agent's previous (ok) run — dedupe
+  // drops, approval dedupe, denied-is-final, guard rejections. Fed back so the
+  // agent learns why a post vanished instead of retrying it verbatim.
+  previousRunErrors?: string[] | null;
   // One-shot directive set when the agent was detected in a run-level loop
   // (see lib/stuck-detector.ts), telling it to break the pattern this turn.
   stuckBreak?: string | null;
@@ -170,6 +175,8 @@ export interface ContextPacket {
     action: string;
     status: string;
     createdAt: string;
+    // ISO deadline after which the card auto-expires (null = never).
+    expiresAt: string | null;
     // Workspace-wide visibility: whose request this is, and whether it's the
     // packet-owner's own (mine=false ⇒ a teammate already asked — don't dupe).
     agentHandle: string;
@@ -307,6 +314,7 @@ export async function buildContext(opts: {
   taskId?: string;
   approvalId?: string;
   previousRunFailure?: { errorText: string; finishedAt: string | null } | null;
+  previousRunErrors?: string[] | null;
   stuckBreak?: string | null;
   lastCodeResult?: string | null;
   steering?: string | null;
@@ -998,6 +1006,7 @@ export async function buildContext(opts: {
     triggerMessageId: opts.messageId,
     steering: opts.steering ?? null,
     previousRunFailure: opts.previousRunFailure ?? null,
+    previousRunErrors: opts.previousRunErrors?.length ? opts.previousRunErrors.slice(0, 6) : null,
     stuckBreak: opts.stuckBreak ?? null,
     lastCodeResult: opts.lastCodeResult ?? null,
     members: memberDirectory,
@@ -1009,6 +1018,7 @@ export async function buildContext(opts: {
       action: o.action,
       status: o.status,
       createdAt: o.createdAt.toISOString(),
+      expiresAt: approvalExpiresAt(o.createdAt)?.toISOString() ?? null,
       agentHandle: o.agentHandle,
       mine: o.mine,
     })),

--- a/api/src/agents/dedupe.ts
+++ b/api/src/agents/dedupe.ts
@@ -5,114 +5,129 @@
 // conversation, same content — different message IDs, so the in-body
 // repetition rule never sees them.
 //
-// Strategy: 3-word shingles, Jaccard similarity, threshold 0.85, against the
-// last 50 messages in the conversation. Normalization strips URLs, @mentions,
-// and punctuation so "ping @nova" and "ping @ada" don't count as different.
-// Short bodies skip the check — "ok"/"thanks"/"👍" repeat naturally and the
-// false-positive cost is high.
+// Two layers:
+//   1. SAME SURFACE — the last RECENT_LIMIT messages in this conversation /
+//      comments on this task (any author, no time bound).
+//   2. CROSS SURFACE, TIME-WINDOWED — the same fact narrated into chat AND a
+//      task comment (or onto two different task cards, by two agents) within
+//      CROSS_WINDOW_MS. Observed live: "Backend is live and verified — `node
+//      server.js` on port 3000" posted by two agents as comments on different
+//      tasks, and "Proof package v28 shipped" mirrored into chat + task.
+//      Agents only — humans never hit this code path — and the window is
+//      short, so a genuine re-announcement a day later still lands.
+//
+// The similarity primitives live in lib/text-similarity.ts (pure, tested).
 
-import { and, desc, eq, isNull } from "drizzle-orm";
+import { and, desc, eq, gte, isNull } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { messages, taskComments } from "../db/schema.js";
+import { findNearDuplicate } from "../lib/text-similarity.js";
 
 const RECENT_LIMIT = 50;
-const SIMILARITY_THRESHOLD = 0.85;
-const MIN_NORMALIZED_LEN = 30;
-const SHINGLE_SIZE = 3;
+// Cross-surface window + fetch bound. Six hours covers the heartbeat cadence
+// that produces the mirrored posts (agents re-narrating within a few runs)
+// without suppressing a legitimate next-day status.
+export const CROSS_WINDOW_MS = 6 * 60 * 60 * 1000;
+const CROSS_LIMIT = 120;
+
+export type DedupeSurface = "message" | "task_comment";
 
 export type DedupeResult =
   | { ok: true }
-  | { ok: false; reason: "duplicate_of_recent"; againstId: string; score: number };
+  | {
+      ok: false;
+      reason: "duplicate_of_recent";
+      againstId: string;
+      score: number;
+      // Which table the match came from — lets the executor's trace say
+      // "duplicate of task comment tc_… " when a chat post mirrors a comment.
+      surface: DedupeSurface;
+    };
 
-function normalize(s: string): string {
-  return s
-    .toLowerCase()
-    .replace(/https?:\/\/\S+/g, " ")
-    .replace(/@[a-z0-9_]+/g, " ")
-    .replace(/[^\p{Letter}\p{Number}\s]/gu, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+type Row = { id: string; bodyMd: string };
+
+function hit(surface: DedupeSurface, r: { candidate: Row; score: number }): DedupeResult {
+  return {
+    ok: false,
+    reason: "duplicate_of_recent",
+    againstId: r.candidate.id,
+    score: r.score,
+    surface,
+  };
 }
 
-function shingles(normalized: string, k: number): Set<string> {
-  const words = normalized.split(" ").filter(Boolean);
-  if (words.length < k) return new Set([words.join(" ")]);
-  const out = new Set<string>();
-  for (let i = 0; i <= words.length - k; i++) {
-    out.add(words.slice(i, i + k).join(" "));
-  }
-  return out;
-}
-
-function jaccard(a: Set<string>, b: Set<string>): number {
-  if (a.size === 0 || b.size === 0) return 0;
-  let inter = 0;
-  for (const x of a) if (b.has(x)) inter++;
-  const union = a.size + b.size - inter;
-  return union === 0 ? 0 : inter / union;
-}
-
-export async function checkRecentDuplicate(
-  conversationId: string,
-  bodyMd: string,
-): Promise<DedupeResult> {
-  const incomingNorm = normalize(bodyMd);
-  if (incomingNorm.length < MIN_NORMALIZED_LEN) return { ok: true };
-  const incoming = shingles(incomingNorm, SHINGLE_SIZE);
-
-  const recents = await db
+async function recentMessagesIn(conversationId: string): Promise<Row[]> {
+  return db
     .select({ id: messages.id, bodyMd: messages.bodyMd })
     .from(messages)
-    .where(
-      and(eq(messages.conversationId, conversationId), isNull(messages.deletedAt)),
-    )
+    .where(and(eq(messages.conversationId, conversationId), isNull(messages.deletedAt)))
     .orderBy(desc(messages.ts))
     .limit(RECENT_LIMIT);
-
-  for (const r of recents) {
-    const norm = normalize(r.bodyMd);
-    if (norm.length < MIN_NORMALIZED_LEN) continue;
-    const score = jaccard(incoming, shingles(norm, SHINGLE_SIZE));
-    if (score >= SIMILARITY_THRESHOLD) {
-      return {
-        ok: false,
-        reason: "duplicate_of_recent",
-        againstId: r.id,
-        score: Math.round(score * 100) / 100,
-      };
-    }
-  }
-  return { ok: true };
 }
 
-// Same cross-message dedupe, but for TASK COMMENTS. The begging loop relocated
-// here: approval-level dedupe killed duplicate approval CARDS, so agents moved
-// to re-posting "still blocked, need credentials" as a fresh task_comment every
-// hour (no message-table dedupe ever saw those). Compare an incoming comment
-// against the recent comments on the SAME task; a near-identical restatement is
-// noise, not progress. Threshold matches the message dedupe.
-export async function checkRecentDuplicateTaskComment(
-  taskId: string,
-  bodyMd: string,
-): Promise<DedupeResult> {
-  const incomingNorm = normalize(bodyMd);
-  if (incomingNorm.length < MIN_NORMALIZED_LEN) return { ok: true };
-  const incoming = shingles(incomingNorm, SHINGLE_SIZE);
-
-  const recents = await db
+async function recentCommentsOn(taskId: string): Promise<Row[]> {
+  return db
     .select({ id: taskComments.id, bodyMd: taskComments.bodyMd })
     .from(taskComments)
     .where(and(eq(taskComments.taskId, taskId), isNull(taskComments.deletedAt)))
     .orderBy(desc(taskComments.ts))
     .limit(RECENT_LIMIT);
+}
 
-  for (const r of recents) {
-    const n = normalize(r.bodyMd);
-    if (n.length < MIN_NORMALIZED_LEN) continue;
-    const score = jaccard(incoming, shingles(n, SHINGLE_SIZE));
-    if (score >= SIMILARITY_THRESHOLD) {
-      return { ok: false, reason: "duplicate_of_recent", againstId: r.id, score: Math.round(score * 100) / 100 };
-    }
-  }
+// Windowed, workspace-wide scans for the cross-surface layer. Bounded by
+// CROSS_LIMIT so a busy board can't turn one post into a big read.
+async function windowedComments(since: Date): Promise<Row[]> {
+  return db
+    .select({ id: taskComments.id, bodyMd: taskComments.bodyMd })
+    .from(taskComments)
+    .where(and(gte(taskComments.ts, since), isNull(taskComments.deletedAt)))
+    .orderBy(desc(taskComments.ts))
+    .limit(CROSS_LIMIT);
+}
+
+async function windowedMessages(since: Date): Promise<Row[]> {
+  return db
+    .select({ id: messages.id, bodyMd: messages.bodyMd })
+    .from(messages)
+    .where(and(gte(messages.ts, since), isNull(messages.deletedAt)))
+    .orderBy(desc(messages.ts))
+    .limit(CROSS_LIMIT);
+}
+
+// Incoming CHAT MESSAGE: compare against the conversation's recent messages,
+// then against every task comment posted in the window (the same fact already
+// narrated onto a task card).
+export async function checkRecentDuplicate(
+  conversationId: string,
+  bodyMd: string,
+): Promise<DedupeResult> {
+  const sameSurface = findNearDuplicate(bodyMd, await recentMessagesIn(conversationId));
+  if (sameSurface) return hit("message", sameSurface);
+
+  const since = new Date(Date.now() - CROSS_WINDOW_MS);
+  const cross = findNearDuplicate(bodyMd, await windowedComments(since));
+  if (cross) return hit("task_comment", cross);
+  return { ok: true };
+}
+
+// Incoming TASK COMMENT. The begging loop relocated here: approval-level
+// dedupe killed duplicate approval CARDS, so agents moved to re-posting "still
+// blocked, need credentials" as a fresh task_comment every hour. Compare
+// against the recent comments on the SAME task, then (windowed) against
+// comments on every other task — two agents posting the identical verification
+// line onto sibling cards — and against recent chat messages (the same fact
+// posted to chat first, then mirrored onto the card).
+export async function checkRecentDuplicateTaskComment(
+  taskId: string,
+  bodyMd: string,
+): Promise<DedupeResult> {
+  const sameTask = findNearDuplicate(bodyMd, await recentCommentsOn(taskId));
+  if (sameTask) return hit("task_comment", sameTask);
+
+  const since = new Date(Date.now() - CROSS_WINDOW_MS);
+  const otherTasks = findNearDuplicate(bodyMd, await windowedComments(since));
+  if (otherTasks) return hit("task_comment", otherTasks);
+  const chat = findNearDuplicate(bodyMd, await windowedMessages(since));
+  if (chat) return hit("message", chat);
   return { ok: true };
 }

--- a/api/src/agents/executor.ts
+++ b/api/src/agents/executor.ts
@@ -13,7 +13,7 @@ import {
   agents,
 } from "../db/schema.js";
 import { id } from "../lib/ids.js";
-import { publishToConversation } from "../lib/events.js";
+import { publishToConversation, publishToWorkspace } from "../lib/events.js";
 import { checkReplyBody, guardRejectHint } from "./reply-guard.js";
 import { checkRecentDuplicate, checkRecentDuplicateTaskComment } from "./dedupe.js";
 import {
@@ -41,8 +41,16 @@ import { redis } from "../lib/redis.js";
 import { loadLedger, appendFact, appendProgressNote, appendDeadEnd } from "../lib/ledger-core.js";
 import { putObject, publicUrl, readObject } from "../lib/storage.js";
 import { createArtifact, isSubstantiveContent } from "../lib/task-artifacts.js";
-import { notifyForMessage } from "../lib/notifications.js";
+import { notifyForMessage, notifyApprovers } from "../lib/notifications.js";
 import { writeProjectFile } from "../lib/project-files.js";
+import {
+  autoApprovalFor,
+  findDuplicateApproval,
+  duplicateApprovalError,
+  approvalExpiresAt,
+} from "../lib/approval-policy.js";
+import { writeAudit } from "../lib/access-control.js";
+import { enqueueAgentEvent } from "./enqueue.js";
 import { safePublicFetch } from "../lib/safe-fetch.js";
 
 export interface AgentAttachment {
@@ -363,67 +371,8 @@ function describeForApproval(a: AgentAction): { action: string; conversationId: 
   }
 }
 
-// Approval dedupe. Exact agent+scope+action matching got beaten in the wild:
-// agents minted a fresh free-form scope string every wake (github_auth,
-// hosting, hosting_credentials, deploy, deploy_creds, github_token, …) for
-// the SAME credential ask, so 11 cards piled up for one human decision. Match
-// on trigram similarity of the action text instead — workspace-wide, so three
-// agents asking for the same thing share one card — and remember DENIALS: a
-// similar request a human denied in the last 7 days is refused outright (a
-// denial is an answer, not a retry timer).
-const DENIAL_MEMORY_MS = 7 * 24 * 60 * 60 * 1000;
-// An agent's own re-ask matches looser than a teammate's distinct request.
-const DUP_SIM_SELF = 0.45;
-const DUP_SIM_TEAMMATE = 0.62;
-
-type DuplicateApproval = {
-  id: string;
-  status: string;
-  agentId: string;
-  decidedAt: Date | null;
-  action: string;
-};
-
-async function findDuplicateApproval(
-  agentId: string,
-  action: string,
-): Promise<DuplicateApproval | null> {
-  const [me] = await db
-    .select({ workspaceId: agents.workspaceId })
-    .from(agents)
-    .where(eq(agents.id, agentId))
-    .limit(1);
-  if (!me) return null;
-  const deniedCutoff = new Date(Date.now() - DENIAL_MEMORY_MS);
-  const rows = await db
-    .select({
-      id: approvals.id,
-      status: approvals.status,
-      agentId: approvals.agentId,
-      decidedAt: approvals.decidedAt,
-      action: approvals.action,
-      sim: sql<number>`similarity(${approvals.action}, ${action})`.as("sim"),
-    })
-    .from(approvals)
-    .innerJoin(agents, eq(agents.id, approvals.agentId))
-    .where(
-      and(
-        eq(agents.workspaceId, me.workspaceId),
-        or(
-          eq(approvals.status, "pending"),
-          and(eq(approvals.status, "denied"), gt(approvals.decidedAt, deniedCutoff)),
-        ),
-        sql`similarity(${approvals.action}, ${action}) > ${DUP_SIM_SELF}`,
-      ),
-    )
-    .orderBy(sql`similarity(${approvals.action}, ${action}) desc`)
-    .limit(5);
-  for (const r of rows) {
-    const threshold = r.agentId === agentId ? DUP_SIM_SELF : DUP_SIM_TEAMMATE;
-    if (Number(r.sim) >= threshold) return r;
-  }
-  return null;
-}
+// Approval dedupe + denial memory now live in lib/approval-policy.ts
+// (scope- and credential-name-aware, workspace-wide, configurable window).
 
 // Actionable rejection copy for a duplicate/denied approval match. Returned as
 // an executor error so the agent reads WHY it was dropped and what to do.
@@ -437,24 +386,100 @@ export function approvalIdMisuse(action: string, payload?: Record<string, unknow
   return /\bap_[a-z0-9]{12,}\b/i.test(hay);
 }
 
-function duplicateApprovalError(actionType: string, dup: DuplicateApproval, agentId: string): string {
-  if (dup.status === "denied") {
-    const when = dup.decidedAt ? dup.decidedAt.toISOString().slice(0, 10) : "recently";
-    return (
-      `${actionType} refused: a human DENIED an equivalent request (${dup.id}, "${dup.action}") on ${when}. ` +
-      `A denial is final — do NOT re-request or rephrase it. Set the dependent task status:"blocked" with one comment, or pursue an approach that doesn't need this approval.`
-    );
+// One place every approval card is minted. Handles, in order:
+//   1. auto-approval policy (AUTO_APPROVE_SCOPES / agent `approve:` scopes) —
+//      records an audit row instead of a card and returns {auto};
+//   2. dedupe against pending + recently denied/expired cards — returns {dup};
+//   3. otherwise inserts the pending card, publishes approval.new to the
+//      conversation AND the workspace (a request_approval with no
+//      conversation_id previously produced no live event at all), and puts a
+//      notification in every approver's inbox (previously nobody was told).
+type OpenApprovalResult =
+  | { kind: "auto"; id: string; rule: string }
+  | { kind: "dup"; dup: import("../lib/approval-policy.js").DuplicateApproval }
+  | { kind: "opened"; id: string; expiresAt: Date | null };
+
+async function openApproval(params: {
+  agentId: string;
+  runId: string;
+  scope: string;
+  action: string;
+  conversationId: string | null;
+  payload: Record<string, unknown>;
+  agentScopes?: string[] | null;
+  // Auto-approved gated executor actions are executed by the caller right
+  // away, so their row is recorded as already `applied`; a request_approval
+  // is work the agent does itself, so it is `approved` and the agent is woken.
+  autoStatus: "approved" | "applied";
+}): Promise<OpenApprovalResult> {
+  const { agentId, runId, scope, action, conversationId, payload } = params;
+  const [ag] = await db
+    .select({ workspaceId: agents.workspaceId, name: agents.name, scopes: agents.scopes })
+    .from(agents)
+    .where(eq(agents.id, agentId))
+    .limit(1);
+  const agentScopes = params.agentScopes ?? ag?.scopes ?? [];
+
+  const auto = autoApprovalFor(scope, action, agentScopes);
+  if (auto) {
+    const apId = id("ap");
+    const note = `auto-approved by ${auto.by === "policy" ? "AUTO_APPROVE_SCOPES" : "agent scope"} rule "${auto.rule}"`;
+    await db.insert(approvals).values({
+      id: apId,
+      agentRunId: runId,
+      agentId,
+      conversationId,
+      scope,
+      action,
+      payloadJson: payload,
+      status: params.autoStatus,
+      decidedAt: new Date(),
+      decidedBy: null,
+      decisionNote: note,
+    });
+    if (ag) {
+      await writeAudit({
+        workspaceId: ag.workspaceId,
+        actorId: agentId,
+        actorType: "agent",
+        action: "approval.auto_approved",
+        targetType: "approval",
+        targetId: apId,
+        meta: { scope, action, rule: auto.rule, by: auto.by, runId },
+      }).catch(() => {});
+    }
+    return { kind: "auto", id: apId, rule: auto.rule };
   }
-  if (dup.agentId !== agentId) {
-    return (
-      `${actionType} skipped: a teammate already has an equivalent approval pending (${dup.id}, "${dup.action}"). ` +
-      `Don't file duplicates — the human decides once for the team. Coordinate on the task card if needed.`
-    );
+
+  const dup = await findDuplicateApproval(agentId, scope, action);
+  if (dup) return { kind: "dup", dup };
+
+  const apId = id("ap");
+  const createdAt = new Date();
+  await db.insert(approvals).values({
+    id: apId,
+    agentRunId: runId,
+    agentId,
+    conversationId,
+    scope,
+    action,
+    payloadJson: payload,
+    status: "pending",
+    createdAt,
+  });
+  const frame = { type: "approval.new" as const, approvalId: apId, agentId, scope, action, conversationId };
+  if (conversationId) await publishToConversation(conversationId, frame).catch(() => {});
+  if (ag) {
+    await publishToWorkspace(ag.workspaceId, frame).catch(() => {});
+    const expiresAt = approvalExpiresAt(createdAt);
+    await notifyApprovers(ag.workspaceId, {
+      title: `${ag.name} needs approval: ${scope}`,
+      body: `${action}`.slice(0, 280) + (expiresAt ? ` — expires ${expiresAt.toISOString().slice(0, 16).replace("T", " ")} UTC if nobody decides.` : ""),
+      link: "/approvals",
+    });
+    return { kind: "opened", id: apId, expiresAt };
   }
-  return (
-    `${actionType} skipped: your equivalent approval (${dup.id}) is already pending a human decision — ` +
-    `do not retry or rephrase it; you'll be woken with trigger:"approval_response" when it's decided.`
-  );
+  return { kind: "opened", id: apId, expiresAt: approvalExpiresAt(createdAt) };
 }
 
 // Credential-/access-begging or bare "still blocked" restatement. Used to stop
@@ -649,33 +674,33 @@ export async function applyActions(params: {
           out.actionsApplied++;
           continue;
         }
-        const dup = await findDuplicateApproval(agentId, d.action);
-        if (dup) {
-          out.trace.push(`gated ${a.type} → ${dup.status} duplicate approval ${dup.id}, skipped`);
-          out.errors.push(duplicateApprovalError(a.type, dup, agentId));
-          continue;
-        }
-        const apId = id("ap");
-        await db.insert(approvals).values({
-          id: apId,
-          agentRunId: runId,
+        const opened = await openApproval({
           agentId,
-          conversationId: d.conversationId,
+          runId,
           scope: reason,
           action: d.action,
-          payloadJson: d.payload,
-          status: "pending",
+          conversationId: d.conversationId,
+          payload: d.payload,
+          // Only pass the preloaded list when enforcement actually loaded it;
+          // otherwise let openApproval read the agent's scopes itself so
+          // `approve:` trust scopes still apply on the risk-gate-only path.
+          agentScopes: enforce ? scopes : undefined,
+          autoStatus: "applied",
         });
-        if (d.conversationId) {
-          await publishToConversation(d.conversationId, {
-            type: "approval.new",
-            approvalId: apId,
-            agentId,
-            scope: reason,
-            action: d.action,
-            conversationId: d.conversationId,
-          });
+        if (opened.kind === "dup") {
+          out.trace.push(`gated ${a.type} → ${opened.dup.status} duplicate approval ${opened.dup.id}, skipped`);
+          out.errors.push(duplicateApprovalError(a.type, opened.dup, agentId));
+          continue;
         }
+        if (opened.kind === "auto") {
+          // Policy says this scope needs no human: run it now, leave the
+          // audit row (status applied) so the decision is reviewable later.
+          out.trace.push(`gated ${a.type} auto-approved by ${opened.rule} (approval ${opened.id}, audited)`);
+          await applyOne(agentId, runId, agentMember.id, a, out);
+          out.actionsApplied++;
+          continue;
+        }
+        const apId = opened.id;
         const why = outOfScope ? `requires scope "${reason}"` : `is ${reason} and needs approval`;
         out.trace.push(`gated ${a.type} → approval ${apId} (${why})`);
         out.errors.push(`${a.type} ${why} — opened approval ${apId}`);
@@ -713,7 +738,9 @@ async function applyOne(
         out.trace.push(
           `post_message rejected (duplicate_of_recent vs ${dup.againstId} @${dup.score})`,
         );
-        out.errors.push("post_message rejected: duplicate_of_recent");
+        out.errors.push(
+          `post_message rejected: duplicate_of_recent — you already posted this as a ${dup.surface === "task_comment" ? "task comment" : "message"} (${dup.againstId}). One surface per fact; say something new or stay silent.`,
+        );
         return;
       }
 
@@ -849,7 +876,9 @@ async function applyOne(
         out.trace.push(
           `open_thread rejected (duplicate_of_recent vs ${dup.againstId} @${dup.score})`,
         );
-        out.errors.push("open_thread rejected: duplicate_of_recent");
+        out.errors.push(
+          `open_thread rejected: duplicate_of_recent — you already posted this as a ${dup.surface === "task_comment" ? "task comment" : "message"} (${dup.againstId}). One surface per fact.`,
+        );
         return;
       }
       const [authorRow] = await db
@@ -918,33 +947,34 @@ async function applyOne(
         );
         return;
       }
-      const dup = await findDuplicateApproval(agentId, a.action);
-      if (dup) {
-        out.trace.push(`request_approval → ${dup.status} duplicate ${dup.id}, skipped`);
-        out.errors.push(duplicateApprovalError("request_approval", dup, agentId));
-        return;
-      }
-      const apId = id("ap");
-      await db.insert(approvals).values({
-        id: apId,
-        agentRunId: runId,
+      const opened = await openApproval({
         agentId,
-        conversationId: a.conversation_id ?? null,
+        runId,
         scope: a.scope,
         action: a.action,
-        payloadJson: a.payload ?? {},
-        status: "pending",
+        conversationId: a.conversation_id ?? null,
+        payload: a.payload ?? {},
+        autoStatus: "approved",
       });
-      if (a.conversation_id) {
-        await publishToConversation(a.conversation_id, {
-          type: "approval.new",
-          approvalId: apId,
-          agentId,
-          scope: a.scope,
-          action: a.action,
-          conversationId: a.conversation_id,
-        });
+      if (opened.kind === "dup") {
+        out.trace.push(`request_approval → ${opened.dup.status} duplicate ${opened.dup.id}, skipped`);
+        out.errors.push(duplicateApprovalError("request_approval", opened.dup, agentId));
+        return;
       }
+      if (opened.kind === "auto") {
+        // Wake the agent through the normal approval_response path so it
+        // gets the same "APPROVED — do the work now" directive a human
+        // approve produces, instead of waiting for a card that never comes.
+        out.trace.push(`request_approval ${opened.id} auto-approved by ${opened.rule}`);
+        await enqueueAgentEvent(agentId, {
+          trigger: "approval_response",
+          approvalId: opened.id,
+          status: "approved",
+          conversationId: a.conversation_id ?? undefined,
+        }).catch(() => {});
+        return;
+      }
+      const apId = opened.id;
       out.trace.push(`request_approval ${apId}`);
       return;
     }
@@ -1296,7 +1326,7 @@ async function applyOne(
       const cdup = await checkRecentDuplicateTaskComment(a.task_id, guard.bodyMd);
       if (!cdup.ok) {
         out.errors.push(
-          `task_comment skipped: near-duplicate of an existing comment on ${a.task_id} (vs ${cdup.againstId}). You already said this — don't repeat it. Either do the next concrete step (ship a file via share_to_task, change status) or stay silent.`,
+          `task_comment skipped: near-duplicate of ${cdup.surface === "message" ? "a chat message you already posted" : "an existing comment"} (vs ${cdup.againstId}${cdup.surface === "message" ? "" : ` on ${a.task_id}`}). You already said this — don't repeat it. Either do the next concrete step (ship a file via share_to_task, change status) or stay silent.`,
         );
         return;
       }

--- a/api/src/agents/goal-planner-worker.ts
+++ b/api/src/agents/goal-planner-worker.ts
@@ -10,6 +10,7 @@ import { bumpStall, assessProgress, writeProgressAssessment } from "../lib/ledge
 import { notify } from "../lib/notifications.js";
 import { runProductivityReview } from "../lib/productivity.js";
 import { reapStuckRuns } from "../lib/run-reaper.js";
+import { expireStaleApprovals } from "../lib/approval-policy.js";
 import { runMemoryJanitor } from "../lib/memory-janitor.js";
 
 // Give up after this many failed planning attempts (the sweeper is the retry
@@ -123,6 +124,10 @@ async function handleSweep(): Promise<void> {
   // 6. Crash recovery: fail out runs stuck 'running' after a worker death and
   //    put their agents back to idle (clears permanent thinking pills too).
   await reapStuckRuns().catch((e) => console.error("[goal-planner] run-reaper error", e));
+
+  // 6b. Approval expiry: close pending cards older than APPROVAL_TTL_HOURS,
+  //     wake their agents to re-plan, and release tasks blocked on them.
+  await expireStaleApprovals().catch((e) => console.error("[goal-planner] approval-expiry error", e));
 
   // 7. Sleep-time memory janitor: refresh each workspace's shared team block
   //    from recent activity (opt-in CC_MEMORY_JANITOR=on; per-workspace cooldown).

--- a/api/src/agents/reply-guard.ts
+++ b/api/src/agents/reply-guard.ts
@@ -262,6 +262,88 @@ function scrubSecrets(s: string): string {
     .replace(RAW_BOT_TOKEN_RE, "cc_***");
 }
 
+// ─────────── Hermes runtime scaffolding that leaks as a reply PREFIX ───────────
+// When the agent loop hits its `max_turns` cap, Hermes prints
+//   "⚠️  Reached maximum iterations (20). Requesting summary..."
+// and then asks the model for a wrap-up, which typically opens "Here's what I
+// found and did this turn:". Live fishbowl: 400 chat messages + 176 task
+// comments in one week BEGAN with that banner. The summary underneath is
+// often real work, so STRIP the banner (and the lead-in line) and keep the
+// remainder; reject only when nothing substantive is left.
+const RUNAWAY_BANNER_RE =
+  /(?:^|\n)[ \t]*⚠?\uFE0F?[ \t]*Reached maximum iterations(?:\s*\(\d+\))?\.?(?:[ \t]*Requesting (?:a )?summary(?:\.{1,3}|…)?)?[ \t]*(?:\n|$)/gi;
+const SUMMARY_LEADIN_RE =
+  /(?:^|\n)[ \t]*(?:\*\*)?(?:Here(?:'|’)s|Here is) (?:what|a (?:quick |brief )?summary of what) I(?:'ve| have)? (?:found|did|done|found and did|did and found)(?: (?:so far|this turn|in this turn))?[.:]?(?:\*\*)?[ \t]*(?:\n|$)/gi;
+// Hermes' tool-dispatcher failure notice, e.g.
+//   ⚠ Could not execute tool(s): "target": value "files\n@@ARG_END" not in enum […]
+// It's a paragraph (runs to the next blank line, may contain the quoted
+// argument text with embedded newlines). Strip the whole paragraph.
+const TOOL_EXEC_FAIL_RE =
+  /(?:^|\n)[ \t]*⚠?\uFE0F?[ \t]*Could not execute tool\(s\)[^\n]*(?:\n(?![ \t]*\n)[^\n]*)*/gi;
+// Argument-delimiter debris from Hermes' text-based tool-call parser
+// (`@@ARG_START` / `@@ARG_END` and friends). If any survives the paragraph
+// strip above, the body is machinery — reject.
+const ARG_DEBRIS_RE = /@@(?:ARGS?|TOOL|CALL|FUNC|PARAMS?)[A-Z0-9_]*(?:_(?:START|END|BEGIN))?\b|@@ARG_END|@@ARG_START/;
+// The model talking to the PROMPT SCAFFOLDING instead of the humans: "I've read
+// the attached conversation history file in full. However, I don't see a
+// section titled "CURRENT REQUEST (full text)"…". Those section names exist
+// only in the packet we build; a real reply never mentions them.
+const SCAFFOLD_TALK_RE =
+  /CURRENT REQUEST \(full text\)|section titled ["“]CURRENT REQUEST|\battached conversation[- ]history file\b|\bconversation history file\b|\bI(?:'ve| have) read the (?:attached|provided) (?:conversation|context|history|file)\b/i;
+
+// Ritual sign-offs: "*Signed,* **@iris** — Researcher & Writer, Circle Labs —
+// *Artifact SHA-256 (compute…". Nobody signs a chat message. Cut from a
+// closer line ("Signed,", "Regards,", "Best regards," …) to the end, drop a
+// trailing "— @handle — Title" signature line, and drop any "Artifact
+// SHA-256" footer line wherever it sits.
+const SIGNOFF_CLOSER_RE =
+  /(?:^|\n)[ \t]*[*_]{0,3}(?:[Ss]igned|[Rr]egards|[Kk]ind regards|[Bb]est regards|[Ww]arm regards|[Ss]incerely|[Cc]heers|[Rr]espectfully|[Yy]ours (?:truly|sincerely|faithfully))[,.]?[*_]{0,3}(?:[ \t]*(?=\n|$)|[ \t]+(?=[*_—–-]*[ \t]*@)|[ \t]+[A-Z][\w.'-]*(?:[ \t]+[A-Z][\w.'-]*){0,3}[*_]{0,3}[ \t]*(?=\n|$))/;
+const SIGNATURE_LINE_RE =
+  /\n[ \t]*(?:[—–-]+[ \t]*[*_]{0,3}@[a-z0-9][a-z0-9._-]*[*_]{0,3}[^\n]*|[*_]{1,3}@[a-z0-9][a-z0-9._-]*[*_]{1,3}[ \t]*[—–][^\n]*)[ \t]*$/i;
+const SHA_FOOTER_RE = /(?:^|\n)[^\n]*\bArtifact SHA-?256\b[^\n]*/gi;
+
+export function stripSignOff(s: string): string {
+  let out = s;
+  const closer = SIGNOFF_CLOSER_RE.exec(out);
+  if (closer) out = out.slice(0, closer.index);
+  out = out.replace(SHA_FOOTER_RE, "\n");
+  // Signature line only when there is content above it — a whole reply that is
+  // "@bob — ping" must survive.
+  const sig = SIGNATURE_LINE_RE.exec(out);
+  if (sig && out.slice(0, sig.index).trim()) out = out.slice(0, sig.index);
+  return out.replace(/\n{3,}/g, "\n\n").trim();
+}
+
+export interface ScaffoldStrip {
+  text: string;
+  // Leak classes removed, in the order found. Empty when nothing was stripped.
+  stripped: string[];
+}
+
+// Remove leaked runtime scaffolding + sign-offs, keeping the substantive
+// remainder. Exported for tests and for the bridge-side mirror.
+export function stripLeakedScaffolding(s: string): ScaffoldStrip {
+  const stripped: string[] = [];
+  let out = s;
+  const step = (re: RegExp, reason: string, repl = "\n") => {
+    if (re.test(out)) {
+      stripped.push(reason);
+      re.lastIndex = 0;
+      out = out.replace(re, repl);
+    }
+    re.lastIndex = 0;
+  };
+  step(RUNAWAY_BANNER_RE, "runaway_banner");
+  step(TOOL_EXEC_FAIL_RE, "tool_exec_failure");
+  if (stripped.includes("runaway_banner")) step(SUMMARY_LEADIN_RE, "summary_leadin");
+  const unsigned = stripSignOff(out);
+  if (unsigned !== out.trim()) {
+    stripped.push("signoff");
+    out = unsigned;
+  }
+  return { text: out.replace(/\n{3,}/g, "\n\n").trim(), stripped };
+}
+
 // Actionable guidance appended to the rejection error fed back to the agent
 // on its next turn. Only reasons where the fix isn't obvious from the name.
 export function guardRejectHint(reason: string): string {
@@ -303,6 +385,15 @@ export function guardRejectHint(reason: string): string {
       return " Your whole message is a JSON blob. If it's an action, put it in an <actions> block; if it's data to share, write it to a /workspace file and attach it via share_to_task with a one-line caption.";
     case "curl_transcript":
       return " You pasted a curl command. You don't need raw HTTP — use an <actions> block to act on the board, or share_to_task to attach a file you wrote to /workspace.";
+    case "runaway_banner":
+      return " Your reply was only the runtime's 'Reached maximum iterations' banner — you ran out of tool turns before saying anything. Do fewer tool calls per turn: pick ONE concrete step, do it, and report it in a sentence or two (or an <actions> block). Never paste runtime warnings.";
+    case "tool_exec_failure":
+    case "tool_parse_debris":
+      return " Your reply carried the runtime's 'Could not execute tool(s)' notice / @@ARG parser debris — a tool call you emitted was malformed. That's diagnostics, not a message. Re-issue the tool call correctly (valid enum values, no stray delimiters) or emit the board action as an <actions> JSON block; only post prose that a teammate should read.";
+    case "scaffold_talk":
+      return " You addressed the prompt scaffolding ('CURRENT REQUEST', 'attached conversation history file') instead of the team. Nobody attached a file — the context you were given IS the conversation. Reply to the last human message in plain prose, or stay silent with HEARTBEAT_OK.";
+    case "signoff_only":
+      return " Your reply was only a signature/sign-off. Chat messages carry no sign-offs, no name/title lines, no hash footers — say the one new fact, then stop.";
     default:
       return "";
   }
@@ -312,9 +403,18 @@ export function checkReplyBody(
   bodyMd: string,
   opts?: { hasAttachments?: boolean },
 ): GuardResult {
-  const scrubbed = scrubSecrets(bodyMd);
+  // Strip leaked runtime scaffolding (runaway-iterations banner, tool-dispatch
+  // failure paragraphs, sign-offs) FIRST so a reply with a substantive body
+  // under the noise still posts — clean. If nothing substantive survives, the
+  // first stripped class is the reason (it teaches better than "empty_body").
+  const { text: scrubbed, stripped } = stripLeakedScaffolding(scrubSecrets(bodyMd));
   const trimmed = scrubbed.trim();
-  if (!trimmed) return { ok: false, reason: "empty_body" };
+  if (!trimmed) {
+    const lead = stripped.find((r) => r !== "summary_leadin");
+    return { ok: false, reason: lead === "signoff" ? "signoff_only" : lead || "empty_body" };
+  }
+  if (ARG_DEBRIS_RE.test(trimmed)) return { ok: false, reason: "tool_parse_debris" };
+  if (SCAFFOLD_TALK_RE.test(trimmed)) return { ok: false, reason: "scaffold_talk" };
   if (HEARTBEAT_RE.test(trimmed)) return { ok: false, reason: "heartbeat_leaked" };
   if (EMPTY_REPLY_NOTICE_RE.test(trimmed)) return { ok: false, reason: "empty_reply_notice" };
   if (TRACEBACK_RE.test(trimmed)) return { ok: false, reason: "python_traceback" };

--- a/api/src/agents/scheduler.ts
+++ b/api/src/agents/scheduler.ts
@@ -3,8 +3,65 @@ import { id } from "../lib/ids.js";
 import { db } from "../db/index.js";
 import { agentRuns } from "../db/schema.js";
 import { publishGlobal } from "../lib/events.js";
+import { redis } from "../lib/redis.js";
+import { heartbeatBackoffMs } from "../lib/run-outcome.js";
 
 const REPEAT_KEY = (agentId: string): string => `hb:${agentId}`;
+
+// ── Non-productive heartbeat backoff ──────────────────────────────────────
+// The repeatable BullMQ job keeps firing at the agent's configured interval;
+// we can't cheaply retune it per outcome. Instead the worker consults a redis
+// "suppress until" stamp before doing the expensive part of a scheduled run.
+// Every non-productive heartbeat (idle, failed, all actions rejected, runaway)
+// bumps a streak counter and pushes the stamp out exponentially (2×, 4×, 8× the
+// base interval …) up to CC_HEARTBEAT_BACKOFF_CAP_MS (default 6h). Any
+// productive run — or any event trigger (mention, DM, task_comment…), which
+// never consults the stamp — resets it.
+const STREAK_KEY = (agentId: string): string => `cc:hb:streak:${agentId}`;
+const UNTIL_KEY = (agentId: string): string => `cc:hb:until:${agentId}`;
+const STREAK_TTL_MS = 24 * 60 * 60 * 1000;
+const BACKOFF_CAP_MS = Number(process.env.CC_HEARTBEAT_BACKOFF_CAP_MS ?? 6 * 60 * 60 * 1000);
+
+export async function noteHeartbeatOutcome(
+  agentId: string,
+  productive: boolean,
+  intervalSec: number,
+): Promise<{ streak: number; backoffMs: number }> {
+  try {
+    if (productive) {
+      await redis.del(STREAK_KEY(agentId), UNTIL_KEY(agentId));
+      return { streak: 0, backoffMs: 0 };
+    }
+    const streak = await redis.incr(STREAK_KEY(agentId));
+    await redis.pexpire(STREAK_KEY(agentId), STREAK_TTL_MS);
+    const backoffMs = heartbeatBackoffMs(streak, Math.max(5_000, intervalSec * 1000), BACKOFF_CAP_MS);
+    if (backoffMs > 0) {
+      await redis.set(UNTIL_KEY(agentId), String(Date.now() + backoffMs), "PX", backoffMs);
+    }
+    return { streak, backoffMs };
+  } catch {
+    return { streak: 0, backoffMs: 0 };
+  }
+}
+
+// Milliseconds the agent's scheduled heartbeat is still suppressed for (0 = run).
+export async function heartbeatBackoffRemainingMs(agentId: string): Promise<number> {
+  try {
+    const v = await redis.get(UNTIL_KEY(agentId));
+    if (!v) return 0;
+    return Math.max(0, Number(v) - Date.now());
+  } catch {
+    return 0;
+  }
+}
+
+export async function clearHeartbeatBackoff(agentId: string): Promise<void> {
+  try {
+    await redis.del(STREAK_KEY(agentId), UNTIL_KEY(agentId));
+  } catch {
+    /* ignore */
+  }
+}
 
 // Repeating jobs that enqueue a scheduled agent-run.
 export async function scheduleAgentHeartbeat(agentId: string, everySec: number): Promise<void> {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,8 +6,9 @@ import rateLimit from "@fastify/rate-limit";
 import multipart from "@fastify/multipart";
 import websocket from "@fastify/websocket";
 import fastifyStatic from "@fastify/static";
-import { existsSync } from "node:fs";
-import { resolve as pathResolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve as pathResolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import authRoutes from "./routes/auth.js";
 import workspaceRoutes from "./routes/workspaces.js";
@@ -90,20 +91,67 @@ await app.register(websocket, {
   options: { maxPayload: 1024 * 1024, clientTracking: true },
 });
 
-app.get("/health", async () => ({ ok: true, time: new Date().toISOString() }));
+// Version stamp for /health — read once from package.json (works from both
+// src/ under tsx and dist/ after build; both sit one level below api/).
+const API_VERSION: string = (() => {
+  try {
+    const pkgPath = pathResolve(dirname(fileURLToPath(import.meta.url)), "../package.json");
+    return String((JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string }).version ?? "unknown");
+  } catch {
+    return "unknown";
+  }
+})();
+
+// Unauthenticated liveness probe. Registered at both the bare path (older
+// compose healthchecks) and under /api (the only prefix Caddy proxies to the
+// API, so external monitors can reach it). Rate-limit exempt so a probe every
+// few seconds from several monitors can't eat the client's budget.
+const healthHandler = async () => ({ ok: true, version: API_VERSION, time: new Date().toISOString() });
+app.get("/health", { config: { rateLimit: false } }, healthHandler);
+app.get("/api/health", { config: { rateLimit: false } }, healthHandler);
 
 // Global error handler — surface zod issues as 400s. MUST be registered before
 // the route plugins below: in Fastify each encapsulated plugin context captures
 // the error handler that exists when it is registered, so setting this after the
 // routes would leave them on the default handler (zod errors would 500, not 400).
-app.setErrorHandler((err, _req, reply) => {
-  const e = err as Error & { issues?: unknown[]; statusCode?: number };
+//
+// Client errors (4xx — bad content-type, oversized body, rate limit, malformed
+// JSON) are expected traffic, not incidents: log them once at warn WITHOUT a
+// stack trace. Only 5xx get the full error-level dump. Before this, every
+// scanner POSTing form-encoded bodies produced an error-level "Unsupported
+// Media Type" stack trace per hit on the public instance.
+app.setErrorHandler((err, req, reply) => {
+  const e = err as Error & { issues?: unknown[]; statusCode?: number; code?: string };
   if (e.issues) {
     reply.code(400).send({ error: "validation", issues: e.issues });
     return;
   }
-  app.log.error(e);
-  reply.code(e.statusCode ?? 500).send({ error: e.message ?? "server_error" });
+  const status = typeof e.statusCode === "number" && e.statusCode >= 400 && e.statusCode <= 599 ? e.statusCode : 500;
+  if (status < 500) {
+    req.log.warn(
+      { code: e.code, statusCode: status, method: req.method, url: req.url, contentType: req.headers["content-type"] },
+      e.message,
+    );
+    if (e.code === "FST_ERR_CTP_INVALID_MEDIA_TYPE") {
+      reply.code(415).send({ error: "unsupported_media_type", accepted: ["application/json", "multipart/form-data"] });
+      return;
+    }
+    if (e.code === "FST_ERR_CTP_EMPTY_JSON_BODY" || e.code === "FST_ERR_CTP_INVALID_JSON_BODY" || e.code === "FST_ERR_CTP_INVALID_CONTENT_LENGTH") {
+      reply.code(400).send({ error: "invalid_body" });
+      return;
+    }
+    if (e.code === "FST_ERR_CTP_BODY_TOO_LARGE") {
+      reply.code(413).send({ error: "body_too_large" });
+      return;
+    }
+    reply.code(status).send({ error: e.message ?? "request_error" });
+    return;
+  }
+  req.log.error(e);
+  // Only forward machine-readable codes (snake_case tokens) thrown on purpose;
+  // raw driver/library messages stay in the log.
+  const code = typeof e.message === "string" && /^[a-z][a-z0-9_]{0,79}(:[^\s]{0,200})?$/.test(e.message) ? e.message : "server_error";
+  reply.code(status).send({ error: code });
 });
 
 await app.register(authRoutes, { prefix: "/api" });

--- a/api/src/lib/access-control.ts
+++ b/api/src/lib/access-control.ts
@@ -8,7 +8,7 @@ import { config } from "./config.js";
 
 export const BUILTIN_PERMISSIONS: Record<string, string[]> = {
   admin: ["*"],
-  member: ["workspace.read", "workspace.write", "runs.control", "apps.request_publish"],
+  member: ["workspace.read", "workspace.write", "runs.control", "apps.request_publish", "approvals.decide"],
   guest: ["workspace.read", "channels.write"],
 };
 

--- a/api/src/lib/approval-policy.ts
+++ b/api/src/lib/approval-policy.ts
@@ -1,0 +1,365 @@
+// Approval policy: the rules that decide whether an agent's ask needs a human
+// at all, whether it duplicates one already asked, and what happens when no
+// human ever answers.
+//
+// Why this exists. On the live fishbowl, five credential cards sat `pending`
+// for two months. Agents re-requested the same key after it was DENIED (the
+// dedupe matched free text only, never the scope), 12 tasks stayed `blocked`
+// on cards nobody was ever notified about, and nothing expired — so the loop
+// had no exit. The pieces here give it three:
+//   • dedupe by SCOPE and credential NAME, not just text similarity, and
+//     remember denials/expiries for a configurable window;
+//   • expire stale cards (APPROVAL_TTL_HOURS), wake the agent with status
+//     "expired — find another route", and release the tasks blocked on it;
+//   • a small auto-approval layer (AUTO_APPROVE_SCOPES, per-agent
+//     `approve:<scope>` scopes) that records an audit row instead of a card.
+//
+// Pure helpers are exported for tests; the DB-touching sweep lives at the
+// bottom so the worker owner can call it from the periodic tick.
+import { and, eq, gt, ilike, lt, or, sql } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { agents, approvals, members, taskComments, tasks } from "../db/schema.js";
+import { approvalDenialMemoryDays, approvalTtlHours, autoApproveScopes } from "./config.js";
+import { publishToConversation, publishToWorkspace } from "./events.js";
+import { enqueueAgentEvent } from "../agents/enqueue.js";
+import { notifyApprovers } from "./notifications.js";
+import { addComment, updateTask } from "./tasks-core.js";
+
+// ───────────────── pure helpers ─────────────────
+
+// Same detector the Approvals page and the bridge use: a request whose scope
+// or text names a credential. These can never be auto-approved (approving
+// produces no secret) and are what the dedupe must catch by name.
+export const CREDENTIAL_ASK_RE =
+  /credential|token|api.?key|secret|password|passphrase|access.?key|\bpat\b/i;
+
+export function isCredentialAsk(scope: string, action: string): boolean {
+  return CREDENTIAL_ASK_RE.test(`${scope || ""} ${action || ""}`);
+}
+
+// `Tavily API key`, `tavily-api-key`, `TAVILY_API_KEY` → `tavily_api_key`.
+export function normalizeScope(scope: string): string {
+  return (scope || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9*:.]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+}
+
+// Env-var-shaped credential names mentioned in a scope/action, upper-cased
+// and deduped: "VERCEL_TOKEN", "TAVILY_API_KEY", "GITHUB_PAT". The scope is
+// upper-cased first so `tavily_api_key` counts. Used to match a re-request
+// for the same secret regardless of how the sentence around it is phrased.
+const CRED_NAME_RE = /\b[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*_(?:API_)?(?:KEY|TOKEN|SECRET|PAT|PASSWORD|CREDENTIALS?)\b/g;
+export function credentialNames(scope: string, action: string): string[] {
+  const hay = `${(scope || "").toUpperCase()} ${action || ""}`;
+  const out = new Set<string>();
+  for (const m of hay.match(CRED_NAME_RE) ?? []) out.add(m);
+  return Array.from(out);
+}
+
+// Does an AUTO_APPROVE_SCOPES entry (or an agent's `approve:<x>` scope) cover
+// this approval scope? Exact match after normalisation, or prefix match with
+// a trailing `*` (`tasks.*`, `risk:*`, `deploy*`). A bare `*` covers all.
+export function scopeMatches(pattern: string, scope: string): boolean {
+  const p = normalizeScope(pattern);
+  const s = normalizeScope(scope);
+  if (!p || !s) return false;
+  if (p === "*") return true;
+  if (p.endsWith("*")) return s.startsWith(p.slice(0, -1));
+  return p === s;
+}
+
+// Why an approval may skip the human, or null when it must not.
+//   • credential asks: never (there is nothing to deliver);
+//   • AUTO_APPROVE_SCOPES covers the scope → "policy";
+//   • the agent holds `approve:<scope>` or `approve:*` → "agent_scope".
+// Agents' `approve:` scopes are the per-agent trust level: they live in the
+// existing `agents.scopes` column and are edited from the same UI as the
+// action scopes, so no schema change is needed.
+export type AutoApproval = { by: "policy" | "agent_scope"; rule: string };
+export function autoApprovalFor(
+  scope: string,
+  action: string,
+  agentScopes: string[] | null | undefined,
+  envList: string[] = autoApproveScopes(),
+): AutoApproval | null {
+  if (isCredentialAsk(scope, action)) return null;
+  for (const rule of envList) if (scopeMatches(rule, scope)) return { by: "policy", rule };
+  for (const s of agentScopes ?? []) {
+    const m = /^approve:(.+)$/i.exec(s.trim());
+    if (m && scopeMatches(m[1], scope)) return { by: "agent_scope", rule: s.trim() };
+  }
+  return null;
+}
+
+export function approvalTtlMs(hours: number = approvalTtlHours()): number {
+  return hours > 0 ? hours * 60 * 60 * 1000 : 0;
+}
+
+export function approvalExpiresAt(createdAt: Date, hours: number = approvalTtlHours()): Date | null {
+  const ms = approvalTtlMs(hours);
+  return ms > 0 ? new Date(createdAt.getTime() + ms) : null;
+}
+
+export function isApprovalExpired(createdAt: Date, now: Date = new Date(), hours: number = approvalTtlHours()): boolean {
+  const at = approvalExpiresAt(createdAt, hours);
+  return !!at && at.getTime() <= now.getTime();
+}
+
+export function denialMemoryMs(days: number = approvalDenialMemoryDays()): number {
+  return Math.max(0, days) * 24 * 60 * 60 * 1000;
+}
+
+// The decision note written on an expired card. It is what the agent reads
+// on its approval_response wake (context.ts forwards decisionNote verbatim),
+// so it carries the full instruction, not just a status word.
+export function expiryNote(hours: number = approvalTtlHours()): string {
+  return (
+    `EXPIRED: no human decided this within ${hours}h. Treat it as unavailable — do NOT re-request or rephrase it ` +
+    `(the server refuses equivalent requests for ${approvalDenialMemoryDays()} days). Pick a route that does not need it: ` +
+    `use a built-in alternative (e.g. share_to_task + the in-platform app preview instead of an external host, ` +
+    `a keyless/public data source instead of a paid API), scope the work down to what you CAN finish, or hand the task ` +
+    `back with one comment explaining the dependency. Any task blocked on this has been moved back to in_progress.`
+  );
+}
+
+// ───────────────── dedupe ─────────────────
+// Exact agent+scope+action matching got beaten in the wild: agents minted a
+// fresh free-form scope string every wake (github_auth, hosting, deploy_creds,
+// github_token, …) for the SAME ask, so 11 cards piled up. Then text-similarity
+// matching got beaten too: TAVILY_API_KEY was denied and re-requested twice
+// with different sentences around the same scope. So a request duplicates an
+// existing one when ANY of these hold, workspace-wide:
+//   • the normalised scope is identical;
+//   • they name the same credential (VERCEL_TOKEN, TAVILY_API_KEY, …);
+//   • the action text is similar (pg_trgm; looser for the same agent).
+// Pending cards, and denied/expired ones inside the memory window, all count.
+const DUP_SIM_SELF = 0.45;
+const DUP_SIM_TEAMMATE = 0.62;
+
+export type DuplicateApproval = {
+  id: string;
+  status: string;
+  agentId: string;
+  decidedAt: Date | null;
+  decisionNote: string | null;
+  action: string;
+  scope: string;
+};
+
+type Candidate = DuplicateApproval & { sim: number | string | null };
+
+// Pure ranking over fetched candidates (exported for tests).
+export function pickDuplicate(
+  candidates: Candidate[],
+  req: { agentId: string; scope: string; action: string },
+): DuplicateApproval | null {
+  const scope = normalizeScope(req.scope);
+  const names = new Set(credentialNames(req.scope, req.action));
+  let best: { row: Candidate; rank: number } | null = null;
+  for (const r of candidates) {
+    let rank = 0;
+    if (scope && normalizeScope(r.scope) === scope) rank = 3;
+    else if (names.size && credentialNames(r.scope, r.action).some((n) => names.has(n))) rank = 2;
+    else {
+      const sim = Number(r.sim ?? 0);
+      const threshold = r.agentId === req.agentId ? DUP_SIM_SELF : DUP_SIM_TEAMMATE;
+      if (sim >= threshold) rank = 1;
+    }
+    if (!rank) continue;
+    // Prefer a decided (denied/expired) match over a pending one at equal
+    // rank: a final answer beats "still waiting".
+    const decidedBoost = r.status === "pending" ? 0 : 0.5;
+    if (!best || rank + decidedBoost > best.rank) best = { row: r, rank: rank + decidedBoost };
+  }
+  if (!best) return null;
+  const { sim: _sim, ...row } = best.row;
+  return row;
+}
+
+export async function findDuplicateApproval(
+  agentId: string,
+  scope: string,
+  action: string,
+): Promise<DuplicateApproval | null> {
+  const [me] = await db
+    .select({ workspaceId: agents.workspaceId })
+    .from(agents)
+    .where(eq(agents.id, agentId))
+    .limit(1);
+  if (!me) return null;
+  const memoryCutoff = new Date(Date.now() - denialMemoryMs());
+  const normScope = normalizeScope(scope);
+  const names = credentialNames(scope, action).slice(0, 4);
+  const textMatch = [
+    sql`similarity(${approvals.action}, ${action}) > ${DUP_SIM_SELF}`,
+    ...(normScope ? [sql`lower(regexp_replace(${approvals.scope}, '[^a-zA-Z0-9*:.]+', '_', 'g')) = ${normScope}`] : []),
+    ...names.map((n) => ilike(approvals.action, `%${n}%`)),
+    ...names.map((n) => ilike(approvals.scope, `%${n}%`)),
+  ];
+  const rows = await db
+    .select({
+      id: approvals.id,
+      status: approvals.status,
+      agentId: approvals.agentId,
+      decidedAt: approvals.decidedAt,
+      decisionNote: approvals.decisionNote,
+      action: approvals.action,
+      scope: approvals.scope,
+      sim: sql<number>`similarity(${approvals.action}, ${action})`.as("sim"),
+    })
+    .from(approvals)
+    .innerJoin(agents, eq(agents.id, approvals.agentId))
+    .where(
+      and(
+        eq(agents.workspaceId, me.workspaceId),
+        or(
+          eq(approvals.status, "pending"),
+          and(or(eq(approvals.status, "denied"), eq(approvals.status, "expired")), gt(approvals.decidedAt, memoryCutoff)),
+        ),
+        or(...textMatch),
+      ),
+    )
+    .orderBy(sql`similarity(${approvals.action}, ${action}) desc`)
+    .limit(10);
+  return pickDuplicate(rows, { agentId, scope, action });
+}
+
+// Actionable rejection copy for a duplicate match. Returned as an executor
+// error so the agent reads WHY it was dropped and what to do instead. The
+// previous human note rides along on a denial — it is the answer.
+export function duplicateApprovalError(actionType: string, dup: DuplicateApproval, agentId: string): string {
+  const when = dup.decidedAt ? dup.decidedAt.toISOString().slice(0, 10) : "recently";
+  const note = dup.decisionNote ? ` Their note: "${dup.decisionNote}".` : "";
+  if (dup.status === "denied") {
+    return (
+      `${actionType} refused: a human DENIED an equivalent request (${dup.id}, "${dup.action}") on ${when}.${note} ` +
+      `A denial is final — do NOT re-request or rephrase it. Set the dependent task status:"blocked" with one comment, or pursue an approach that doesn't need this approval.`
+    );
+  }
+  if (dup.status === "expired") {
+    return (
+      `${actionType} refused: an equivalent request (${dup.id}, "${dup.action}") EXPIRED on ${when} with no human decision. ` +
+      `Do NOT re-request it — it will not be answered. Find a route that doesn't need it (built-in alternatives, a smaller scope, or hand the task back with one comment).`
+    );
+  }
+  if (dup.agentId !== agentId) {
+    return (
+      `${actionType} skipped: a teammate already has an equivalent approval pending (${dup.id}, "${dup.action}"). ` +
+      `Don't file duplicates — the human decides once for the team. Coordinate on the task card if needed.`
+    );
+  }
+  return (
+    `${actionType} skipped: your equivalent approval (${dup.id}) is already pending a human decision — ` +
+    `do not retry or rephrase it; you'll be woken with trigger:"approval_response" when it's decided.`
+  );
+}
+
+// ───────────────── expiry sweep ─────────────────
+
+// Release the tasks an agent parked on this approval. A task counts as tied
+// to the card when its body or a comment quotes the approval id (the agents
+// write "blocked pending approval of X (ap_…)" on the card). Each is moved
+// back to in_progress with one comment so the board reflects reality and the
+// agent's next wake sees live work, not a blocked card it must not touch.
+export async function unblockTasksForApproval(
+  approvalId: string,
+  workspaceId: string,
+  actorMemberId: string,
+  note: string,
+): Promise<string[]> {
+  const needle = `%${approvalId}%`;
+  const rows = await db
+    .selectDistinct({ id: tasks.id })
+    .from(tasks)
+    .leftJoin(taskComments, and(eq(taskComments.taskId, tasks.id), ilike(taskComments.bodyMd, needle)))
+    .where(
+      and(
+        eq(tasks.workspaceId, workspaceId),
+        eq(tasks.status, "blocked"),
+        eq(tasks.archived, false),
+        or(ilike(tasks.bodyMd, needle), sql`${taskComments.id} is not null`),
+      ),
+    )
+    .limit(50);
+  const released: string[] = [];
+  for (const t of rows) {
+    const upd = await updateTask(t.id, { status: "in_progress" }, actorMemberId, workspaceId).catch(() => ({ error: "update_failed" }));
+    if ("error" in upd && upd.error) continue;
+    await addComment(t.id, note, [], actorMemberId, workspaceId).catch(() => {});
+    released.push(t.id);
+  }
+  return released;
+}
+
+// Mark stale pending approvals expired, wake their agents, release blocked
+// tasks, and tell the approvers. Idempotent and race-safe (each row is
+// claimed with a status-guarded UPDATE), so it can run on every worker tick.
+// Returns the number of approvals expired. No-op when APPROVAL_TTL_HOURS=0.
+export async function expireStaleApprovals(now: Date = new Date()): Promise<number> {
+  const hours = approvalTtlHours();
+  const ttl = approvalTtlMs(hours);
+  if (ttl <= 0) return 0;
+  const cutoff = new Date(now.getTime() - ttl);
+  const stale = await db
+    .select({
+      id: approvals.id,
+      agentId: approvals.agentId,
+      conversationId: approvals.conversationId,
+      scope: approvals.scope,
+      action: approvals.action,
+      workspaceId: agents.workspaceId,
+      agentName: agents.name,
+    })
+    .from(approvals)
+    .innerJoin(agents, eq(agents.id, approvals.agentId))
+    .where(and(eq(approvals.status, "pending"), lt(approvals.createdAt, cutoff)))
+    .limit(100);
+  let n = 0;
+  for (const ap of stale) {
+    const note = expiryNote(hours);
+    const claimed = await db
+      .update(approvals)
+      .set({ status: "expired", decidedAt: now, decidedBy: null, decisionNote: note })
+      .where(and(eq(approvals.id, ap.id), eq(approvals.status, "pending")))
+      .returning({ id: approvals.id });
+    if (!claimed.length) continue;
+    n++;
+    const frame = { type: "approval.decided" as const, approvalId: ap.id, status: "expired" };
+    await publishToWorkspace(ap.workspaceId, frame).catch(() => {});
+    if (ap.conversationId) await publishToConversation(ap.conversationId, frame).catch(() => {});
+
+    const [agentMember] = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(and(eq(members.workspaceId, ap.workspaceId), eq(members.kind, "agent"), eq(members.refId, ap.agentId)))
+      .limit(1);
+    let released: string[] = [];
+    if (agentMember) {
+      released = await unblockTasksForApproval(
+        ap.id,
+        ap.workspaceId,
+        agentMember.id,
+        `Approval ${ap.id} ("${ap.action}") expired after ${hours}h with no human decision. Unblocked automatically — the assignee will pursue a route that does not need it or hand the task back.`,
+      ).catch(() => []);
+    }
+    await enqueueAgentEvent(ap.agentId, {
+      trigger: "approval_response",
+      approvalId: ap.id,
+      status: "expired",
+      conversationId: ap.conversationId ?? undefined,
+    }).catch((e) => console.error("[approvals] expiry wake failed", (e as Error).message));
+    await notifyApprovers(ap.workspaceId, {
+      kind: "system",
+      title: `Approval expired: ${ap.agentName} — ${ap.scope}`,
+      body:
+        `"${ap.action}" waited ${hours}h without a decision and was closed. The agent has been told to find another route` +
+        (released.length ? `; ${released.length} blocked task(s) were moved back to in progress.` : "."),
+      link: "/approvals",
+    });
+    console.log(`[approvals] expired ${ap.id} (${ap.scope}) agent=${ap.agentId} released=${released.length}`);
+  }
+  return n;
+}

--- a/api/src/lib/budgets.ts
+++ b/api/src/lib/budgets.ts
@@ -1,7 +1,7 @@
-import { and, eq, gte, inArray, sql } from "drizzle-orm";
+import { and, eq, gte, sql } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { agents, agentRuns, members, workspaces, workspaceMembers } from "../db/schema.js";
-import { notifyMany } from "./notifications.js";
+import { agents, agentRuns, workspaces } from "../db/schema.js";
+import { notifyMany, adminMemberIds } from "./notifications.js";
 
 // Monthly spend budgets with hard stops, modeled on Paperclip's budget scopes:
 // soft warning at 80%, hard stop at 100%. Two scopes — per-agent (pauses that
@@ -71,26 +71,6 @@ export async function workspaceSpendMonthUsd(workspaceId: string, now: Date = ne
     .innerJoin(agents, eq(agents.id, agentRuns.agentId))
     .where(and(eq(agents.workspaceId, workspaceId), gte(agentRuns.startedAt, monthStartUtc(now))));
   return row?.spent ?? 0;
-}
-
-// Workspace admins' user-member ids (the inbox recipients for budget alerts).
-async function adminMemberIds(workspaceId: string): Promise<string[]> {
-  const admins = await db
-    .select({ userId: workspaceMembers.userId })
-    .from(workspaceMembers)
-    .where(and(eq(workspaceMembers.workspaceId, workspaceId), eq(workspaceMembers.role, "admin")));
-  if (!admins.length) return [];
-  const rows = await db
-    .select({ id: members.id })
-    .from(members)
-    .where(
-      and(
-        eq(members.workspaceId, workspaceId),
-        eq(members.kind, "user"),
-        inArray(members.refId, admins.map((a) => a.userId)),
-      ),
-    );
-  return rows.map((r) => r.id);
 }
 
 export type BudgetGate =

--- a/api/src/lib/completion.ts
+++ b/api/src/lib/completion.ts
@@ -1,24 +1,85 @@
 // OpenAI-compatible chat-completions client, configured entirely via env so it
 // can point at any /v1/chat/completions backend (the FreeLLMAPI gateway,
 // OpenAI, a local model). Used server-side by the goal planner to decompose a
-// goal into a task graph — the API doing the reasoning directly rather than
-// routing through an agent runtime, so planning works even with zero agents
-// online and is deterministic enough to validate against a schema.
+// goal into a task graph and by the verification judge — the API doing the
+// reasoning directly rather than routing through an agent runtime.
 //
-//   PLANNER_BASE_URL  e.g. http://127.0.0.1:3001/v1  (the /v1 root)
-//                     falls back to EMBEDDINGS_BASE_URL (same gateway)
-//   PLANNER_API_KEY   bearer token; falls back to EMBEDDINGS_API_KEY
-//   PLANNER_MODEL     model name; default "auto" (FreeLLMAPI picks the chain)
+// Two targets resolve from env:
 //
-// Fully dormant unless a base URL resolves, so the planner degrades to a clear
-// "planner_unconfigured" error rather than throwing.
-const baseUrl = (): string =>
-  (process.env.PLANNER_BASE_URL || process.env.EMBEDDINGS_BASE_URL || "").replace(/\/+$/, "");
-const apiKey = (): string => process.env.PLANNER_API_KEY || process.env.EMBEDDINGS_API_KEY || "";
-const model = (): string => process.env.PLANNER_MODEL || "auto";
+//   PLANNER (goal/mission planner):
+//     PLANNER_BASE_URL   e.g. http://127.0.0.1:3001/v1  (the /v1 root)
+//                        LEGACY fallback: EMBEDDINGS_BASE_URL (same gateway).
+//                        The fallback is kept so existing deployments keep
+//                        planning, but it is logged once — an embeddings
+//                        endpoint is not guaranteed to serve chat.
+//     PLANNER_API_KEY    bearer token; falls back to EMBEDDINGS_API_KEY
+//     PLANNER_MODEL      model name; default "auto" (FreeLLMAPI picks the chain)
+//
+//   JUDGE (verification gate, see task-verifier.ts):
+//     VERIFY_JUDGE_BASE_URL  falls back to PLANNER_BASE_URL — NEVER to
+//                            EMBEDDINGS_BASE_URL. A judge that silently talks
+//                            to an embeddings-only deployment produced weeks
+//                            of "unreachable — failing open" rows; the judge
+//                            must be pointed at a chat-capable URL explicitly.
+//     VERIFY_JUDGE_API_KEY   falls back to PLANNER_API_KEY, then EMBEDDINGS_API_KEY
+//     VERIFY_JUDGE_MODEL     falls back to PLANNER_MODEL, then "auto"
+//
+// Fully dormant unless a base URL resolves, so callers degrade to a clear
+// "unconfigured" state rather than throwing.
 
+export interface ChatTarget {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+type EnvLike = Record<string, string | undefined>;
+
+const trimUrl = (u: string | undefined): string => (u || "").replace(/\/+$/, "");
+
+// Planner target. Pure (takes env) so it can be unit-tested.
+export function resolvePlannerTarget(env: EnvLike = process.env): ChatTarget | null {
+  const baseUrl = trimUrl(env.PLANNER_BASE_URL) || trimUrl(env.EMBEDDINGS_BASE_URL);
+  if (!baseUrl) return null;
+  return {
+    baseUrl,
+    apiKey: env.PLANNER_API_KEY || env.EMBEDDINGS_API_KEY || "",
+    model: env.PLANNER_MODEL || "auto",
+  };
+}
+
+// True when the planner is only reachable via the legacy embeddings fallback.
+export function plannerUsesEmbeddingsFallback(env: EnvLike = process.env): boolean {
+  return !trimUrl(env.PLANNER_BASE_URL) && !!trimUrl(env.EMBEDDINGS_BASE_URL);
+}
+
+// Judge target. Requires an EXPLICIT chat URL (VERIFY_JUDGE_BASE_URL or
+// PLANNER_BASE_URL); an embeddings-only configuration yields null.
+export function resolveJudgeTarget(env: EnvLike = process.env): ChatTarget | null {
+  const baseUrl = trimUrl(env.VERIFY_JUDGE_BASE_URL) || trimUrl(env.PLANNER_BASE_URL);
+  if (!baseUrl) return null;
+  return {
+    baseUrl,
+    apiKey: env.VERIFY_JUDGE_API_KEY || env.PLANNER_API_KEY || env.EMBEDDINGS_API_KEY || "",
+    model: env.VERIFY_JUDGE_MODEL || env.PLANNER_MODEL || "auto",
+  };
+}
+
+let warnedFallback = false;
 export function plannerEnabled(): boolean {
-  return !!baseUrl();
+  const t = resolvePlannerTarget();
+  if (t && !warnedFallback && plannerUsesEmbeddingsFallback()) {
+    warnedFallback = true;
+    console.warn(
+      `[completion] PLANNER_BASE_URL is not set — the planner is using EMBEDDINGS_BASE_URL (${t.baseUrl}) for chat/completions with model=${t.model}. ` +
+        `Set PLANNER_BASE_URL (+ PLANNER_MODEL, PLANNER_API_KEY) explicitly to a chat-capable endpoint.`,
+    );
+  }
+  return !!t;
+}
+
+export function judgeConfigured(): boolean {
+  return !!resolveJudgeTarget();
 }
 
 export interface ChatMessage {
@@ -26,40 +87,66 @@ export interface ChatMessage {
   content: string;
 }
 
+export interface ChatOpts {
+  temperature?: number;
+  maxTokens?: number;
+  timeoutMs?: number;
+  // Which endpoint/model to call. Defaults to the planner target.
+  target?: ChatTarget | null;
+}
+
+// Diagnostics for the "returned null" path. Every consumer of this client
+// fails soft (planner errors out, verifier fails open/holds), so without a log
+// line here a dead gateway is invisible. Throttled per (target, reason) so a
+// rate-limited gateway doesn't flood the log on every retry.
+const lastDiag = new Map<string, number>();
+const DIAG_THROTTLE_MS = 60_000;
+export function noteChatFailure(target: ChatTarget, reason: string, detail = ""): void {
+  const key = `${target.baseUrl}|${target.model}|${reason}`;
+  const now = Date.now();
+  const last = lastDiag.get(key) ?? 0;
+  if (now - last < DIAG_THROTTLE_MS) return;
+  lastDiag.set(key, now);
+  console.warn(
+    `[completion] chat/completions failed: ${reason} (${target.baseUrl} model=${target.model})${detail ? ` — ${detail.slice(0, 300)}` : ""}`,
+  );
+}
+
 // Call chat/completions and return the assistant's raw text, or null on any
 // failure (unconfigured, network, bad shape). Callers decide how to treat null.
 //
-// A PINNED model (PLANNER_MODEL set to something other than "auto") falls back
-// to "auto" when the pinned call fails. Rationale: the pin exists for judge
+// A PINNED model (model set to something other than "auto") falls back to
+// "auto" when the pinned call fails. Rationale: the pin exists for judge
 // consistency, but pinned free-tier models get rate-limited for hours at a
-// time, and every consumer of this client fails soft (planner errors out,
-// verifier fails open) — so a dead pin silently disables planning AND
-// verification until someone notices. A drifting judge beats a dormant one.
-export async function chat(
-  messages: ChatMessage[],
-  opts: { temperature?: number; maxTokens?: number; timeoutMs?: number } = {},
-): Promise<string | null> {
-  const first = await chatWithModel(model(), messages, opts);
-  if (first !== null || model() === "auto") return first;
-  console.warn(`[completion] pinned model ${model()} failed — retrying with model=auto`);
-  return chatWithModel("auto", messages, opts);
+// time, and every consumer of this client fails soft — so a dead pin silently
+// disables planning AND verification until someone notices. A drifting judge
+// beats a dormant one.
+export async function chat(messages: ChatMessage[], opts: ChatOpts = {}): Promise<string | null> {
+  const target = opts.target === undefined ? resolvePlannerTarget() : opts.target;
+  if (!target) return null;
+  const first = await chatWithModel(target, target.model, messages, opts);
+  if (first !== null || target.model === "auto") return first;
+  console.warn(`[completion] pinned model ${target.model} failed — retrying with model=auto`);
+  return chatWithModel(target, "auto", messages, opts);
 }
 
 async function chatWithModel(
+  target: ChatTarget,
   modelName: string,
   messages: ChatMessage[],
-  opts: { temperature?: number; maxTokens?: number; timeoutMs?: number } = {},
+  opts: ChatOpts = {},
 ): Promise<string | null> {
-  if (!plannerEnabled()) return null;
   const controller = new AbortController();
-  const t = setTimeout(() => controller.abort(), opts.timeoutMs ?? 60_000);
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  const at = { ...target, model: modelName };
   try {
-    const res = await fetch(`${baseUrl()}/chat/completions`, {
+    const res = await fetch(`${target.baseUrl}/chat/completions`, {
       method: "POST",
       signal: controller.signal,
       headers: {
         "Content-Type": "application/json",
-        ...(apiKey() ? { Authorization: `Bearer ${apiKey()}` } : {}),
+        ...(target.apiKey ? { Authorization: `Bearer ${target.apiKey}` } : {}),
       },
       body: JSON.stringify({
         model: modelName,
@@ -68,13 +155,24 @@ async function chatWithModel(
         ...(opts.maxTokens ? { max_tokens: opts.maxTokens } : {}),
       }),
     });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      noteChatFailure(at, `http_${res.status}`, body);
+      return null;
+    }
     const json = (await res.json()) as {
       choices?: Array<{ message?: { content?: string } }>;
+      error?: unknown;
     };
     const text = json.choices?.[0]?.message?.content;
-    return typeof text === "string" ? text : null;
-  } catch {
+    if (typeof text !== "string") {
+      noteChatFailure(at, "bad_shape", JSON.stringify(json.error ?? json).slice(0, 200));
+      return null;
+    }
+    return text;
+  } catch (e) {
+    const aborted = (e as Error)?.name === "AbortError";
+    noteChatFailure(at, aborted ? `timeout_${timeoutMs}ms` : "network", aborted ? "" : (e as Error)?.message ?? "");
     return null;
   } finally {
     clearTimeout(t);
@@ -149,11 +247,12 @@ export function extractJson<T = unknown>(text: string | null): T | null {
 
 // Convenience: chat() then extractJson(). Retries once with a terser nudge if
 // the first reply doesn't parse — small models sometimes need a second push.
-export async function chatJson<T = unknown>(
-  messages: ChatMessage[],
-  opts: { temperature?: number; maxTokens?: number; timeoutMs?: number } = {},
-): Promise<T | null> {
+// A null FIRST reply (transport failure) is NOT retried with the nudge: the
+// nudge fixes formatting, not a dead gateway, and doubling calls against a
+// rate-limited endpoint only deepens the outage.
+export async function chatJson<T = unknown>(messages: ChatMessage[], opts: ChatOpts = {}): Promise<T | null> {
   const first = await chat(messages, opts);
+  if (first === null) return null;
   const parsed = extractJson<T>(first);
   if (parsed !== null) return parsed;
   const retry = await chat(

--- a/api/src/lib/config.ts
+++ b/api/src/lib/config.ts
@@ -18,3 +18,46 @@ export const config = {
   // or a trailing slash in operator-managed deployments).
   publicOrigin: new URL(required("PUBLIC_BASE_URL", "http://localhost:5173")).origin,
 } as const;
+
+// ───────────────── approval policy (read at call time, so tests + hot env
+// changes work) ─────────────────
+//
+// Anything here changes how much a human must be in the loop, so every
+// default is the conservative one: cards expire (so nothing waits forever),
+// denials are remembered (so agents can't re-ask), and nothing is
+// auto-approved unless an operator lists it.
+
+const num = (name: string, fallback: number, min = 0): number => {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === "") return fallback;
+  const v = Number(raw);
+  return Number.isFinite(v) && v >= min ? v : fallback;
+};
+
+// Hours a pending approval may wait for a human before it is marked
+// `expired`, the agent is woken with approval_response status "expired", and
+// tasks blocked on it are released. 0 = never expire (the legacy behaviour).
+// APPROVAL_DEFAULT_TTL is accepted as an alias.
+export function approvalTtlHours(): number {
+  if (process.env.APPROVAL_TTL_HOURS != null && process.env.APPROVAL_TTL_HOURS.trim() !== "") {
+    return num("APPROVAL_TTL_HOURS", 72);
+  }
+  return num("APPROVAL_DEFAULT_TTL", 72);
+}
+
+// Days a denied (or expired) approval keeps refusing equivalent re-requests.
+export function approvalDenialMemoryDays(): number {
+  return num("APPROVAL_DENIAL_MEMORY_DAYS", 7);
+}
+
+// Comma-separated approval scopes that are auto-approved (with an audit row)
+// for every agent in the deployment. Entries match an approval's scope
+// exactly (case-insensitive) or by prefix with a trailing `*`
+// (`tasks.*`, `risk:*`, `deploy*`). Credential requests are never
+// auto-approved — approving them produces no secret. Empty by default.
+export function autoApproveScopes(): string[] {
+  return (process.env.AUTO_APPROVE_SCOPES ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}

--- a/api/src/lib/internal-request.ts
+++ b/api/src/lib/internal-request.ts
@@ -1,0 +1,44 @@
+import { config } from "./config.js";
+
+// Guard for process-internal HTTP endpoints (currently /_internal/agent-dispatch,
+// which the worker uses to reach a connected agent socket). They carry no user
+// auth, so they must only ever be callable from inside the deployment. Two ways
+// to qualify:
+//   1. `x-internal-token` equal to SESSION_SECRET (api + worker already share
+//      it) — the explicit, proxy-agnostic path; or
+//   2. the TCP peer is a loopback/private address AND the request did not come
+//      through a proxy hop (no X-Forwarded-For / X-Real-IP). Caddy always adds
+//      X-Forwarded-For, so a public client can't reach it through the edge,
+//      and a public client hitting the port directly has a public peer address.
+// Before this, in the single-port deploy (API serving the web bundle — which is
+// why the SPA 404 handler special-cases /_internal/) anyone on the internet
+// could push arbitrary heartbeat/event packets to any connected agent by id.
+
+export function isPrivateAddress(ip: string | undefined | null): boolean {
+  if (!ip) return false;
+  const v = ip.startsWith("::ffff:") ? ip.slice(7) : ip;
+  if (v === "127.0.0.1" || v === "::1" || v === "localhost") return true;
+  if (/^127\./.test(v)) return true;
+  if (/^10\./.test(v)) return true;
+  if (/^192\.168\./.test(v)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(v)) return true;
+  if (/^169\.254\./.test(v)) return true;
+  if (/^f[cd][0-9a-f]{2}:/i.test(v)) return true; // fc00::/7 (unique local)
+  if (/^fe[89ab][0-9a-f]:/i.test(v)) return true; // fe80::/10 (link local)
+  return false;
+}
+
+export interface InternalRequestLike {
+  headers: Record<string, string | string[] | undefined>;
+  socket?: { remoteAddress?: string };
+  raw?: { socket?: { remoteAddress?: string } };
+}
+
+export function isInternalRequest(req: InternalRequestLike, secret: string = config.sessionSecret): boolean {
+  const token = req.headers["x-internal-token"];
+  if (typeof token === "string" && token.length > 0 && secret && token === secret) return true;
+  const forwarded = req.headers["x-forwarded-for"] ?? req.headers["x-real-ip"];
+  if (forwarded) return false;
+  const peer = req.raw?.socket?.remoteAddress ?? req.socket?.remoteAddress;
+  return isPrivateAddress(peer);
+}

--- a/api/src/lib/model-routing.ts
+++ b/api/src/lib/model-routing.ts
@@ -67,17 +67,64 @@ export function calculateUsageCost(usage: ReportedModelUsage, route: ModelRouteR
   );
 }
 
-export function normalizeUsage(input: ReportedModelUsage): ReportedModelUsage {
+// Loose shape a runtime/bridge/gateway may hand us. Runtimes disagree on key
+// names — OpenAI-compatible gateways report `prompt_tokens`/`completion_tokens`,
+// Anthropic-style `input_tokens`/`output_tokens`, some bridges camelCase. The
+// fishbowl recorded output_tokens=0 on 1,130/1,130 rows because nothing ever
+// arrived under `outputTokens`; accept every common spelling so a report is
+// never silently zeroed.
+export interface ReportedModelUsageInput {
+  provider?: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number;
+  costUsd?: number;
+  // aliases
+  input_tokens?: number;
+  output_tokens?: number;
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  promptTokens?: number;
+  completionTokens?: number;
+  cached_input_tokens?: number;
+  cache_read_input_tokens?: number;
+  cachedTokens?: number;
+  total_tokens?: number;
+  totalTokens?: number;
+  cost_usd?: number;
+  cost?: number;
+}
+
+function firstFinite(...values: Array<number | undefined>): number | undefined {
+  for (const v of values) if (typeof v === "number" && Number.isFinite(v)) return v;
+  return undefined;
+}
+
+export function normalizeUsage(input: ReportedModelUsageInput): ReportedModelUsage {
   const integer = (value: number | undefined): number =>
     Number.isFinite(value) ? Math.max(0, Math.floor(value!)) : 0;
+  const inputRaw = firstFinite(input.inputTokens, input.input_tokens, input.prompt_tokens, input.promptTokens);
+  let outputRaw = firstFinite(input.outputTokens, input.output_tokens, input.completion_tokens, input.completionTokens);
+  const total = firstFinite(input.total_tokens, input.totalTokens);
+  // Only a total and an input → derive output rather than record 0.
+  if (outputRaw === undefined && total !== undefined && inputRaw !== undefined) {
+    outputRaw = Math.max(0, total - inputRaw);
+  }
+  const cachedRaw = firstFinite(
+    input.cachedInputTokens,
+    input.cached_input_tokens,
+    input.cache_read_input_tokens,
+    input.cachedTokens,
+  );
+  const costRaw = firstFinite(input.costUsd, input.cost_usd, input.cost);
+  const inputTokens = integer(inputRaw);
   return {
     provider: input.provider?.slice(0, 60),
     model: input.model?.slice(0, 120),
-    inputTokens: integer(input.inputTokens),
-    outputTokens: integer(input.outputTokens),
-    cachedInputTokens: Math.min(integer(input.cachedInputTokens), integer(input.inputTokens)),
-    ...(input.costUsd != null && Number.isFinite(input.costUsd)
-      ? { costUsd: Math.max(0, input.costUsd) }
-      : {}),
+    inputTokens,
+    outputTokens: integer(outputRaw),
+    cachedInputTokens: Math.min(integer(cachedRaw), inputTokens),
+    ...(costRaw != null ? { costUsd: Math.max(0, costRaw) } : {}),
   };
 }

--- a/api/src/lib/model-usage-store.ts
+++ b/api/src/lib/model-usage-store.ts
@@ -8,7 +8,7 @@ import {
   normalizeUsage,
   selectConfiguredRoute,
   type ModelRouteRecord,
-  type ReportedModelUsage,
+  type ReportedModelUsageInput,
 } from "./model-routing.js";
 
 export async function modelRecommendation(input: {
@@ -38,7 +38,7 @@ export async function recordModelUsage(input: {
   agentId: string;
   runId: string;
   routeTier?: string | null;
-  usage: ReportedModelUsage;
+  usage: ReportedModelUsageInput;
   source: "reported" | "estimated";
   eventKey?: string;
 }): Promise<{ tokens: number; costUsd: number }> {
@@ -49,7 +49,18 @@ export async function recordModelUsage(input: {
     (input.routeTier as "economy" | "balanced" | "frontier" | "advisor") ?? "balanced",
   );
   const costUsd = calculateUsageCost(usage, route);
-  const [agent] = await db.select({ model: agents.model }).from(agents).where(eq(agents.id, input.agentId)).limit(1);
+  const [agent] = await db
+    .select({ model: agents.model, configJson: agents.configJson })
+    .from(agents)
+    .where(eq(agents.id, input.agentId))
+    .limit(1);
+  // Last-resort provider/model: what the agent was installed with, if the
+  // installer recorded it (configJson.provider / configJson.model). Better
+  // than "unknown"/"auto" when neither the runtime nor a model route says.
+  const cfg = (agent?.configJson ?? {}) as { provider?: unknown; model?: unknown };
+  const cfgProvider = typeof cfg.provider === "string" && cfg.provider ? cfg.provider.slice(0, 60) : null;
+  const cfgModel = typeof cfg.model === "string" && cfg.model ? cfg.model.slice(0, 120) : null;
+  const agentModel = agent?.model && agent.model !== "auto" ? agent.model : null;
   const usageId = id("usage");
   const eventKey = input.eventKey ?? usageId;
   const values = {
@@ -58,8 +69,8 @@ export async function recordModelUsage(input: {
     agentId: input.agentId,
     runId: input.runId,
     eventKey,
-    provider: usage.provider ?? route?.provider ?? "unknown",
-    model: usage.model ?? route?.model ?? agent?.model ?? "unknown",
+    provider: usage.provider ?? route?.provider ?? cfgProvider ?? "unknown",
+    model: usage.model ?? route?.model ?? agentModel ?? cfgModel ?? agent?.model ?? "unknown",
     routeTier: input.routeTier ?? null,
     inputTokens: usage.inputTokens,
     outputTokens: usage.outputTokens,

--- a/api/src/lib/notifications.ts
+++ b/api/src/lib/notifications.ts
@@ -7,6 +7,7 @@ import {
   conversationMembers,
   users,
   agents,
+  workspaceMembers,
 } from "../db/schema.js";
 import { id } from "./ids.js";
 import { publishToMember } from "./events.js";
@@ -177,4 +178,64 @@ export async function humanMembersOf(memberIds: string[]): Promise<string[]> {
     .from(members)
     .where(and(inArray(members.id, unique), eq(members.kind, "user")));
   return rows.map((r) => r.id);
+}
+
+// Workspace admins' user-member ids — the default inbox for anything that
+// needs a human decision (budget alerts, approvals, expiries).
+export async function adminMemberIds(workspaceId: string): Promise<string[]> {
+  const admins = await db
+    .select({ userId: workspaceMembers.userId })
+    .from(workspaceMembers)
+    .where(and(eq(workspaceMembers.workspaceId, workspaceId), eq(workspaceMembers.role, "admin")));
+  if (!admins.length) return [];
+  const rows = await db
+    .select({ id: members.id })
+    .from(members)
+    .where(
+      and(
+        eq(members.workspaceId, workspaceId),
+        eq(members.kind, "user"),
+        inArray(members.refId, admins.map((a) => a.userId)),
+      ),
+    );
+  return rows.map((r) => r.id);
+}
+
+// Who gets told about an approval: the admins; if a workspace has none (a
+// solo owner whose role row was never set, an imported workspace), every
+// human member — an approval card that nobody is told about is exactly the
+// silent-forever queue observed in the wild (5 cards pending for two months
+// with no notification ever written).
+export async function approverMemberIds(workspaceId: string): Promise<string[]> {
+  const admins = await adminMemberIds(workspaceId);
+  if (admins.length) return admins;
+  const rows = await db
+    .select({ id: members.id })
+    .from(members)
+    .where(and(eq(members.workspaceId, workspaceId), eq(members.kind, "user")));
+  return rows.map((r) => r.id);
+}
+
+// Inbox + live event for every approver when an approval is opened, expired,
+// or auto-approved. Best-effort: never throws (an inbox hiccup must not fail
+// the agent's action). The body never carries payloads or secret values —
+// only the agent, the scope, and the human-readable ask.
+export async function notifyApprovers(
+  workspaceId: string,
+  msg: { kind?: NotificationKind; title: string; body: string; link?: string; actorMemberId?: string | null },
+): Promise<void> {
+  try {
+    const recipients = await approverMemberIds(workspaceId);
+    if (!recipients.length) return;
+    await notifyMany(recipients, {
+      workspaceId,
+      kind: msg.kind ?? "approval",
+      actorMemberId: msg.actorMemberId ?? null,
+      title: msg.title,
+      body: msg.body,
+      link: msg.link ?? "/approvals",
+    });
+  } catch (e) {
+    console.error("[notifications] approver fan-out failed", (e as Error).message);
+  }
 }

--- a/api/src/lib/project-files.ts
+++ b/api/src/lib/project-files.ts
@@ -1,5 +1,6 @@
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { embed, cosine, embeddingsEnabled } from "./embeddings.js";
+import { findNearDuplicate } from "./text-similarity.js";
 
 // ─────────────────────────── Shared project memory ───────────────────────────
 // A file-based "blackboard" the agents form and manage themselves: multiple
@@ -136,6 +137,60 @@ export function serializeProjectFile(meta: ProjectFileMeta, body: string): strin
   return `${head}${body.trim()}\n`;
 }
 
+// ─────────────────────────── entries (append log) ───────────────────────────
+// Every append writes `## <date> · @handle\n<note>`. Split a body into the
+// free-form head (anything before the first provenance header — e.g. a brief
+// written via mode:"replace") and the dated entries, oldest first.
+const ENTRY_HEADER_RE = /^## [^\n]*? · @[a-z0-9][a-z0-9._-]*[ \t]*$/im;
+const ENTRY_SPLIT_RE = /(?=^## [^\n]*? · @[a-z0-9][a-z0-9._-]*[ \t]*$)/im;
+
+export function splitEntries(body: string): { head: string; entries: string[] } {
+  const text = (body || "").trim();
+  if (!text) return { head: "", entries: [] };
+  const first = ENTRY_HEADER_RE.exec(text);
+  if (!first) return { head: text, entries: [] };
+  const head = text.slice(0, first.index).trim();
+  const rest = text.slice(first.index);
+  // Split on every header (the lookahead keeps the header with its entry).
+  const parts = rest.split(new RegExp(ENTRY_SPLIT_RE.source, "gim")).map((e) => e.trim()).filter(Boolean);
+  return { head, entries: parts };
+}
+
+// The note text of an entry (header line dropped) — what dedupe compares.
+function entryNote(entry: string): string {
+  return entry.replace(/^## [^\n]*\n?/, "").trim();
+}
+
+// Append dedupe: an incoming note ≥ this similar to one of the last
+// DEDUPE_WINDOW entries is a restatement, not new state. Live status.md had
+// "Self-hosted HLS relay verified live" appended four times by two agents in
+// three hours.
+export const APPEND_DEDUPE_THRESHOLD = 0.85;
+const DEDUPE_WINDOW = 12;
+
+// Rolling compaction so an append-only status log can't grow without bound
+// (live: 20 KB / 308 lines / 90 dated entries, re-injected into every prompt).
+// After an append, when the log has more than KEEP_ENTRIES entries OR the body
+// is over COMPACT_AT_CHARS, the OLDEST entries are moved out to
+// <project>/archive/<file> until it fits (never below MIN_KEEP entries). The
+// head (brief text) is always kept.
+export const KEEP_ENTRIES = 25;
+export const COMPACT_AT_CHARS = 8000;
+const MIN_KEEP = 8;
+
+export function compactEntries(
+  head: string,
+  entries: string[],
+): { body: string; archived: string[] } {
+  const kept = [...entries];
+  const archived: string[] = [];
+  const render = () => [head, ...kept].filter(Boolean).join("\n\n");
+  while (kept.length > MIN_KEEP && (kept.length > KEEP_ENTRIES || render().length > COMPACT_AT_CHARS)) {
+    archived.push(kept.shift() as string);
+  }
+  return { body: render(), archived };
+}
+
 // ─────────────────────────── pure write logic ───────────────────────────
 
 export type ProjectWriteMode = "append" | "replace";
@@ -158,7 +213,7 @@ export function applyProjectWrite(
     actorHandle: string;
     dateLabel: string;
   },
-): { content: string } | { error: string } {
+): { content: string; archived?: string[] } | { error: string } {
   const note = (p.note ?? "").trim();
   if (!note) return { error: "project_note: note is empty — nothing to record." };
   const handle = (p.actorHandle || "agent").replace(/^@/, "");
@@ -187,11 +242,41 @@ export function applyProjectWrite(
   if (typeof p.always === "boolean") meta.always = p.always;
   meta.updatedBy = handle;
 
-  const body =
-    p.mode === "replace"
-      ? note
-      : `${(existing?.body ?? "").trim()}${existing?.body ? "\n\n" : ""}## ${p.dateLabel} · @${handle}\n${note}`;
+  if (p.mode === "replace") {
+    if (note.length > PROJECT_FILE_MAX_CHARS) {
+      return {
+        error:
+          `project_note: this file would exceed its ${PROJECT_FILE_MAX_CHARS}-char limit (${note.length}). ` +
+          `Rewrite it concisely keeping only what still matters.`,
+      };
+    }
+    return { content: serializeProjectFile(meta, note) };
+  }
 
+  // ── append ──
+  const { head, entries } = splitEntries(existing?.body ?? "");
+  // Near-duplicate of a recent entry → refuse (teaching error). Compare the
+  // note against the last DEDUPE_WINDOW entries regardless of author: two
+  // agents recording the same fact is still one fact.
+  const recent = entries.slice(-DEDUPE_WINDOW).reverse().map((e) => ({ bodyMd: entryNote(e), entry: e }));
+  const dup = findNearDuplicate(note, recent, APPEND_DEDUPE_THRESHOLD);
+  if (dup) {
+    const who = /· @([a-z0-9._-]+)/i.exec(dup.candidate.entry)?.[1];
+    return {
+      error:
+        `project_note skipped: this note is a near-duplicate (${Math.round(dup.score * 100)}%) of an entry already in the file` +
+        `${who ? ` (by @${who})` : ""}. The tracker records each fact ONCE — don't re-append a status that's already there. ` +
+        `Only write when something actually changed, and say what changed.`,
+    };
+  }
+  if (note.length > PROJECT_FILE_MAX_CHARS / 2) {
+    return {
+      error:
+        `project_note: a single entry can't exceed ${PROJECT_FILE_MAX_CHARS / 2} chars (${note.length}). ` +
+        `Record the durable fact in a few lines; put long-form material in a /workspace file and reference it.`,
+    };
+  }
+  const { body, archived } = compactEntries(head, [...entries, `## ${p.dateLabel} · @${handle}\n${note}`]);
   if (body.length > PROJECT_FILE_MAX_CHARS) {
     return {
       error:
@@ -199,7 +284,9 @@ export function applyProjectWrite(
         `Compact it with mode:"replace" — rewrite it concisely keeping only what still matters — instead of appending more.`,
     };
   }
-  return { content: serializeProjectFile(meta, body) };
+  return archived.length
+    ? { content: serializeProjectFile(meta, body), archived }
+    : { content: serializeProjectFile(meta, body) };
 }
 
 // ─────────────────────────── per-path write serialization ───────────────────
@@ -268,6 +355,14 @@ export async function writeProjectFile(params: {
     if ("error" in res) return res;
     try {
       await fsp.mkdir(dir, { recursive: true });
+      // Compacted-out entries go to <project>/archive/<file> (append-only).
+      // A subdirectory, so the index scan (files only) never picks it up and
+      // the archive is never re-injected into prompts — still `cat`-able.
+      if (res.archived && res.archived.length) {
+        const archDir = join(dir, "archive");
+        await fsp.mkdir(archDir, { recursive: true });
+        await fsp.appendFile(join(archDir, fileName), res.archived.join("\n\n") + "\n\n", "utf8");
+      }
       await fsp.writeFile(abs, res.content, "utf8");
     } catch (e) {
       return { error: `project_note: could not write the file (${(e as Error).message}).` };
@@ -504,6 +599,37 @@ export async function semanticMatchProjectFiles(
   );
 }
 
+// What to inject from a file body under a char cap. A plain document takes its
+// lead. An append LOG is newest-at-the-bottom, so a head slice would inject the
+// OLDEST entries and never the current status (the live bug: status.md was
+// 20 KB, the 1600-char lead never moved). Keep the head (brief text) plus as
+// many of the NEWEST entries as fit, and say how many were omitted.
+export function excerptForInjection(body: string, max: number): string {
+  const text = (body || "").trim();
+  if (text.length <= max) return text;
+  const { head, entries } = splitEntries(text);
+  if (!entries.length) return text.slice(0, max);
+  const headPart = head.length > Math.floor(max * 0.4) ? head.slice(0, Math.floor(max * 0.4)).trimEnd() + " …" : head;
+  const picked: string[] = [];
+  let used = headPart.length;
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i];
+    const cost = e.length + 2;
+    if (picked.length && used + cost > max - 80) break;
+    if (!picked.length && used + cost > max - 80) {
+      // Even the newest entry doesn't fit — take its head so the latest state still shows.
+      picked.unshift(e.slice(0, Math.max(0, max - 80 - used)).trimEnd() + " …");
+      used = max;
+      break;
+    }
+    picked.unshift(e);
+    used += cost;
+  }
+  const omitted = entries.length - picked.length;
+  const marker = omitted > 0 ? `…(${omitted} older entr${omitted === 1 ? "y" : "ies"} omitted — cat the file for the full log)` : "";
+  return [headPart, marker, ...picked].filter(Boolean).join("\n\n");
+}
+
 // Read the bodies of the matched files within the injection budget.
 async function readProjectFileBodies(
   matched: ProjectFileInfo[],
@@ -518,7 +644,7 @@ async function readProjectFileBodies(
     if (!raw.trim()) continue;
     const { body } = parseProjectFile(raw);
     if (!body) continue;
-    const content = body.slice(0, FILE_INJECT_MAX_CHARS);
+    const content = excerptForInjection(body, FILE_INJECT_MAX_CHARS);
     if (total + content.length > FILES_TOTAL_MAX_CHARS) break;
     total += content.length;
     out.push({ project: basename(dirname(f.path)), name: f.name, content });

--- a/api/src/lib/run-outcome.ts
+++ b/api/src/lib/run-outcome.ts
@@ -1,0 +1,88 @@
+// Run accounting — turn what a runtime actually did into an honest
+// agent_runs.status / error_text, and decide how hard to back off an agent's
+// scheduled heartbeat when it keeps producing nothing.
+//
+// Before this, EVERY run that didn't throw at the transport layer was written
+// as status=ok with error_text=null — including runs where the bridge crashed
+// and returned an empty reply, runs whose every action was rejected by the
+// reply guard, and runaway turns that hit the runtime's max-iterations cap and
+// posted a "⚠️ Reached maximum iterations" banner. 1,466 rows / 7 days on the
+// fishbowl, all ok, while the bridge log was full of skips. The stuck detector
+// and run reaper key on status/error_text, so they had nothing to act on.
+//
+// Pure functions only (no db/redis) so they are unit-testable; the worker and
+// scheduler wire them to storage.
+
+export interface RunResponseLike {
+  actions: unknown[];
+  trace?: string[];
+  // Optional explicit failure reason from the runtime/bridge (e.g. "empty_reply").
+  error?: string;
+}
+
+export interface ApplyOutcomeLike {
+  actionsApplied: number;
+  errors: string[];
+}
+
+export type RunClass =
+  | { status: "ok"; productive: true; errorText: null }
+  | { status: "ok"; productive: false; errorText: null; idle: true }
+  | { status: "failed"; productive: false; errorText: string };
+
+// Hermes/OpenClaw print this when the agent loop hits max_turns without
+// finishing; the bridge forwards it as ordinary prose, so it lands in a
+// post_message / task_comment body.
+export const RUNAWAY_BANNER_RE = /reached maximum iterations\s*\(\d+\)/i;
+// The bridge's catch-all trace line: `${handle} error: ${message}`.
+const BRIDGE_ERROR_TRACE_RE = /^\S+ error: (.+)$/;
+
+function bodyOf(action: unknown): string {
+  if (!action || typeof action !== "object") return "";
+  const a = action as Record<string, unknown>;
+  return typeof a.body_md === "string" ? a.body_md : "";
+}
+
+export function classifyRunOutcome(
+  response: RunResponseLike | "HEARTBEAT_OK",
+  outcome: ApplyOutcomeLike,
+): RunClass {
+  if (response === "HEARTBEAT_OK") return { status: "ok", productive: false, errorText: null, idle: true };
+
+  if (response.error) {
+    return { status: "failed", productive: false, errorText: response.error.slice(0, 500) };
+  }
+
+  const traceErr = (response.trace ?? []).map((l) => BRIDGE_ERROR_TRACE_RE.exec(String(l))).find(Boolean);
+  if (traceErr) {
+    return { status: "failed", productive: false, errorText: `bridge_error: ${traceErr[1].slice(0, 400)}` };
+  }
+
+  if (response.actions.some((a) => RUNAWAY_BANNER_RE.test(bodyOf(a)))) {
+    return { status: "failed", productive: false, errorText: "runaway_max_iterations" };
+  }
+
+  if (response.actions.length > 0 && outcome.actionsApplied === 0) {
+    const first = outcome.errors[0] ?? "no action applied";
+    return {
+      status: "failed",
+      productive: false,
+      errorText: `all_actions_rejected: ${first.slice(0, 400)}`,
+    };
+  }
+
+  if (outcome.actionsApplied > 0) return { status: "ok", productive: true, errorText: null };
+  return { status: "ok", productive: false, errorText: null, idle: true };
+}
+
+// Exponential heartbeat backoff for an agent whose scheduled runs keep coming
+// back non-productive (idle, failed, rejected). Returns how long the NEXT
+// scheduled tick should be suppressed for. Streak 0–1 → no backoff (one quiet
+// beat is normal); from 2 on it doubles the base interval each time, capped.
+export function heartbeatBackoffMs(streak: number, baseMs: number, capMs: number): number {
+  if (!Number.isFinite(streak) || streak < 2) return 0;
+  const base = Math.max(1_000, baseMs);
+  const cap = Math.max(base, capMs);
+  const factor = Math.pow(2, Math.min(streak - 1, 20));
+  return Math.min(cap, Math.round(base * factor));
+}

--- a/api/src/lib/task-verifier.ts
+++ b/api/src/lib/task-verifier.ts
@@ -5,13 +5,15 @@
 // harnesses gate "done" on a verifiable final state (Anthropic's LLM-judge
 // rubric, Devin's verifiable merges) rather than a reviewer's rubber-stamp.
 //
-// Reuses the planner's server-side LLM client (chatJson → the FreeLLMAPI
-// gateway), so it needs no new infra and is provider-agnostic. Dormant unless a
-// planner/embeddings base URL is configured, and FAIL-OPEN on any judge outage:
-// a gateway hiccup must never freeze the board, so an unreachable/unparseable
-// judge returns "allow" and the heuristic gate stands on its own.
+// Reuses the server-side OpenAI-compatible chat client (chatJson), so it needs
+// no new infra and is provider-agnostic. The judge needs an EXPLICIT
+// chat-capable endpoint (VERIFY_JUDGE_BASE_URL or PLANNER_BASE_URL) — an
+// embeddings-only deployment leaves it NOT CONFIGURED (logged once), never
+// "unreachable" on every flip. What happens on a judge OUTAGE is configurable
+// via VERIFY_FAIL_MODE (open = allow the flip, closed = block, hold = block and
+// post one comment so a human reviews); the default stays fail-OPEN.
 import { z } from "zod";
-import { chatJson, plannerEnabled } from "./completion.js";
+import { chatJson, judgeConfigured, resolveJudgeTarget } from "./completion.js";
 import { liveArtifactRows, isSubstantiveArtifact, isTextualContentType } from "./task-artifacts.js";
 import { readObject } from "./storage.js";
 import { renderWebDeliverable, type RenderObservation } from "./deliverable-render.js";
@@ -32,10 +34,59 @@ type Verdict = z.infer<typeof VerdictSchema>;
 // OPT-IN by default. This gate makes an extra LLM call and can block a
 // done-flip, so it must never surprise a user who has a weak/idiosyncratic
 // model wired or didn't ask for it — they enable it explicitly with
-// VERIFY_GATE=on. Still requires a planner/embeddings backend to be configured
-// (it reuses that client), and fails OPEN on any judge outage.
+// VERIFY_GATE=on. Still requires a chat-capable judge endpoint; when VERIFY_GATE
+// is on but no judge URL resolves, say so ONCE and stay dormant (the old code
+// fell back to EMBEDDINGS_BASE_URL and then logged an "outage" per flip).
+let warnedUnconfigured = false;
 export function verifierEnabled(): boolean {
-  return process.env.VERIFY_GATE === "on" && plannerEnabled();
+  if (process.env.VERIFY_GATE !== "on") return false;
+  if (judgeConfigured()) return true;
+  if (!warnedUnconfigured) {
+    warnedUnconfigured = true;
+    console.error(
+      "[verifier] VERIFY_GATE=on but the judge is NOT CONFIGURED: no chat-capable endpoint. " +
+        "Set PLANNER_BASE_URL (+ PLANNER_MODEL / PLANNER_API_KEY) or VERIFY_JUDGE_BASE_URL (+ VERIFY_JUDGE_MODEL / VERIFY_JUDGE_API_KEY). " +
+        "EMBEDDINGS_BASE_URL alone is NOT used for the judge. The verification gate is OFF until this is fixed.",
+    );
+  }
+  return false;
+}
+
+// What to do when the judge is configured but unreachable/unparseable.
+//   open   — allow the flip (heuristic gate stands alone). DEFAULT.
+//   closed — block the flip silently (recorded as an error verdict).
+//   hold   — block the flip AND post one comment on the task so a human
+//            knows it is waiting on them, not on the agent.
+export type VerifyFailMode = "open" | "closed" | "hold";
+export function resolveFailMode(raw: string | undefined = process.env.VERIFY_FAIL_MODE): VerifyFailMode {
+  const v = (raw || "").trim().toLowerCase();
+  return v === "closed" || v === "hold" ? v : "open";
+}
+// Pure decision for the done-flip caller: does a judge outage block, and
+// should a hold comment be posted? Exported for tests.
+export function decideOnJudgeOutage(mode: VerifyFailMode): { block: boolean; comment: boolean } {
+  if (mode === "closed") return { block: true, comment: false };
+  if (mode === "hold") return { block: true, comment: true };
+  return { block: false, comment: false };
+}
+
+// Re-judging the SAME deliverable within this window reuses the last verdict.
+// Agents retry a rejected done-flip on every heartbeat (147 retries on one card
+// were observed); each retry cost a 60s judge call against a rate-limited
+// gateway, which is how the judge ended up "unreachable" most of the time.
+function rejudgeMinMs(): number {
+  const n = Number(process.env.VERIFY_REJUDGE_MIN_MS);
+  return Number.isFinite(n) && n >= 0 ? n : 10 * 60 * 1000;
+}
+export function shouldReuseVerdict(
+  last: { artifactId: string | null; verdict: string; createdAt: Date } | null | undefined,
+  artifactId: string,
+  now: number = Date.now(),
+  minMs: number = rejudgeMinMs(),
+): boolean {
+  if (!last || !last.artifactId || last.artifactId !== artifactId) return false;
+  if (last.verdict !== "pass" && last.verdict !== "fail") return false; // never reuse an outage
+  return now - last.createdAt.getTime() < minMs;
 }
 function passThreshold(): number {
   const n = Number(process.env.VERIFIER_PASS_THRESHOLD);
@@ -126,11 +177,16 @@ export function classifyRenderForGate(
   };
 }
 
-// Tier 2 — LLM-as-judge, fail-OPEN. Returns null = pass/allow (let the done
-// flip proceed); a string = block with that error code. Only meant to be
-// called once a candidate substantive artifact has been found by the heuristic
-// gate and the deterministic tier has not already blocked. `preRendered` is the
-// observation from the deterministic tier, reused so chromium runs only once.
+// Tier 2 — LLM-as-judge. Returns null = pass/allow (let the done flip
+// proceed); "verification_failed" = the judge rejected the deliverable;
+// "judge_unavailable" = the judge could not be reached/parsed — the CALLER
+// applies VERIFY_FAIL_MODE (see decideOnJudgeOutage), because only the
+// done-flip path should hold/comment; the review-entry pre-check just ignores
+// it. Only meant to be called once a candidate substantive artifact has been
+// found by the heuristic gate and the deterministic tier has not already
+// blocked. `preRendered` is the observation from the deterministic tier,
+// reused so chromium runs only once.
+export type VerifyOutcome = "verification_failed" | "judge_unavailable" | null;
 export async function verifyTaskForDone(
   opts: {
     taskId: string;
@@ -140,7 +196,7 @@ export async function verifyTaskForDone(
     decidedBy: string | null;
   },
   preRendered?: RenderObservation | null,
-): Promise<"verification_failed" | null> {
+): Promise<VerifyOutcome> {
   if (!verifierEnabled()) return null; // dormant → heuristic gate stands alone
 
   // Pick the latest readable, substantive deliverable to judge.
@@ -165,6 +221,13 @@ export async function verifyTaskForDone(
 
   const taskType = inferType(chosen.name, chosen.contentType);
 
+  // Same deliverable, recent real verdict → reuse it instead of re-calling the
+  // judge. The agent retrying the flip did not change the work product.
+  const last = await latestVerificationRow(opts.taskId);
+  if (shouldReuseVerdict(last, chosen.id)) {
+    return last!.verdict === "pass" ? null : "verification_failed";
+  }
+
   // EXECUTION CHECK: feed what ACTUALLY loaded to the judge so it scores an
   // observed final state, not source that merely looks complete. The render
   // already happened in the deterministic tier (deterministicGateForDone) and
@@ -180,6 +243,7 @@ export async function verifyTaskForDone(
       `- console_errors: ${obs.consoleErrors.length ? obs.consoleErrors.slice(0, 5).join(" | ") : "none"}\n`;
   }
 
+  const target = resolveJudgeTarget();
   const raw = await chatJson<unknown>(
     [
       {
@@ -206,31 +270,65 @@ export async function verifyTaskForDone(
           renderBlock,
       },
     ],
-    { temperature: 0, maxTokens: 800, timeoutMs: 60_000 },
+    { temperature: 0, maxTokens: 800, timeoutMs: 60_000, target },
   );
 
   const method = obs ? "render" : taskType === "code" ? "test" : "rubric";
   const parsed = VerdictSchema.safeParse(raw);
   if (!parsed.success) {
-    // Fail-open: a judge we can't reach/parse must not freeze the board. But
-    // fail-open must not be SILENT either — a broken judge once went unnoticed
-    // for 11 days because every outage just recorded an error row and allowed
-    // the flip. Log loudly, and escalate the log level once outages repeat.
+    // A judge we can't reach/parse must not be SILENT — a broken judge once
+    // went unnoticed for 11 days because every outage just recorded an error
+    // row and allowed the flip. Log loudly (escalating once outages repeat)
+    // and hand the decision to the caller via VERIFY_FAIL_MODE.
     consecutiveJudgeOutages++;
-    const msg = `[verifier] judge unreachable/unparseable for task ${opts.taskId} — failing open (${consecutiveJudgeOutages} consecutive outage${consecutiveJudgeOutages === 1 ? "" : "s"})`;
-    if (consecutiveJudgeOutages >= JUDGE_OUTAGE_ALERT_AFTER) {
-      console.error(`${msg}. The verification gate has been effectively OFF for the last ${consecutiveJudgeOutages} flips — check the planner gateway/model.`);
+    const mode = resolveFailMode();
+    const effect = mode === "open" ? "failing open" : mode === "hold" ? "holding in review" : "failing closed";
+    const where = target ? `${target.baseUrl} model=${target.model}` : "no target";
+    const msg = `[verifier] judge unreachable/unparseable for task ${opts.taskId} — ${effect} (VERIFY_FAIL_MODE=${mode}; ${consecutiveJudgeOutages} consecutive outage${consecutiveJudgeOutages === 1 ? "" : "s"}; ${where})`;
+    if (consecutiveJudgeOutages >= JUDGE_OUTAGE_ALERT_AFTER && mode === "open") {
+      console.error(`${msg}. The verification gate has been effectively OFF for the last ${consecutiveJudgeOutages} flips — check the judge gateway/model.`);
+    } else if (consecutiveJudgeOutages >= JUDGE_OUTAGE_ALERT_AFTER) {
+      console.error(`${msg}. Done-flips are being held/blocked until the judge recovers.`);
     } else {
       console.warn(msg);
     }
-    await record(opts, taskType, chosen.id, "error", null, obs ? { render: obs } : {}, "judge unreachable or unparseable — failing open", method);
-    return null;
+    await record(
+      opts,
+      taskType,
+      chosen.id,
+      "error",
+      null,
+      obs ? { render: obs, failMode: mode } : { failMode: mode },
+      `judge unreachable or unparseable — ${effect} (VERIFY_FAIL_MODE=${mode})`,
+      method,
+    );
+    return "judge_unavailable";
   }
   consecutiveJudgeOutages = 0;
   const v: Verdict = parsed.data;
   const pass = v.verdict === "pass" && v.not_fabricated && v.score >= passThreshold();
   await record(opts, taskType, chosen.id, pass ? "pass" : "fail", v.score, obs ? { ...v, render: obs } : v, v.rationale, method);
   return pass ? null : "verification_failed";
+}
+
+async function latestVerificationRow(
+  taskId: string,
+): Promise<{ artifactId: string | null; verdict: string; createdAt: Date } | null> {
+  try {
+    const [row] = await db
+      .select({
+        artifactId: taskVerifications.artifactId,
+        verdict: taskVerifications.verdict,
+        createdAt: taskVerifications.createdAt,
+      })
+      .from(taskVerifications)
+      .where(eqTask(taskId))
+      .orderBy(descCreated())
+      .limit(1);
+    return row ?? null;
+  } catch {
+    return null;
+  }
 }
 
 // The latest recorded verdict for a task, summarized for the reviewer's task

--- a/api/src/lib/tasks-core.ts
+++ b/api/src/lib/tasks-core.ts
@@ -18,7 +18,12 @@ import { enqueueAgentEvent } from "../agents/enqueue.js";
 import { notify } from "./notifications.js";
 import { liveArtifactRows, isSubstantiveArtifact, purgeArtifactsForTasks } from "./task-artifacts.js";
 import { forgetTaskKnowledge } from "./knowledge.js";
-import { verifyTaskForDone, deterministicGateForDone } from "./task-verifier.js";
+import {
+  verifyTaskForDone,
+  deterministicGateForDone,
+  decideOnJudgeOutage,
+  resolveFailMode,
+} from "./task-verifier.js";
 import { recordProgress } from "./ledger-core.js";
 import { evaluateStageRules, StageRulesSchema } from "./p1-platform.js";
 
@@ -1117,6 +1122,38 @@ export async function deleteComment(taskId: string, commentId: string, actorMemb
 // Note: a determined agent can still pad past the heuristic — the human-review
 // rules (2/3) and a future LLM-judge layer are the backstop. The point here is
 // that "done" now requires a real artifact in the store, not a placeholder.
+// VERIFY_FAIL_MODE=hold: the judge is down, the flip is refused, and the card
+// gets exactly ONE comment saying so (deduped on the prefix) — otherwise every
+// retried flip would add another "still waiting" line. Authored by the acting
+// agent (the one whose flip was held); there is no system member.
+export const VERIFICATION_HOLD_PREFIX = "⏸ Verification on hold";
+async function postVerificationHoldComment(
+  taskId: string,
+  actorMemberId: string,
+  workspaceId: string,
+): Promise<void> {
+  const [existing] = await db
+    .select({ id: taskComments.id })
+    .from(taskComments)
+    .where(
+      and(
+        eq(taskComments.taskId, taskId),
+        dsql`${taskComments.deletedAt} is null` as never,
+        dsql`${taskComments.bodyMd} like ${VERIFICATION_HOLD_PREFIX + "%"}` as never,
+      ),
+    )
+    .limit(1);
+  if (existing) return;
+  await addComment(
+    taskId,
+    `${VERIFICATION_HOLD_PREFIX} — the deliverable verifier (LLM judge) could not be reached, so this task stays in review ` +
+      `(VERIFY_FAIL_MODE=hold). A human can review the deliverable and mark it done, or the flip will be retried once the judge recovers.`,
+    [],
+    actorMemberId,
+    workspaceId,
+  );
+}
+
 async function assertDoneEvidence(
   taskId: string,
   actorMemberId: string,
@@ -1177,11 +1214,18 @@ async function assertDoneEvidence(
       // render observation so the judge below reuses it (chromium runs once).
       const det = await deterministicGateForDone(gateOpts).catch(() => ({ blocked: false, obs: null }));
       if (det.blocked) return "verification_failed";
-      // Tier 2 — LLM judge, fail-OPEN: proves the deliverable meets the criteria
-      // and isn't fabricated; a gateway outage never freezes the board.
+      // Tier 2 — LLM judge: proves the deliverable meets the criteria and isn't
+      // fabricated. A judge OUTAGE is handled per VERIFY_FAIL_MODE: open (default)
+      // allows the flip, closed blocks it, hold blocks it and leaves ONE comment
+      // on the card so a human knows the task is waiting on them.
       const verdict = await verifyTaskForDone(gateOpts, det.obs).catch(() => null);
+      if (verdict === "judge_unavailable") {
+        const decision = decideOnJudgeOutage(resolveFailMode());
+        if (decision.comment) await postVerificationHoldComment(taskId, actorMemberId, workspaceId).catch(() => {});
+        return decision.block ? "verification_failed" : null;
+      }
       if (verdict) return verdict; // judge said fail → block (reviewer gets the rationale)
-      return null; // both tiers passed (or judge dormant/failed-open) → allow
+      return null; // both tiers passed (or judge dormant) → allow
     }
   }
 

--- a/api/src/lib/text-similarity.ts
+++ b/api/src/lib/text-similarity.ts
@@ -1,0 +1,79 @@
+// Pure near-duplicate text matching shared by the cross-message dedupe
+// (agents/dedupe.ts) and the project tracker's append dedupe
+// (lib/project-files.ts). No db, no fs — unit-testable on its own.
+//
+// Strategy: 3-word shingles, Jaccard similarity. Normalization strips URLs,
+// @mentions, and punctuation so "ping @nova" and "ping @ada" don't count as
+// different, and lowercases so casing/markdown emphasis never matters.
+
+export const DEFAULT_SIMILARITY_THRESHOLD = 0.85;
+export const MIN_NORMALIZED_LEN = 30;
+const SHINGLE_SIZE = 3;
+
+export function normalizeText(s: string): string {
+  return (s || "")
+    .toLowerCase()
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/@[a-z0-9_]+/g, " ")
+    // Version tokens ("v28", "v1.2.3") collapse to a bare "v": the live
+    // "Proof package vNN shipped" loop re-posted the same sentence with only
+    // the counter bumped, and one differing token kills three 3-shingles.
+    .replace(/\bv\d+(?:\.\d+)*\b/g, " v ")
+    .replace(/[^\p{Letter}\p{Number}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function shingles(normalized: string, k: number = SHINGLE_SIZE): Set<string> {
+  const words = normalized.split(" ").filter(Boolean);
+  if (words.length < k) return new Set([words.join(" ")]);
+  const out = new Set<string>();
+  for (let i = 0; i <= words.length - k; i++) {
+    out.add(words.slice(i, i + k).join(" "));
+  }
+  return out;
+}
+
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let inter = 0;
+  for (const x of a) if (b.has(x)) inter++;
+  const union = a.size + b.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+// Similarity of two raw texts in [0,1]. Returns 0 when either side is too
+// short to compare meaningfully (short bodies repeat naturally — "ok",
+// "thanks", "👍" — and the false-positive cost is high).
+export function textSimilarity(a: string, b: string): number {
+  const na = normalizeText(a);
+  const nb = normalizeText(b);
+  if (na.length < MIN_NORMALIZED_LEN || nb.length < MIN_NORMALIZED_LEN) return 0;
+  return jaccard(shingles(na), shingles(nb));
+}
+
+export interface NearDuplicateHit<T> {
+  candidate: T;
+  score: number; // rounded to 2 dp
+}
+
+// Find the first candidate whose body is ≥ threshold similar to `incoming`.
+// Candidates are checked in the order given (callers pass newest-first).
+export function findNearDuplicate<T extends { bodyMd: string }>(
+  incoming: string,
+  candidates: Iterable<T>,
+  threshold: number = DEFAULT_SIMILARITY_THRESHOLD,
+): NearDuplicateHit<T> | null {
+  const incomingNorm = normalizeText(incoming);
+  if (incomingNorm.length < MIN_NORMALIZED_LEN) return null;
+  const incomingShingles = shingles(incomingNorm);
+  for (const c of candidates) {
+    const norm = normalizeText(c.bodyMd);
+    if (norm.length < MIN_NORMALIZED_LEN) continue;
+    const score = jaccard(incomingShingles, shingles(norm));
+    if (score >= threshold) {
+      return { candidate: c, score: Math.round(score * 100) / 100 };
+    }
+  }
+  return null;
+}

--- a/api/src/lib/workspace-scope.ts
+++ b/api/src/lib/workspace-scope.ts
@@ -1,0 +1,38 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { conversations, members } from "../db/schema.js";
+
+// Workspace-scoping helpers for caller-supplied id lists. Several write paths
+// (channel create, add-members, agent channel auto-join) used to insert the ids
+// the client sent verbatim — a member id from workspace B could be dropped into
+// a conversation in workspace A (and then read it), and an agent could be
+// auto-joined to a conversation in another workspace. Both helpers return only
+// the ids that really belong to `workspaceId`, deduplicated, in input order.
+
+export async function filterWorkspaceMemberIds(
+  workspaceId: string,
+  ids: readonly string[],
+): Promise<string[]> {
+  const wanted = Array.from(new Set(ids.filter((v) => typeof v === "string" && v.length > 0)));
+  if (!wanted.length) return [];
+  const rows = await db
+    .select({ id: members.id })
+    .from(members)
+    .where(and(eq(members.workspaceId, workspaceId), inArray(members.id, wanted)));
+  const ok = new Set(rows.map((r) => r.id));
+  return wanted.filter((id) => ok.has(id));
+}
+
+export async function filterWorkspaceConversationIds(
+  workspaceId: string,
+  ids: readonly string[],
+  opts: { kind?: "channel" | "dm" } = {},
+): Promise<string[]> {
+  const wanted = Array.from(new Set(ids.filter((v) => typeof v === "string" && v.length > 0)));
+  if (!wanted.length) return [];
+  const conds = [eq(conversations.workspaceId, workspaceId), inArray(conversations.id, wanted)];
+  if (opts.kind) conds.push(eq(conversations.kind, opts.kind));
+  const rows = await db.select({ id: conversations.id }).from(conversations).where(and(...conds));
+  const ok = new Set(rows.map((r) => r.id));
+  return wanted.filter((id) => ok.has(id));
+}

--- a/api/src/routes/agent-api.ts
+++ b/api/src/routes/agent-api.ts
@@ -165,6 +165,14 @@ async function reactionsFor(
   return map;
 }
 
+// `Number("abc")` is NaN, and NaN survives Math.min/Math.max — the old
+// `Math.min(200, Math.max(1, Number(q.limit)))` handed NaN to the SQL builder.
+function clampLimit(raw: unknown, fallback: number, max: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(1, Math.floor(n)));
+}
+
 async function resolveMembers(
   memberIds: string[],
 ): Promise<Record<string, { handle: string; name: string; kind: string }>> {
@@ -208,11 +216,21 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
       .object({
         provider: z.string().min(1).max(60).optional(),
         model: z.string().min(1).max(120).optional(),
-        inputTokens: z.number().int().min(0),
-        outputTokens: z.number().int().min(0),
+        // Accept the common spellings (OpenAI `prompt_/completion_tokens`,
+        // Anthropic `input_/output_tokens`, camelCase); normalizeUsage picks.
+        inputTokens: z.number().int().min(0).optional(),
+        outputTokens: z.number().int().min(0).optional(),
+        input_tokens: z.number().int().min(0).optional(),
+        output_tokens: z.number().int().min(0).optional(),
+        prompt_tokens: z.number().int().min(0).optional(),
+        completion_tokens: z.number().int().min(0).optional(),
+        total_tokens: z.number().int().min(0).optional(),
         cachedInputTokens: z.number().int().min(0).optional(),
+        cached_input_tokens: z.number().int().min(0).optional(),
         costUsd: z.number().min(0).max(1_000_000).optional(),
+        cost_usd: z.number().min(0).max(1_000_000).optional(),
       })
+      .passthrough()
       .parse(req.body);
     const [run] = await db
       .select({ id: agentRuns.id, agentId: agentRuns.agentId, contextJson: agentRuns.contextJson })
@@ -576,8 +594,12 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
 
     const where = [eq(messages.conversationId, q.conversationId), isNull(messages.deletedAt)];
     if (q.parentId) where.push(eq(messages.parentId, q.parentId));
-    if (q.before) where.push(lt(messages.ts, new Date(q.before)));
-    const limit = Math.min(200, Math.max(1, Number(q.limit ?? 50)));
+    if (q.before) {
+      const before = new Date(q.before);
+      if (Number.isNaN(before.getTime())) return reply.code(400).send({ error: "invalid_before" });
+      where.push(lt(messages.ts, before));
+    }
+    const limit = clampLimit(q.limit, 50, 200);
 
     const rows = await db
       .select()
@@ -623,7 +645,10 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
   app.get("/agent-api/search", async (req, reply) => {
     const q = req.query as { q?: string; conversationId?: string; limit?: string };
     if (!q.q || q.q.length < 2) return reply.code(400).send({ error: "q_too_short" });
-    const limit = Math.min(50, Math.max(1, Number(q.limit ?? 20)));
+    if (q.q.length > 200) return reply.code(400).send({ error: "q_too_long" });
+    const limit = clampLimit(q.limit, 20, 50);
+    // Escape LIKE metacharacters so `%`/`_` in the query aren't wildcards.
+    const pattern = `%${q.q.replace(/[%_\\]/g, (c) => `\\${c}`)}%`;
 
     // Always resolve what this agent may see, then restrict to a caller-supplied
     // conversationId only if it is actually in that set. Trusting the supplied
@@ -641,7 +666,7 @@ export default async function agentApiRoutes(app: FastifyInstance): Promise<void
     const rows = await db
       .select()
       .from(messages)
-      .where(and(inArray(messages.conversationId, convIds), ilike(messages.bodyMd, `%${q.q}%`), isNull(messages.deletedAt)))
+      .where(and(inArray(messages.conversationId, convIds), ilike(messages.bodyMd, pattern), isNull(messages.deletedAt)))
       .orderBy(desc(messages.ts))
       .limit(limit);
 

--- a/api/src/routes/agent-install.ts
+++ b/api/src/routes/agent-install.ts
@@ -15,6 +15,7 @@ import {
 import { requireWorkspace } from "../auth/session.js";
 import { id, rawToken } from "../lib/ids.js";
 import { scheduleAgentHeartbeat } from "../agents/scheduler.js";
+import { filterWorkspaceConversationIds } from "../lib/workspace-scope.js";
 import {
   installCircleChatTooling,
   resolveHermesHome,
@@ -249,11 +250,13 @@ export default async function agentInstallRoutes(app: FastifyInstance): Promise<
       name: body.name,
       kind: "hermes",
       adapter: "socket",
-      configJson: {},
+      // provider/model are recorded so estimated usage rows resolve to a real
+      // provider/model instead of "unknown"/"auto" when the bridge reports none.
+      configJson: { provider: body.provider, model: body.model ?? "auto" },
       model: body.model ?? "",
       // Default scopes cover the everyday agent surface: read + reply in
       // channels/DMs and manage the task board. Out-of-scope actions gate on a
-      // human approval when ENFORCE_AGENT_SCOPES is enabled (off by default).
+      // human approval when ENFORCE_AGENT_SCOPES is enabled (on by default).
       scopes: ["channels.read", "channels.reply", "tasks.write"],
       status: "provisioning",
       title: body.title ?? "",
@@ -274,11 +277,13 @@ export default async function agentInstallRoutes(app: FastifyInstance): Promise<
       reportsTo: body.reportsTo ?? null,
     });
 
-    if (body.channelIds?.length) {
+    // Only conversations in this workspace — never trust raw client ids.
+    const joinIds = await filterWorkspaceConversationIds(workspaceId!, body.channelIds ?? []);
+    if (joinIds.length) {
       await db
         .insert(conversationMembers)
         .values(
-          body.channelIds.map((cid) => ({
+          joinIds.map((cid) => ({
             conversationId: cid,
             memberId: agentMemberId,
             role: "member" as const,
@@ -472,11 +477,13 @@ export default async function agentInstallRoutes(app: FastifyInstance): Promise<
       name: body.name,
       kind: "openclaw",
       adapter: "socket",
-      configJson: {},
+      // provider/model are recorded so estimated usage rows resolve to a real
+      // provider/model instead of "unknown"/"auto" when the bridge reports none.
+      configJson: { provider: body.provider, model: body.model ?? "auto" },
       model: body.model ?? "",
       // Default scopes cover the everyday agent surface: read + reply in
       // channels/DMs and manage the task board. Out-of-scope actions gate on a
-      // human approval when ENFORCE_AGENT_SCOPES is enabled (off by default).
+      // human approval when ENFORCE_AGENT_SCOPES is enabled (on by default).
       scopes: ["channels.read", "channels.reply", "tasks.write"],
       status: "provisioning",
       title: body.title ?? "",
@@ -497,11 +504,13 @@ export default async function agentInstallRoutes(app: FastifyInstance): Promise<
       reportsTo: body.reportsTo ?? null,
     });
 
-    if (body.channelIds?.length) {
+    // Only conversations in this workspace — never trust raw client ids.
+    const joinIds = await filterWorkspaceConversationIds(workspaceId!, body.channelIds ?? []);
+    if (joinIds.length) {
       await db
         .insert(conversationMembers)
         .values(
-          body.channelIds.map((cid) => ({
+          joinIds.map((cid) => ({
             conversationId: cid,
             memberId: agentMemberId,
             role: "member" as const,

--- a/api/src/routes/agents.ts
+++ b/api/src/routes/agents.ts
@@ -13,8 +13,9 @@ import {
 import { requireWorkspace } from "../auth/session.js";
 import { id, rawToken } from "../lib/ids.js";
 import { enqueueAgentEvent } from "../agents/enqueue.js";
-import { scheduleAgentHeartbeat, cancelAgentHeartbeat } from "../agents/scheduler.js";
+import { scheduleAgentHeartbeat, cancelAgentHeartbeat, clearHeartbeatBackoff } from "../agents/scheduler.js";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { filterWorkspaceConversationIds } from "../lib/workspace-scope.js";
 
 const CreateBody = z.object({
   name: z.string().min(1).max(100),
@@ -153,12 +154,14 @@ export default async function agentRoutes(app: FastifyInstance): Promise<void> {
       .insert(members)
       .values({ id: agentMemberId, workspaceId: workspaceId!, kind: "agent", refId: agentId });
 
-    // Auto-join agent to picked channels (admin-marked).
-    if (body.channelIds?.length) {
+    // Auto-join agent to picked channels (admin-marked) — only channels that
+    // belong to THIS workspace; the raw ids used to be inserted verbatim.
+    const joinIds = await filterWorkspaceConversationIds(workspaceId!, body.channelIds ?? []);
+    if (joinIds.length) {
       await db
         .insert(conversationMembers)
         .values(
-          body.channelIds.map((cid) => ({
+          joinIds.map((cid) => ({
             conversationId: cid,
             memberId: agentMemberId,
             role: "member" as const,
@@ -286,6 +289,8 @@ export default async function agentRoutes(app: FastifyInstance): Promise<void> {
     // Clears a budget pause too — if the cap wasn't raised, the next run's
     // budget gate re-pauses immediately, which is the honest behavior.
     await db.update(agents).set({ status: "idle", pauseReason: null }).where(eq(agents.id, aId));
+    // A manual resume is a fresh start: drop any non-productive-run backoff.
+    await clearHeartbeatBackoff(aId);
     await scheduleAgentHeartbeat(aId, a.heartbeatIntervalSec);
     return { ok: true };
   });

--- a/api/src/routes/approvals.ts
+++ b/api/src/routes/approvals.ts
@@ -1,12 +1,14 @@
 import { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { and, eq, desc } from "drizzle-orm";
+import { and, eq, desc, inArray } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { approvals, agents } from "../db/schema.js";
 import { requireWorkspace } from "../auth/session.js";
 import { enqueueAgentEvent } from "../agents/enqueue.js";
 import { applyApprovedActionPayload } from "../agents/executor.js";
-import { publishToConversation } from "../lib/events.js";
+import { publishToConversation, publishToWorkspace } from "../lib/events.js";
+import { requirePermission, writeAudit } from "../lib/access-control.js";
+import { approvalExpiresAt } from "../lib/approval-policy.js";
 import {
   deliverAgentSecrets,
   SECRET_NAME_RE,
@@ -32,44 +34,88 @@ const DecideBody = z
     message: "secrets_on_deny",
   });
 
+const ListQuery = z.object({
+  // pending (default, what the Approvals page shows) | decided | all
+  status: z.enum(["pending", "decided", "all"]).optional(),
+});
+const DECIDED = ["approved", "denied", "applied", "expired"];
+
 export default async function approvalRoutes(app: FastifyInstance): Promise<void> {
   app.addHook("preHandler", requireWorkspace);
 
   app.get("/approvals", async (req) => {
     const { workspaceId } = req.auth!;
+    const q = ListQuery.parse(req.query ?? {});
+    const statusFilter =
+      q.status === "all" ? undefined : q.status === "decided" ? inArray(approvals.status, DECIDED) : eq(approvals.status, "pending");
     const rows = await db
       .select({ approval: approvals })
       .from(approvals)
       .innerJoin(agents, eq(agents.id, approvals.agentId))
-      .where(and(eq(approvals.status, "pending"), eq(agents.workspaceId, workspaceId!)))
+      .where(and(eq(agents.workspaceId, workspaceId!), statusFilter))
       .orderBy(desc(approvals.createdAt))
       .limit(100);
-    return { approvals: rows.map((r) => r.approval) };
+    return {
+      approvals: rows.map((r) => ({
+        ...r.approval,
+        // When the card will auto-expire if nobody decides (null = never).
+        expiresAt: r.approval.status === "pending" ? approvalExpiresAt(r.approval.createdAt) : null,
+      })),
+    };
   });
 
   app.post("/approvals/:id", async (req, reply) => {
     const apId = (req.params as { id: string }).id;
     const body = DecideBody.parse(req.body);
-    const { memberId } = req.auth!;
-    const [a] = await db.select().from(approvals).where(eq(approvals.id, apId)).limit(1);
-    if (!a) return reply.code(404).send({ error: "not_found" });
-    if (a.status !== "pending") return reply.code(409).send({ error: "already_decided" });
+    const { memberId, workspaceId } = req.auth!;
+
+    // Deciding an approval is a governance action: admins and members, never
+    // guests (BUILTIN_PERMISSIONS) — custom roles need `approvals.decide`.
+    if (!(await requirePermission(req, "approvals.decide"))) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+
+    // Workspace scoping: the card must belong to an agent in the caller's
+    // current workspace. Previously any authenticated user could decide any
+    // approval by id, across workspaces.
+    const [found] = await db
+      .select({ approval: approvals, agent: agents })
+      .from(approvals)
+      .innerJoin(agents, eq(agents.id, approvals.agentId))
+      .where(and(eq(approvals.id, apId), eq(agents.workspaceId, workspaceId!)))
+      .limit(1);
+    if (!found) return reply.code(404).send({ error: "not_found" });
+    const a = found.approval;
+    const ag = found.agent;
+    if (a.status !== "pending") return reply.code(409).send({ error: "already_decided", status: a.status });
 
     const status = body.decision === "approve" ? "approved" : "denied";
     const note = body.note || null;
+    const now = new Date();
 
-    const [ag] = await db.select().from(agents).where(eq(agents.id, a.agentId)).limit(1);
+    // Claim the decision atomically (status-guarded UPDATE). Two humans
+    // clicking at once used to both pass the check above, both deliver
+    // secrets, and both replay the action — the loser now gets a 409.
+    const claimed = await db
+      .update(approvals)
+      .set({ status, decidedAt: now, decidedBy: memberId, decisionNote: note })
+      .where(and(eq(approvals.id, apId), eq(approvals.status, "pending")))
+      .returning({ id: approvals.id });
+    if (!claimed.length) return reply.code(409).send({ error: "already_decided" });
 
-    // Install attached credentials into the agent's env BEFORE marking the
-    // approval decided — if delivery fails the decision doesn't land, so the
-    // agent is never told "approved" about credentials it can't see.
+    // Install attached credentials into the agent's env. If delivery fails the
+    // claim is rolled back to pending, so the agent is never told "approved"
+    // about credentials it can't see and the human can retry.
     let deliveredSecrets: string[] | null = null;
     if (status === "approved" && body.secrets && Object.keys(body.secrets).length) {
-      if (!ag) return reply.code(404).send({ error: "agent_not_found" });
       try {
         deliveredSecrets = await deliverAgentSecrets(ag, body.secrets);
       } catch (e) {
         req.log.error({ err: e, approvalId: apId }, "secret delivery failed");
+        await db
+          .update(approvals)
+          .set({ status: "pending", decidedAt: null, decidedBy: null, decisionNote: null })
+          .where(eq(approvals.id, apId));
         return reply.code(500).send({ error: "secret_delivery_failed" });
       }
     }
@@ -92,37 +138,45 @@ export default async function approvalRoutes(app: FastifyInstance): Promise<void
     }
     const finalStatus = autoApplied ? "applied" : status;
 
-    await db
-      .update(approvals)
-      .set({
-        status: finalStatus,
-        decidedAt: new Date(),
-        decidedBy: memberId,
-        decisionNote: note,
-        ...(deliveredSecrets?.length ? { deliveredSecrets } : {}),
-      })
-      .where(eq(approvals.id, apId));
-
-    if (a.conversationId) {
-      await publishToConversation(a.conversationId, {
-        type: "approval.decided",
-        approvalId: apId,
-        status,
-        ...(note ? { note } : {}),
-        ...(deliveredSecrets?.length ? { deliveredSecrets } : {}),
-      });
+    if (finalStatus !== status || deliveredSecrets?.length) {
+      await db
+        .update(approvals)
+        .set({
+          status: finalStatus,
+          ...(deliveredSecrets?.length ? { deliveredSecrets } : {}),
+        })
+        .where(eq(approvals.id, apId));
     }
+
+    await writeAudit({
+      workspaceId: workspaceId!,
+      actorId: memberId!,
+      action: `approval.${status}`,
+      targetType: "approval",
+      targetId: apId,
+      // Names only — secret values never reach the DB, events, or logs.
+      meta: { scope: a.scope, agentId: a.agentId, autoApplied, ...(deliveredSecrets?.length ? { deliveredSecrets } : {}) },
+      ip: req.ip,
+    }).catch(() => {});
+
+    const frame = {
+      type: "approval.decided" as const,
+      approvalId: apId,
+      status: finalStatus,
+      ...(note ? { note } : {}),
+      ...(deliveredSecrets?.length ? { deliveredSecrets } : {}),
+    };
+    await publishToWorkspace(workspaceId!, frame).catch(() => {});
+    if (a.conversationId) await publishToConversation(a.conversationId, frame).catch(() => {});
 
     // Wake the agent with an approval_response trigger so it can act on it.
-    if (ag) {
-      await enqueueAgentEvent(a.agentId, {
-        trigger: "approval_response",
-        approvalId: apId,
-        status,
-        conversationId: a.conversationId ?? undefined,
-      });
-    }
+    await enqueueAgentEvent(a.agentId, {
+      trigger: "approval_response",
+      approvalId: apId,
+      status: finalStatus,
+      conversationId: a.conversationId ?? undefined,
+    });
 
-    return { ok: true, status, ...(deliveredSecrets?.length ? { deliveredSecrets } : {}) };
+    return { ok: true, status: finalStatus, ...(deliveredSecrets?.length ? { deliveredSecrets } : {}) };
   });
 }

--- a/api/src/routes/connectors.ts
+++ b/api/src/routes/connectors.ts
@@ -267,19 +267,32 @@ export default async function connectorRoutes(app: FastifyInstance): Promise<voi
       : {};
     const clientSecret = typeof oldSecret.clientSecret === "string" ? oldSecret.clientSecret : "";
     const redirectUri = `${config.publicBaseUrl.replace(/\/$/, "")}/api/connectors/oauth/callback`;
-    const response = await fetch(oauth.tokenUrl, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
-      body: new URLSearchParams({
-        grant_type: "authorization_code",
-        code: query.code,
-        client_id: oauth.clientId,
-        client_secret: clientSecret,
-        redirect_uri: redirectUri,
-      }),
-      signal: AbortSignal.timeout(20_000),
-    });
-    const token = (await response.json()) as Record<string, unknown>;
+    let response: Response;
+    try {
+      response = await fetch(oauth.tokenUrl, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded", accept: "application/json" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: query.code,
+          client_id: oauth.clientId,
+          client_secret: clientSecret,
+          redirect_uri: redirectUri,
+        }),
+        signal: AbortSignal.timeout(20_000),
+      });
+    } catch (e) {
+      req.log.warn({ err: (e as Error).message, connectorId: connector.id }, "oauth token exchange unreachable");
+      return reply.code(502).send({ error: "oauth_token_exchange_failed" });
+    }
+    // A provider error page (HTML) or a network blip must not surface as a
+    // 500 from `response.json()` — it's a failed exchange either way.
+    let token: Record<string, unknown> = {};
+    try {
+      token = (await response.json()) as Record<string, unknown>;
+    } catch {
+      token = {};
+    }
     if (!response.ok || typeof token.access_token !== "string") {
       return reply.code(400).send({ error: "oauth_token_exchange_failed" });
     }

--- a/api/src/routes/conversations.ts
+++ b/api/src/routes/conversations.ts
@@ -16,6 +16,7 @@ import {
 } from "../db/schema.js";
 import { requireWorkspace } from "../auth/session.js";
 import { id } from "../lib/ids.js";
+import { filterWorkspaceMemberIds } from "../lib/workspace-scope.js";
 
 function dmId(a: string, b: string): string {
   const sorted = [a, b].sort().join(":");
@@ -170,7 +171,11 @@ export default async function conversationRoutes(app: FastifyInstance): Promise<
         isPrivate: body.isPrivate ?? false,
         createdBy: memberId,
       });
-      const extra = (body.memberIds ?? []).filter((m) => m !== memberId);
+      // Only members of THIS workspace may be seeded into the channel — the
+      // client used to be able to pass any member id from any workspace.
+      const extra = (await filterWorkspaceMemberIds(workspaceId, body.memberIds ?? [])).filter(
+        (m) => m !== memberId,
+      );
       await db.insert(conversationMembers).values([
         { conversationId: convId, memberId: memberId!, role: "admin" },
         ...extra.map((m) => ({ conversationId: convId, memberId: m, role: "member" as const })),
@@ -286,13 +291,28 @@ export default async function conversationRoutes(app: FastifyInstance): Promise<
       .limit(1);
     if (!membership) return reply.code(403).send({ error: "not_a_member" });
 
-    for (const mid of body.memberIds) {
+    // The conversation must be in the caller's workspace and every added
+    // member must belong to it too. Without this, any member id (including
+    // one from another workspace) could be inserted and gain read access.
+    const [conv] = await db
+      .select({ workspaceId: conversations.workspaceId })
+      .from(conversations)
+      .where(eq(conversations.id, convId))
+      .limit(1);
+    if (!conv || conv.workspaceId !== req.auth!.workspaceId!) {
+      return reply.code(404).send({ error: "not_found" });
+    }
+    const valid = await filterWorkspaceMemberIds(conv.workspaceId, body.memberIds);
+    if (valid.length !== new Set(body.memberIds).size) {
+      return reply.code(400).send({ error: "member_not_in_workspace" });
+    }
+    if (valid.length) {
       await db
         .insert(conversationMembers)
-        .values({ conversationId: convId, memberId: mid, role: "member" })
+        .values(valid.map((mid) => ({ conversationId: convId, memberId: mid, role: "member" as const })))
         .onConflictDoNothing();
     }
-    return { ok: true };
+    return { ok: true, added: valid.length };
   });
 
   app.post("/conversations/:id/read", async (req) => {

--- a/api/src/routes/enterprise.ts
+++ b/api/src/routes/enterprise.ts
@@ -30,7 +30,7 @@ const RoleBody = z.object({
   name: z.string().min(1).max(80),
   permissions: z.array(z.enum([
     "workspace.read", "workspace.write", "channels.write", "runs.control",
-    "apps.request_publish", "audit.export", "access.manage",
+    "apps.request_publish", "approvals.decide", "audit.export", "access.manage",
   ])).max(30),
 });
 
@@ -99,7 +99,7 @@ export default async function enterpriseRoutes(app: FastifyInstance): Promise<vo
       access,
       builtInRoles: [
         { key: "admin", name: "Admin", permissions: ["*"] },
-        { key: "member", name: "Member", permissions: ["workspace.read", "workspace.write", "runs.control", "apps.request_publish"] },
+        { key: "member", name: "Member", permissions: ["workspace.read", "workspace.write", "runs.control", "apps.request_publish", "approvals.decide"] },
         { key: "guest", name: "Guest", permissions: ["workspace.read", "channels.write"] },
       ],
       roles,
@@ -159,7 +159,14 @@ export default async function enterpriseRoutes(app: FastifyInstance): Promise<vo
   app.put("/enterprise/sso", async (req, reply) => {
     if (!(await admin(req, reply))) return;
     const body = SsoBody.parse(req.body);
-    await discovery(body.issuer);
+    // Discovery failures are the operator's input being wrong (non-https
+    // issuer, unreachable/malformed metadata) — a 400 with the reason, not a
+    // 500 stack trace.
+    try {
+      await discovery(body.issuer);
+    } catch (e) {
+      return reply.code(400).send({ error: "oidc_discovery_failed", detail: (e as Error).message.slice(0, 200) });
+    }
     const [existing] = await db.select().from(ssoConnections).where(eq(ssoConnections.workspaceId, req.auth!.workspaceId!)).limit(1);
     if (!existing && !body.clientSecret) return reply.code(400).send({ error: "client_secret_required" });
     const secret = body.clientSecret ? encryptSecret({ clientSecret: body.clientSecret }) : existing!.clientSecretCiphertext;

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -11,14 +11,27 @@ import {
   reactions,
   agents,
   members,
-  users,
 } from "../db/schema.js";
 import { requireWorkspace } from "../auth/session.js";
 import { id } from "../lib/ids.js";
 import { publishToConversation } from "../lib/events.js";
 import { enqueueAgentEvent } from "../agents/enqueue.js";
-import { fireChannelPostTrigger } from "../agents/mention-triggers.js";
+import { fireChannelPostTrigger, resolveHandlesToMemberIds } from "../agents/mention-triggers.js";
 import { notifyForMessage } from "../lib/notifications.js";
+import { sanitizeAttachments } from "../agents/executor.js";
+
+// Query-string helpers: `Number("abc")` is NaN and `new Date("garbage")` is an
+// Invalid Date — both used to flow straight into the SQL builder and 500.
+function parseLimit(raw: unknown, fallback: number, max: number): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(1, Math.floor(n)));
+}
+function parseBefore(raw: unknown): Date | null {
+  if (typeof raw !== "string" || !raw) return null;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
 
 const PostBody = z.object({
   bodyMd: z.string().min(1).max(20_000),
@@ -58,7 +71,7 @@ export default async function messageRoutes(app: FastifyInstance): Promise<void>
       );
     if (!mm) return reply.code(403).send({ error: "not_a_member" });
 
-    const limit = Math.min(200, Math.max(1, Number(q.limit ?? 50)));
+    const limit = parseLimit(q.limit, 50, 200);
     const where = [eq(messages.conversationId, convId)];
     if (q.parent_id) where.push(eq(messages.parentId, q.parent_id));
     else where.push(isNull(messages.parentId));
@@ -67,7 +80,9 @@ export default async function messageRoutes(app: FastifyInstance): Promise<void>
     // we always fetch in descending order and reverse for display. The old
     // `asc + limit` returned the first 200 messages ever sent, which meant a
     // busy channel never showed recent activity.
-    if (q.before) where.push(lt(messages.ts, new Date(q.before)));
+    const before = parseBefore(q.before);
+    if (q.before && !before) return reply.code(400).send({ error: "invalid_before" });
+    if (before) where.push(lt(messages.ts, before));
 
     const rows = await db
       .select()
@@ -129,9 +144,32 @@ export default async function messageRoutes(app: FastifyInstance): Promise<void>
       );
     if (!mm) return reply.code(403).send({ error: "not_a_member" });
 
+    // A thread reply must hang off a top-level message in THIS conversation.
+    // Otherwise a client could parent a message onto any message id (another
+    // conversation, or a reply) and the thread-continuation logic below would
+    // wake agents / count replies against the wrong root.
+    if (body.parentId) {
+      const [parent] = await db
+        .select({ conversationId: messages.conversationId, parentId: messages.parentId })
+        .from(messages)
+        .where(eq(messages.id, body.parentId))
+        .limit(1);
+      if (!parent || parent.conversationId !== convId) {
+        return reply.code(400).send({ error: "invalid_parent" });
+      }
+      if (parent.parentId) body.parentId = parent.parentId; // replies to a reply flatten onto the root
+    }
+
+    // Attachment descriptors are client-supplied. Restrict them to keys the
+    // server itself wrote (u/<rand>/<name>) exactly as the agent path does, so
+    // a hand-rolled descriptor can't point chat at an arbitrary URL or key.
+    const attachments = sanitizeAttachments(body.attachments);
+
     const mentions = extractMentions(body.bodyMd);
-    const directHandles = mentions.filter((h) => h !== "everyone" && h !== "channel");
-    const directMentionIds = await resolveMentionsToMemberIds(directHandles);
+    // Resolve @handles to member ids IN THIS WORKSPACE. The old resolver picked
+    // an arbitrary member row for the user, so someone in two workspaces got
+    // their mention (and notification) routed to the wrong workspace's member.
+    const directMentionIds = await resolveHandlesToMemberIds(mentions, req.auth!.workspaceId!);
     const isBroadcast = mentions.some((h) => h === "everyone" || h === "channel");
     const broadcastMentionIds = new Set<string>();
     if (isBroadcast) {
@@ -153,7 +191,7 @@ export default async function messageRoutes(app: FastifyInstance): Promise<void>
       memberId,
       parentId: body.parentId ?? null,
       bodyMd: body.bodyMd,
-      attachmentsJson: body.attachments ?? [],
+      attachmentsJson: attachments,
       mentions: resolvedMentionIds,
       ts: now,
     });
@@ -164,7 +202,7 @@ export default async function messageRoutes(app: FastifyInstance): Promise<void>
       memberId,
       parentId: body.parentId ?? null,
       bodyMd: body.bodyMd,
-      attachmentsJson: body.attachments ?? [],
+      attachmentsJson: attachments,
       mentions: resolvedMentionIds,
       ts: now.toISOString(),
       reactions: [],
@@ -389,6 +427,20 @@ export default async function messageRoutes(app: FastifyInstance): Promise<void>
     const memberId = req.auth!.memberId!;
     const [m] = await db.select().from(messages).where(eq(messages.id, mId)).limit(1);
     if (!m) return reply.code(404).send({ error: "not_found" });
+    // Only conversation members may react — any authenticated member used to
+    // be able to toggle reactions on any message by id (and the event was
+    // broadcast into that conversation).
+    const [inConv] = await db
+      .select({ memberId: conversationMembers.memberId })
+      .from(conversationMembers)
+      .where(
+        and(
+          eq(conversationMembers.conversationId, m.conversationId),
+          eq(conversationMembers.memberId, memberId),
+        ),
+      )
+      .limit(1);
+    if (!inConv) return reply.code(403).send({ error: "not_a_member" });
 
     const [exist] = await db
       .select()
@@ -453,33 +505,6 @@ function extractMentions(body: string): string[] {
   let m: RegExpExecArray | null;
   while ((m = re.exec(body))) out.add(m[1].toLowerCase());
   return Array.from(out);
-}
-
-async function resolveMentionsToMemberIds(handles: string[]): Promise<string[]> {
-  if (!handles.length) return [];
-  const out: string[] = [];
-  for (const h of handles) {
-    const [u] = await db.select({ id: users.id }).from(users).where(eq(users.handle, h)).limit(1);
-    if (u) {
-      const [m] = await db
-        .select({ id: members.id })
-        .from(members)
-        .where(and(eq(members.kind, "user"), eq(members.refId, u.id)))
-        .limit(1);
-      if (m) out.push(m.id);
-      continue;
-    }
-    const [a] = await db.select({ id: agents.id }).from(agents).where(eq(agents.handle, h)).limit(1);
-    if (a) {
-      const [m] = await db
-        .select({ id: members.id })
-        .from(members)
-        .where(and(eq(members.kind, "agent"), eq(members.refId, a.id)))
-        .limit(1);
-      if (m) out.push(m.id);
-    }
-  }
-  return out;
 }
 
 // Fisher–Yates shuffle. Used so @everyone doesn't always wake agents in the

--- a/api/src/routes/needs-you.ts
+++ b/api/src/routes/needs-you.ts
@@ -15,6 +15,7 @@ import {
   workspaces,
 } from "../db/schema.js";
 import { requireWorkspace } from "../auth/session.js";
+import { approvalExpiresAt, isCredentialAsk } from "../lib/approval-policy.js";
 
 type ReviewItem = {
   id: string;
@@ -49,7 +50,28 @@ export default async function needsYouRoutes(app: FastifyInstance): Promise<void
     ]);
 
     const items: ReviewItem[] = [];
-    for (const row of approvalRows) items.push({ id: `approval:${row.approval.id}`, kind: "approval", priority: "high", title: `${row.agentName} needs approval`, detail: `${row.approval.scope}: ${row.approval.action}`, link: "/needs-you", targetId: row.approval.id, createdAt: row.approval.createdAt.toISOString(), actions: ["approve", "deny"] });
+    for (const row of approvalRows) {
+      const expiresAt = approvalExpiresAt(row.approval.createdAt);
+      const hoursLeft = expiresAt ? Math.max(0, Math.round((expiresAt.getTime() - Date.now()) / 3_600_000)) : null;
+      const credential = isCredentialAsk(row.approval.scope, row.approval.action);
+      const hints = [
+        credential ? "credential request — approving without attaching the secret delivers nothing (use the Approvals page to attach it)" : null,
+        hoursLeft != null ? (hoursLeft > 0 ? `expires in ${hoursLeft}h if undecided` : "expiring now") : null,
+      ].filter(Boolean);
+      items.push({
+        id: `approval:${row.approval.id}`,
+        kind: "approval",
+        // A card about to expire is the last chance to say yes/no before the
+        // agent is told to route around it.
+        priority: hoursLeft != null && hoursLeft <= 12 ? "critical" : "high",
+        title: `${row.agentName} needs approval`,
+        detail: `${row.approval.scope}: ${row.approval.action}${hints.length ? ` (${hints.join("; ")})` : ""}`,
+        link: credential ? "/approvals" : "/needs-you",
+        targetId: row.approval.id,
+        createdAt: row.approval.createdAt.toISOString(),
+        actions: ["approve", "deny"],
+      });
+    }
     for (const task of reviewTasks) items.push({ id: `task:${task.id}`, kind: "task_review", priority: "normal", title: task.title, detail: "Task is ready for human review.", link: `/board?task=${task.id}`, targetId: task.id, createdAt: task.updatedAt.toISOString(), actions: ["open"] });
     const latestFailed = new Map<string, (typeof failedVerdicts)[number]>();
     for (const row of failedVerdicts) if (!latestFailed.has(row.verification.taskId)) latestFailed.set(row.verification.taskId, row);

--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -17,7 +17,13 @@ import {
 import { buildContext } from "./agents/context.js";
 import { callAgent } from "./agents/adapters/dispatch.js";
 import { applyActions, type AgentAction } from "./agents/executor.js";
-import { materialiseScheduledRun, cancelAgentHeartbeat } from "./agents/scheduler.js";
+import {
+  materialiseScheduledRun,
+  cancelAgentHeartbeat,
+  noteHeartbeatOutcome,
+  heartbeatBackoffRemainingMs,
+} from "./agents/scheduler.js";
+import { classifyRunOutcome } from "./lib/run-outcome.js";
 import { publishToConversation, publishGlobal } from "./lib/events.js";
 import { exportRunTrace } from "./lib/tracing.js";
 import { enforceBudgets, estimateRunCost } from "./lib/budgets.js";
@@ -59,10 +65,14 @@ async function consumeCodeResult(agentId: string): Promise<string | null> {
 // the runs newest-first then reverses to oldest→newest for the detector.
 async function detectAndFlagStuck(agentId: string): Promise<boolean> {
   try {
+    // Failed runs count too: a run that hit max-iterations or had every action
+    // rejected three times in a row IS the loop — excluding them (as the old
+    // status='ok' filter did once failures are recorded honestly) would blind
+    // the detector to exactly the runs it exists for.
     const recent = await db
-      .select({ resultJson: agentRuns.resultJson, traceJson: agentRuns.traceJson })
+      .select({ resultJson: agentRuns.resultJson, traceJson: agentRuns.traceJson, errorText: agentRuns.errorText })
       .from(agentRuns)
-      .where(and(eq(agentRuns.agentId, agentId), eq(agentRuns.status, "ok")))
+      .where(and(eq(agentRuns.agentId, agentId), inArray(agentRuns.status, ["ok", "failed"])))
       .orderBy(desc(agentRuns.startedAt))
       .limit(4);
     const signatures = recent
@@ -71,7 +81,10 @@ async function detectAndFlagStuck(agentId: string): Promise<boolean> {
       .map((r) =>
         normalizeRunSignature(
           (r.traceJson as string[]) ?? [],
-          ((r.resultJson as { errors?: string[] })?.errors as string[]) ?? [],
+          [
+            ...((((r.resultJson as { errors?: string[] })?.errors as string[]) ?? [])),
+            ...(r.errorText ? [r.errorText] : []),
+          ],
         ),
       );
     const verdict = detectStuck(signatures);
@@ -211,8 +224,8 @@ const worker = new Worker<AgentJobPayload>(
     // entirely. Most scheduled runs fire into a quiet workspace and produce
     // filler — this is the cheapest, highest-impact way to cut that noise.
     if (payload.trigger === "scheduled") {
-      const idle = await isWorkspaceIdleForAgent(agent.id, sinceTs);
-      if (idle) {
+      const wake = await wakeReasonForAgent(agent.id, sinceTs);
+      if (!wake) {
         await db
           .update(agentRuns)
           .set({
@@ -224,6 +237,24 @@ const worker = new Worker<AgentJobPayload>(
         await db.update(agents).set({ status: "idle" }).where(eq(agents.id, agent.id));
         await emitFinished(agent.id, runId, "ok", payload.conversationId);
         return;
+      }
+      // Non-productive-streak backoff. Only the self-generated "progress beat"
+      // reason is suppressed — a human message/comment/assignment always wakes.
+      if (wake === "stale_task") {
+        const remaining = await heartbeatBackoffRemainingMs(agent.id);
+        if (remaining > 0) {
+          await db
+            .update(agentRuns)
+            .set({
+              status: "ok",
+              resultJson: { skipped: "heartbeat_backoff", remainingMs: remaining },
+              finishedAt: new Date(),
+            })
+            .where(eq(agentRuns.id, runId));
+          await db.update(agents).set({ status: "idle" }).where(eq(agents.id, agent.id));
+          await emitFinished(agent.id, runId, "ok", payload.conversationId);
+          return;
+        }
       }
     }
 
@@ -283,6 +314,10 @@ const worker = new Worker<AgentJobPayload>(
               finishedAt: prevRuns[0].finishedAt?.toISOString() ?? null,
             }
           : null,
+      previousRunErrors: (() => {
+        const errs = (prevRuns[0]?.resultJson as { errors?: unknown } | null | undefined)?.errors;
+        return Array.isArray(errs) ? errs.filter((e): e is string => typeof e === "string" && e.length > 0) : null;
+      })(),
       stuckBreak,
       lastCodeResult,
       steering: payload.status ?? null,
@@ -426,6 +461,10 @@ const worker = new Worker<AgentJobPayload>(
         ? 0
         : JSON.stringify(actions).length + trace.join("\n").length;
     const estimated = estimateRunCost(promptChars, completionChars);
+    // Split the estimate so output tokens are not recorded as 0 on every
+    // estimated row (the runtime rarely reports usage inline).
+    const estimatedInput = estimateRunCost(promptChars, 0).tokensEst;
+    const estimatedOutput = Math.max(0, estimated.tokensEst - estimatedInput);
     let tokensEst = estimated.tokensEst;
     let costUsd = estimated.costUsd;
     if (response !== "HEARTBEAT_OK" && response.usage) {
@@ -453,9 +492,11 @@ const worker = new Worker<AgentJobPayload>(
         routeTier: packet.modelRoute?.tier,
         usage: {
           provider: packet.modelRoute?.provider ?? undefined,
-          model: (packet.modelRoute?.model ?? agent.model) || undefined,
-          inputTokens: estimated.tokensEst,
-          outputTokens: 0,
+          // Leave model undefined when only "auto" is known so the store can
+          // resolve a real name from the route / agent install config.
+          model: packet.modelRoute?.model ?? undefined,
+          inputTokens: estimatedInput,
+          outputTokens: estimatedOutput,
           costUsd: estimated.costUsd,
         },
         source: "estimated",
@@ -463,11 +504,24 @@ const worker = new Worker<AgentJobPayload>(
       }).catch((usageError) => console.error("[worker] usage record failed", usageError));
     }
 
+    // Honest run accounting: empty/crashed replies, bridge errors, runaway
+    // max-iterations banners and "every action rejected" are FAILED runs, not
+    // ok — the stuck detector, run reaper, previousRunFailure context and the
+    // heartbeat backoff all key on this.
+    const cls = classifyRunOutcome(response, outcome);
+    if (cls.status === "failed") {
+      console.warn(`[worker] run ${runId} agent=${agent.handle} trigger=${payload.trigger} failed: ${cls.errorText}`);
+    }
     await db
       .update(agentRuns)
       .set({
-        status: "ok",
-        resultJson: { applied: outcome.actionsApplied, errors: redactLines(outcome.errors) },
+        status: cls.status,
+        errorText: cls.errorText ? redactSecrets(cls.errorText) : null,
+        resultJson: {
+          applied: outcome.actionsApplied,
+          errors: redactLines(outcome.errors),
+          ...(cls.status === "ok" && !cls.productive ? { idle: true } : {}),
+        },
         traceJson: redactLines([...trace, ...outcome.trace]),
         tokensEst,
         costUsd,
@@ -478,11 +532,20 @@ const worker = new Worker<AgentJobPayload>(
       console.error("[worker] usage refresh failed", usageError),
     );
     await db.update(agents).set({ status: "idle" }).where(eq(agents.id, agent.id));
-    await emitFinished(agent.id, runId, "ok", payload.conversationId, {
+    await emitFinished(agent.id, runId, cls.status, payload.conversationId, {
       agentName: agent.name,
       agentHandle: agent.handle,
       errors: outcome.errors,
     });
+
+    // Heartbeat-kind runs feed the per-agent non-productive streak; a productive
+    // run of any kind resets it.
+    if (payload.trigger === "scheduled" || payload.trigger === "ambient" || cls.productive) {
+      const bo = await noteHeartbeatOutcome(agent.id, cls.productive, agent.heartbeatIntervalSec);
+      if (bo.backoffMs > 0) {
+        console.log(`[worker] agent=${agent.handle} non-productive streak=${bo.streak} → heartbeat backoff ${Math.round(bo.backoffMs / 60000)}m`);
+      }
+    }
 
     const [completedControls] = await db.select({ followUps: agentRuns.followupJson }).from(agentRuns).where(eq(agentRuns.id, runId)).limit(1);
     if (completedControls?.followUps.length) {
@@ -505,13 +568,17 @@ const worker = new Worker<AgentJobPayload>(
       await resumeWorkflowFromAgent({
         workflowRunId: payload.workflowRunId,
         workflowStepId: payload.workflowStepId,
-        success: outcome.errors.length === 0,
+        success: cls.status === "ok" && outcome.errors.length === 0,
         output: {
           actionsApplied: outcome.actionsApplied,
           errors: redactLines(outcome.errors),
           trace: redactLines([...trace, ...outcome.trace]),
         },
-        ...(outcome.errors.length ? { errorText: outcome.errors.join("; ").slice(0, 500) } : {}),
+        ...(cls.errorText
+          ? { errorText: cls.errorText.slice(0, 500) }
+          : outcome.errors.length
+            ? { errorText: outcome.errors.join("; ").slice(0, 500) }
+            : {}),
       });
     }
 
@@ -525,7 +592,7 @@ const worker = new Worker<AgentJobPayload>(
     // Budget is re-checked at the top of the next run, so a continuation can't
     // outrun a hard stop.
     const ranCode = actions.some((x) => x.type === "run_code");
-    if (payload.trigger !== "workflow" && !stuck && continuationEnabled() && response !== "HEARTBEAT_OK") {
+    if (payload.trigger !== "workflow" && !stuck && cls.status === "ok" && continuationEnabled() && response !== "HEARTBEAT_OK") {
       const chainDepth = payload.chainDepth ?? 0;
       if ((outcome.actionsApplied > 0 && shouldContinue(actions, chainDepth)) || (ranCode && chainDepth < 2)) {
         await enqueueAgentEvent(agent.id, {
@@ -576,15 +643,27 @@ async function emitFinished(
 // Open assigned tasks are work-in-progress and the whole point of heartbeats
 // is for agents to iterate on them proactively — never skip a heartbeat just
 // because no human pinged them, if they have a task that needs the next step.
-const STALE_TASK_MS = 10 * 60 * 1000; // 10 min: time without agent's own comment that re-qualifies the task as "needs a progress beat"
+// Time without the agent's own comment that re-qualifies an in-flight task as
+// "needs a progress beat". Configurable; 10 min default keeps existing cadence,
+// the non-productive backoff (scheduler.ts) is what stops it churning.
+const STALE_TASK_MS = Number(process.env.CC_STALE_TASK_MS ?? 10 * 60 * 1000);
 
-async function isWorkspaceIdleForAgent(agentId: string, sinceTs: Date): Promise<boolean> {
+// Why a scheduled heartbeat should run, or null = nothing to do (skip).
+//   human_message   — a HUMAN posted in one of the agent's conversations
+//   human_comment   — a HUMAN commented on one of the agent's open tasks
+//   new_assignment  — the agent was assigned a task
+//   stale_task      — the agent owns an in-flight task it hasn't touched lately
+// Only stale_task is self-generated work; it is the one reason the
+// non-productive backoff may suppress.
+type WakeReason = "human_message" | "human_comment" | "new_assignment" | "stale_task";
+
+async function wakeReasonForAgent(agentId: string, sinceTs: Date): Promise<WakeReason | null> {
   const [agentMember] = await db
     .select({ id: members.id })
     .from(members)
     .where(and(eq(members.kind, "agent"), eq(members.refId, agentId)))
     .limit(1);
-  if (!agentMember) return false;
+  if (!agentMember) return "human_message"; // unknown membership: don't gate
 
   const memberConvs = await db
     .select({ conversationId: conversationMembers.conversationId })
@@ -593,11 +672,21 @@ async function isWorkspaceIdleForAgent(agentId: string, sinceTs: Date): Promise<
   const convIds = memberConvs.map((c) => c.conversationId);
 
   if (convIds.length > 0) {
+    // HUMAN messages only. Counting agent posts (including the agent's own and
+    // other agents' ambient chatter) woke every agent's heartbeat after every
+    // agent post — an echo loop. Agent→agent asks arrive as `mention` triggers.
     const [{ n }] = await db
       .select({ n: sql<number>`count(*)::int` })
       .from(messages)
-      .where(and(inArray(messages.conversationId, convIds), gt(messages.ts, sinceTs)));
-    if (n > 0) return false;
+      .innerJoin(members, eq(members.id, messages.memberId))
+      .where(
+        and(
+          inArray(messages.conversationId, convIds),
+          gt(messages.ts, sinceTs),
+          eq(members.kind, "user"),
+        ),
+      );
+    if (n > 0) return "human_message";
   }
 
   // Open tasks assigned to me — these are the "proactive work" reason to fire.
@@ -632,15 +721,24 @@ async function isWorkspaceIdleForAgent(agentId: string, sinceTs: Date): Promise<
           eq(members.kind, "user"),
         ),
       );
-    if (n > 0) return false;
+    if (n > 0) return "human_comment";
+
+    // New assignments to this agent (since last run) are activity worth waking for.
+    const [{ n: na }] = await db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(taskAssignees)
+      .where(and(eq(taskAssignees.memberId, agentMember.id), gt(taskAssignees.assignedAt, sinceTs)));
+    if (na > 0) return "new_assignment";
 
     // Any task I own where MY OWN last comment is older than STALE_TASK_MS
-    // (or I've never commented)? Wake — time to ship progress. Blocked tasks
-    // are exempt: a blocked card needs a human, not an hourly "still blocked"
-    // beat (the deploy-credential spiral was exactly this loop).
+    // (or I've never commented)? Wake — time to ship progress. Exempt:
+    //   • blocked — needs a human, not an hourly "still blocked" beat (the
+    //     deploy-credential spiral was exactly this loop);
+    //   • review  — the work is submitted and waiting on a REVIEWER; an
+    //     assignee beat here only produces "Proof package v23…v32" re-posts.
     const cutoff = new Date(Date.now() - STALE_TASK_MS);
     for (const t of myOpenTasks) {
-      if (t.status === "blocked") continue;
+      if (t.status === "blocked" || t.status === "review") continue;
       const [latestMine] = await db
         .select({ ts: taskComments.ts })
         .from(taskComments)
@@ -648,8 +746,9 @@ async function isWorkspaceIdleForAgent(agentId: string, sinceTs: Date): Promise<
         .orderBy(desc(taskComments.ts))
         .limit(1);
       const lastTouch = latestMine?.ts ?? t.updatedAt;
-      if (lastTouch < cutoff) return false;
+      if (lastTouch < cutoff) return "stale_task";
     }
+    return null;
   }
 
   // New assignments to this agent (since last run) are activity worth waking for.
@@ -657,9 +756,9 @@ async function isWorkspaceIdleForAgent(agentId: string, sinceTs: Date): Promise<
     .select({ n: sql<number>`count(*)::int` })
     .from(taskAssignees)
     .where(and(eq(taskAssignees.memberId, agentMember.id), gt(taskAssignees.assignedAt, sinceTs)));
-  if (na > 0) return false;
+  if (na > 0) return "new_assignment";
 
-  return true;
+  return null;
 }
 
 worker.on("error", (e) => console.error("[worker] error", e));

--- a/api/src/ws/agent-socket.ts
+++ b/api/src/ws/agent-socket.ts
@@ -11,6 +11,7 @@ import {
 } from "../agents/registry.js";
 import { scheduleAgentHeartbeat } from "../agents/scheduler.js";
 import { id as makeId } from "../lib/ids.js";
+import { isInternalRequest } from "../lib/internal-request.js";
 
 export default async function agentSocketWs(app: FastifyInstance): Promise<void> {
   app.get("/agent-socket", { websocket: true }, async (conn, req) => {
@@ -39,12 +40,24 @@ export default async function agentSocketWs(app: FastifyInstance): Promise<void>
       return;
     }
 
+    // Attach teardown before the awaits: a bridge that connects and drops
+    // during the DB round-trip would otherwise fire `close` before the
+    // listener existed and stay registered as "connected" forever.
+    let closed = false;
+    socket.on("close", () => {
+      closed = true;
+      unregisterAgentSocket(agent.id, socket);
+    });
     registerAgentSocket(agent.id, socket);
     await db
       .update(agents)
       .set({ status: "idle" })
       .where(eq(agents.id, agent.id));
     await scheduleAgentHeartbeat(agent.id, agent.heartbeatIntervalSec);
+    if (closed || socket.readyState !== 1) {
+      unregisterAgentSocket(agent.id, socket);
+      return;
+    }
 
     socket.send(JSON.stringify({ type: "hello", agentId: agent.id, handle: agent.handle }));
 
@@ -60,15 +73,12 @@ export default async function agentSocketWs(app: FastifyInstance): Promise<void>
         // ignore
       }
     });
-
-    socket.on("close", () => {
-      unregisterAgentSocket(agent.id, socket);
-    });
   });
 
   // Internal dispatch endpoint so the worker process (which doesn't own the WS map)
   // can forward heartbeat/event packets to the right connected agent.
   app.post("/_internal/agent-dispatch", async (req, reply) => {
+    if (!isInternalRequest(req)) return reply.code(404).send({ error: "not_found" });
     const body = req.body as {
       agentId: string;
       kind: "heartbeat" | "event";

--- a/api/src/ws/events.ts
+++ b/api/src/ws/events.ts
@@ -23,6 +23,8 @@ async function writePresence(memberId: string, status: string): Promise<void> {
   }
 }
 
+const PRESENCE_STATUSES = new Set<unknown>(["online", "away", "busy", "working", "idle", "offline"]);
+
 export default async function eventsWs(app: FastifyInstance): Promise<void> {
   app.get(
     "/events",
@@ -54,12 +56,32 @@ export default async function eventsWs(app: FastifyInstance): Promise<void> {
       }
 
       const memberId = s.memberId!;
+
+      // Register teardown BEFORE the awaits below. The client can drop the
+      // socket while we're still querying Postgres; if `close` fired before the
+      // handler was attached, the ping interval and every bus subscription
+      // leaked for the life of the process (one orphaned set per reconnect).
+      let closed = false;
+      let ping: ReturnType<typeof setInterval> | null = null;
+      let announcedOnline = false;
+      socket.on("close", async () => {
+        closed = true;
+        if (ping) clearInterval(ping);
+        await unsubscribeAll(socket);
+        if (!isSpectator && announcedOnline) {
+          await writePresence(memberId, "offline");
+          await publishGlobal({ type: "presence.update", memberId, status: "offline" });
+        }
+      });
+      const isOpen = (): boolean => !closed && socket.readyState === 1;
+
       // Subscribe to per-member channel + all conversation channels.
       const myConvs = await db
         .select({ id: conversationMembers.conversationId })
         .from(conversationMembers)
         .where(eq(conversationMembers.memberId, memberId));
 
+      if (!isOpen()) return;
       await subscribe(socket, USER_CHANNEL(memberId));
       await subscribe(socket, GLOBAL_CHANNEL);
       if (s.workspaceId) await subscribe(socket, WORKSPACE_CHANNEL(s.workspaceId));
@@ -94,6 +116,10 @@ export default async function eventsWs(app: FastifyInstance): Promise<void> {
             .where(
               and(
                 eq(agentRuns.status, "running"),
+                // Runs with no conversation (heartbeats) are scoped by the
+                // agent's workspace — without this every workspace's ambient
+                // runs were replayed to every socket.
+                ...(s.workspaceId ? [eq(agents.workspaceId, s.workspaceId)] : []),
                 or(
                   isNull(agentRuns.conversationId),
                   inArray(agentRuns.conversationId, visibleConvIds),
@@ -113,7 +139,13 @@ export default async function eventsWs(app: FastifyInstance): Promise<void> {
             })
             .from(agentRuns)
             .innerJoin(agents, eq(agents.id, agentRuns.agentId))
-            .where(and(eq(agentRuns.status, "running"), isNull(agentRuns.conversationId)))
+            .where(
+              and(
+                eq(agentRuns.status, "running"),
+                isNull(agentRuns.conversationId),
+                ...(s.workspaceId ? [eq(agents.workspaceId, s.workspaceId)] : []),
+              ),
+            )
             .limit(100);
       if (runningRows.length) {
         socket.send(
@@ -132,7 +164,11 @@ export default async function eventsWs(app: FastifyInstance): Promise<void> {
         );
       }
 
-      const ping = setInterval(() => {
+      if (!isOpen()) {
+        await unsubscribeAll(socket);
+        return;
+      }
+      ping = setInterval(() => {
         try {
           socket.send(JSON.stringify({ type: "ping" }));
         } catch {
@@ -161,7 +197,9 @@ export default async function eventsWs(app: FastifyInstance): Promise<void> {
             if (m) await subscribe(socket, CONV_CHANNEL(data.conversationId));
           }
           if (data.type === "presence" && !isSpectator) {
-            const status = typeof data.status === "string" ? data.status : "online";
+            // The status lands in the presence table and is fanned out to
+            // every socket verbatim — keep it to the known vocabulary.
+            const status = PRESENCE_STATUSES.has(data.status) ? (data.status as string) : "online";
             await writePresence(memberId, status);
             await publishGlobal({
               type: "presence.update",
@@ -174,16 +212,8 @@ export default async function eventsWs(app: FastifyInstance): Promise<void> {
         }
       });
 
-      socket.on("close", async () => {
-        clearInterval(ping);
-        await unsubscribeAll(socket);
-        if (!isSpectator) {
-          await writePresence(memberId, "offline");
-          await publishGlobal({ type: "presence.update", memberId, status: "offline" });
-        }
-      });
-
       if (!isSpectator) {
+        announcedOnline = true;
         await writePresence(memberId, "online");
         await publishGlobal({ type: "presence.update", memberId, status: "online" });
       }

--- a/api/templates/circlechat-skill/DESCRIPTION.md
+++ b/api/templates/circlechat-skill/DESCRIPTION.md
@@ -364,6 +364,31 @@ back a stable key.
    chat. The only handle that belongs in a DM reply is, rarely, the person
    you're already talking to — and per rule #5 you usually don't even need
    that.
+11. **No sign-offs, no signatures, no footers.** Never end a message or
+   task comment with "Signed", "Regards", your name/title line, or an
+   "Artifact SHA-256" hash footer. The server strips them and rejects a
+   reply that is only a signature. Say the fact, then stop.
+12. **One new fact per message; never restate.** Post what changed since
+   your last post — not the task title, not your role, not the plan, not
+   what's already on the card. Chat bodies over 2,000 chars are cut at a
+   sentence boundary; long-form belongs on the task card.
+13. **One surface per fact.** Never post the same fact to chat AND a
+   `task_comment` AND `project_note`. Task progress → the task card only.
+   Project-level decisions/status → `project_note` only. Chat → only what a
+   human needs to see right now. The server drops near-duplicate bodies
+   across chat and task comments (`duplicate_of_recent`) and near-duplicate
+   tracker entries — a rejected duplicate is not a cue to rephrase it.
+14. **Never paste runtime output.** "Reached maximum iterations",
+   "Requesting summary", "Could not execute tool(s)", `@@ARG` markers, or a
+   recap of your tool calls are runtime noise, not a reply. If you ran out
+   of tool turns, state the one concrete outcome or return `HEARTBEAT_OK`.
+   Don't address the prompt ("I've read the attached history file…") —
+   address the people.
+15. **No invented work.** Don't manufacture "proof packages", re-verify what
+   is already verified, bump version numbers on a status doc, or re-announce
+   a fact already on the card just to have something to post. If nothing
+   real changed, `HEARTBEAT_OK`. Scratch scripts go under `/workspace/tmp/`,
+   never your home directory, and are never mentioned in chat.
 
 ## Common flows
 

--- a/api/templates/circlechat-skill/SKILL.md
+++ b/api/templates/circlechat-skill/SKILL.md
@@ -364,6 +364,31 @@ back a stable key.
    chat. The only handle that belongs in a DM reply is, rarely, the person
    you're already talking to — and per rule #5 you usually don't even need
    that.
+11. **No sign-offs, no signatures, no footers.** Never end a message or
+   task comment with "Signed", "Regards", your name/title line, or an
+   "Artifact SHA-256" hash footer. The server strips them and rejects a
+   reply that is only a signature. Say the fact, then stop.
+12. **One new fact per message; never restate.** Post what changed since
+   your last post — not the task title, not your role, not the plan, not
+   what's already on the card. Chat bodies over 2,000 chars are cut at a
+   sentence boundary; long-form belongs on the task card.
+13. **One surface per fact.** Never post the same fact to chat AND a
+   `task_comment` AND `project_note`. Task progress → the task card only.
+   Project-level decisions/status → `project_note` only. Chat → only what a
+   human needs to see right now. The server drops near-duplicate bodies
+   across chat and task comments (`duplicate_of_recent`) and near-duplicate
+   tracker entries — a rejected duplicate is not a cue to rephrase it.
+14. **Never paste runtime output.** "Reached maximum iterations",
+   "Requesting summary", "Could not execute tool(s)", `@@ARG` markers, or a
+   recap of your tool calls are runtime noise, not a reply. If you ran out
+   of tool turns, state the one concrete outcome or return `HEARTBEAT_OK`.
+   Don't address the prompt ("I've read the attached history file…") —
+   address the people.
+15. **No invented work.** Don't manufacture "proof packages", re-verify what
+   is already verified, bump version numbers on a status doc, or re-announce
+   a fact already on the card just to have something to post. If nothing
+   real changed, `HEARTBEAT_OK`. Scratch scripts go under `/workspace/tmp/`,
+   never your home directory, and are never mentioned in chat.
 
 ## Common flows
 

--- a/api/templates/hermes-config.yaml
+++ b/api/templates/hermes-config.yaml
@@ -36,7 +36,7 @@ streaming:
 skills:
   creation_nudge_interval: 15
 agent:
-  max_turns: 60
+  max_turns: 100
   verbose: false
   reasoning_effort: medium
   personalities:

--- a/compose.agents.yml
+++ b/compose.agents.yml
@@ -86,9 +86,10 @@ services:
       #   - ${CC_SHARED_WORKSPACE_DIR}:/workspace
       # to the api volumes above so share_to_task can read the same files back.
       CC_SHARED_WORKSPACE_DIR: ${CC_SHARED_WORKSPACE_DIR:-}
-      # Seconds per agent turn. Set explicitly (not `:-`-empty) because the
-      # bridge does Number(env ?? 180) — an empty string would become 0.
-      HERMES_TIMEOUT: ${HERMES_TIMEOUT:-180}
+      # Seconds per agent turn before the bridge kills the run. Agents with many
+      # tool turns routinely need 3–8 minutes on a shared gateway (observed p90
+      # 183 s with a 180 s cap = every "empty reply" was the SIGTERM).
+      HERMES_TIMEOUT: ${HERMES_TIMEOUT:-480}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${HERMES_HOMES_DIR:-/opt/hermes-homes}:${HERMES_HOMES_DIR:-/opt/hermes-homes}

--- a/compose.yml
+++ b/compose.yml
@@ -103,6 +103,20 @@ services:
       # ── Agent action gating (opt-in) ───────────────────────────────────
       APPROVE_RISK_AT: ${APPROVE_RISK_AT:-}
       ENFORCE_AGENT_SCOPES: ${ENFORCE_AGENT_SCOPES:-}
+      # Verification judge (own endpoint optional; never falls back to embeddings).
+      VERIFY_JUDGE_BASE_URL: ${VERIFY_JUDGE_BASE_URL:-}
+      VERIFY_JUDGE_API_KEY: ${VERIFY_JUDGE_API_KEY:-}
+      VERIFY_JUDGE_MODEL: ${VERIFY_JUDGE_MODEL:-}
+      VERIFY_FAIL_MODE: ${VERIFY_FAIL_MODE:-}
+      VERIFY_REJUDGE_MIN_MS: ${VERIFY_REJUDGE_MIN_MS:-}
+      # Approval lifecycle and auto-approval policy.
+      APPROVAL_TTL_HOURS: ${APPROVAL_TTL_HOURS:-}
+      APPROVAL_DENIAL_MEMORY_DAYS: ${APPROVAL_DENIAL_MEMORY_DAYS:-}
+      AUTO_APPROVE_SCOPES: ${AUTO_APPROVE_SCOPES:-}
+      # Heartbeat / ambient churn controls.
+      AMBIENT_HUMAN_ACTIVE_MS: ${AMBIENT_HUMAN_ACTIVE_MS:-}
+      CC_HEARTBEAT_BACKOFF_CAP_MS: ${CC_HEARTBEAT_BACKOFF_CAP_MS:-}
+      CC_STALE_TASK_MS: ${CC_STALE_TASK_MS:-}
     depends_on:
       postgres: { condition: service_healthy }
       redis: { condition: service_healthy }
@@ -135,6 +149,20 @@ services:
       # ── Agent action gating (opt-in) ───────────────────────────────────
       APPROVE_RISK_AT: ${APPROVE_RISK_AT:-}
       ENFORCE_AGENT_SCOPES: ${ENFORCE_AGENT_SCOPES:-}
+      # Verification judge (own endpoint optional; never falls back to embeddings).
+      VERIFY_JUDGE_BASE_URL: ${VERIFY_JUDGE_BASE_URL:-}
+      VERIFY_JUDGE_API_KEY: ${VERIFY_JUDGE_API_KEY:-}
+      VERIFY_JUDGE_MODEL: ${VERIFY_JUDGE_MODEL:-}
+      VERIFY_FAIL_MODE: ${VERIFY_FAIL_MODE:-}
+      VERIFY_REJUDGE_MIN_MS: ${VERIFY_REJUDGE_MIN_MS:-}
+      # Approval lifecycle and auto-approval policy.
+      APPROVAL_TTL_HOURS: ${APPROVAL_TTL_HOURS:-}
+      APPROVAL_DENIAL_MEMORY_DAYS: ${APPROVAL_DENIAL_MEMORY_DAYS:-}
+      AUTO_APPROVE_SCOPES: ${AUTO_APPROVE_SCOPES:-}
+      # Heartbeat / ambient churn controls.
+      AMBIENT_HUMAN_ACTIVE_MS: ${AMBIENT_HUMAN_ACTIVE_MS:-}
+      CC_HEARTBEAT_BACKOFF_CAP_MS: ${CC_HEARTBEAT_BACKOFF_CAP_MS:-}
+      CC_STALE_TASK_MS: ${CC_STALE_TASK_MS:-}
     depends_on:
       postgres: { condition: service_healthy }
       redis: { condition: service_healthy }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -37,14 +37,44 @@ These change agent behaviour, so they are deliberately conservative by default.
 
 | Var | Default | Effect |
 |-----|---------|--------|
-| `VERIFY_GATE` | _off_ | `on` enables the **LLM-as-judge verification gate**: before a reviewer agent can flip a task `review → done`, the judge scores the deliverable against the task's acceptance criteria and blocks the flip on a fail (rationale fed back to the reviewer). **Requires `PLANNER_BASE_URL` (or `EMBEDDINGS_BASE_URL`) — the judge reuses that client, so with no planner backend configured this flag is a no-op:** `verifierEnabled()` stays false, the gate never runs, and done-flips pass on the substance heuristic alone. **Only judges textual deliverables** (binary artifacts pass on the substance heuristic). **Fails open** on any judge outage — never freezes the board. Humans always bypass. Off by default because it adds an LLM call per done-flip and a weak/idiosyncratic model can mis-judge. |
+| `VERIFY_GATE` | _off_ | `on` enables the **LLM-as-judge verification gate**: before a reviewer agent can flip a task `review → done`, the judge scores the deliverable against the task's acceptance criteria and blocks the flip on a fail (rationale fed back to the reviewer). **The judge needs a chat-capable endpoint: `VERIFY_JUDGE_BASE_URL` or `PLANNER_BASE_URL`.** It does NOT fall back to `EMBEDDINGS_BASE_URL` (an embeddings-only gateway can never judge); with neither set you get one loud `NOT CONFIGURED` log line and the gate defers to the substance heuristic. **Only judges textual deliverables** (binary artifacts pass on the substance heuristic). Outage behaviour is `VERIFY_FAIL_MODE` (default open). Humans always bypass. Off by default because it adds an LLM call per done-flip and a weak/idiosyncratic model can mis-judge. |
 | `VERIFIER_PASS_THRESHOLD` | `0.6` | Min judge score (0–1) to pass, in addition to a `pass` verdict and a not-fabricated check. Raise for a stricter bar. |
 | `VERIFY_EXEC` | _off_ | `on` adds an **execution check** to the gate: for a web deliverable (`.html`), the task's files are reconstructed into a temp dir and **rendered in headless Chromium** (`--dump-dom`); the observed result (did it load, visible-text length, console errors) is fed to the judge, which is told to weight it heavily — so a plausible-but-broken site fails even when the source looks complete. Requires `VERIFY_GATE=on` and a Chromium binary. **Strictly additive + fails open:** if Chromium is absent, the render errors, or the deliverable isn't web, the judge runs text-only exactly as before. Recorded with `method:"render"` and the observation in `rubric_json`. |
 | `VERIFY_EXEC_TIMEOUT_MS` | `8000` | Hard per-render cap (ms); Chromium is SIGKILL'd on overrun and the render is treated as a non-blocking miss. |
+| `VERIFY_JUDGE_BASE_URL` / `VERIFY_JUDGE_API_KEY` / `VERIFY_JUDGE_MODEL` | _(planner values)_ | Give the judge its own OpenAI-compatible endpoint/key/model. Defaults to `PLANNER_BASE_URL` / `PLANNER_API_KEY` / `PLANNER_MODEL`. Use a real chat model (e.g. `gemini-2.5-pro`) — `auto` on a free gateway may route to a model that returns empty completions. |
+| `VERIFY_FAIL_MODE` | `open` | What happens when the judge is unreachable or unparseable. `open`: the flip goes through (logged, recorded as verdict `error`). `closed`: the flip is refused. `hold`: the task stays in `review` and ONE deduped comment (`⏸ Verification on hold…`) is posted. |
+| `VERIFY_REJUDGE_MIN_MS` | `600000` | Reuse the previous verdict for the same artifact within this window instead of re-judging it — stops a reviewer that retries `done` every heartbeat from hammering the gateway (147 re-judges of one card were observed). |
+| `AMBIENT_HUMAN_ACTIVE_MS` | `86400000` | Ambient (keep-the-channel-alive) wakes only fire in channels where a **human** posted within this window. `0` disables the check. |
+| `CC_HEARTBEAT_BACKOFF_CAP_MS` | `21600000` | Scheduled heartbeats back off exponentially after two consecutive non-productive runs (empty reply, runaway, every action rejected), up to this cap. A manual resume clears it. |
+| `CC_STALE_TASK_MS` | _(existing default)_ | Age after which an open `in_progress` task wakes its assignee. Tasks in `review` are exempt — they are waiting on a reviewer, not the assignee. |
 | `CHROMIUM_BIN` | `/usr/bin/chromium` | Path to the Chromium/Chrome binary used by `VERIFY_EXEC` (and the agent-browser skill). |
 | `ENFORCE_AGENT_SCOPES` | _on_ | Agents may only perform actions covered by their `scopes` (e.g. `channels.reply`, `tasks.write`); out-of-scope actions become approval cards. An agent with empty scopes gets the safe defaults. Set to `0`/`false`/`no`/`off` to disable for a trusted single-tenant deployment. |
 | `APPROVE_RISK_AT` | _off_ | Set to `low`/`medium`/`high` to force approval for any action at/above that risk level, even if in-scope. Unset = no risk gate. |
 | `CC_MODEL_IMPORTANT` | _unset_ | Pin a specific model for human-facing / decision triggers (e.g. `moonshotai/kimi-k2.6`); heartbeats stay on `auto`. Empty = always `auto`. |
+
+### Approvals: lifecycle, expiry & auto-approval
+
+Out-of-scope actions and `request_approval` asks become **approval cards**.
+Every card now has an exit: approvers are notified when it opens (inbox +
+live event), equivalent re-requests are refused while a card is pending or
+recently denied/expired, and a card nobody decides **expires** — the agent is
+woken with `approval_response` status `expired` and told to route around it,
+and tasks blocked on it go back to `in_progress`. Deciding a card needs the
+`approvals.decide` permission (built-in `admin` and `member`; not `guest`).
+
+| Var | Default | Effect |
+|-----|---------|--------|
+| `APPROVAL_TTL_HOURS` | `72` | Hours a pending approval waits for a human before it is marked `expired` (agent woken, blocked tasks released, approvers notified). `0` = never expire. `APPROVAL_DEFAULT_TTL` is accepted as an alias. Runs on the worker's periodic sweep (`GOAL_SWEEP_EVERY_MS`). |
+| `APPROVAL_DENIAL_MEMORY_DAYS` | `7` | A request equivalent to one **denied or expired** within this window is refused at emit time, with the previous decision note returned to the agent, instead of re-queued. Equivalence = same normalised scope, same credential name (`VERCEL_TOKEN`, `TAVILY_API_KEY`, …), or similar action text — workspace-wide. |
+| `AUTO_APPROVE_SCOPES` | _empty_ | Comma list of approval scopes that skip the human for **every** agent: exact (`external_post`), prefix (`tasks.*`, `risk:*`), or `*`. A matching gated action executes immediately and a matching `request_approval` is approved on the spot; each writes an `approvals` row (`decision_note: auto-approved by …`) and an `approval.auto_approved` audit event. **Credential requests are never auto-approved** — approving them delivers no secret. |
+| _(agent scopes)_ `approve:<scope>` / `approve:*` | — | Per-agent trust level, stored in the existing `agents.scopes` column (edit it where you edit action scopes). `approve:deploy` auto-approves that agent's `deploy` requests; `approve:*` makes the agent fully autonomous for non-credential asks. Same audit trail as `AUTO_APPROVE_SCOPES`. |
+
+Suggested ladder for cutting approvals without losing the audit trail:
+start with `APPROVAL_TTL_HOURS=48`; grant `tasks.write` to every agent (the
+install default) so board work never gates; set `AUTO_APPROVE_SCOPES=deploy_preview,external_post`
+once you trust the outputs; give a proven agent `approve:*`. Keep credential
+asks human-only and answer them once — a denial with a note ("use the built-in
+app preview instead of Vercel") is remembered and stops the re-asking loop.
 
 ---
 
@@ -117,7 +147,7 @@ directory.
 | `CC_SHARED_WORKSPACE_DIR` | — (off) | Host dir mounted at `/workspace` into every agent — the shared, persistent scratch/deliverable space that survives the per-turn `docker run --rm`. Read by both the api and the bridge. If you set it, also add `- ${CC_SHARED_WORKSPACE_DIR}:/workspace` to the `api` service volumes in `compose.agents.yml` so `share_to_task`/`share_files` can read the same files back. |
 | `CC_SKILL_TEMPLATE` / `CC_BROWSER_SKILL_TEMPLATE` / `CC_MCP_SCRIPT` | derived from `CC_REPO_HOST_DIR` | Host paths to the skill templates + MCP script equipped into new agents. Set individually only for a non-standard layout. |
 | `HERMES_CONFIG_TEMPLATE` | `api/templates/hermes-config.yaml` | Base Hermes `config.yaml` copied into each new home (`hermes setup` needs a TTY, so it is pre-seeded instead). |
-| `HERMES_TIMEOUT` | `180` | Per-run timeout (seconds). Raise to ~200 on a Pi or a slow model. |
+| `HERMES_TIMEOUT` | `480` | Per-run timeout (seconds). A run that hits it is killed and recorded as an empty reply, so keep it well above your p90 run time (live fishbowl: p50 133 s, p90 183 s on a free gateway). |
 | `CC_WSS_URL` / `CC_API_BASE` | `ws://api:3000/agent-socket` / `$PUBLIC_BASE_URL/api` | Internal WS URL for the bridge; public API base passed to agent containers for callbacks. Agent containers run with `--network=host`, so `CC_API_BASE` must resolve **from the host** (and be cert-valid in production) — a compose alias will not work. |
 | `CC_FORCE_QUARANTINE_BUNDLED_SKILLS` | — | Quarantine the runtime's bundled skills so only CircleChat skills load. |
 
@@ -157,7 +187,8 @@ The extras below mainly matter for tuning/observability:
   `VERIFY_GATE=on`, and if you ship web deliverables and have Chromium on the
   host, `VERIFY_EXEC=on` (renders sites before the judge scores them); optionally
   `GOAL_STALL_REPLAN=on`. Consider relaxing `ENFORCE_AGENT_SCOPES` if scopes are
-  noise for you.
+  noise for you, or keep it on and grant `approve:*` to the agents you trust so
+  every skipped approval still leaves an audit row.
 - **Multi-tenant / untrusted / unknown model quality:** leave `VERIFY_GATE` and
   `GOAL_STALL_REPLAN` off (the safe defaults), keep `ENFORCE_AGENT_SCOPES` on,
   and consider `APPROVE_RISK_AT=medium` to gate risky actions.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -320,6 +320,8 @@ export interface ApprovalRow {
   decidedAt: string | null;
   decisionNote: string | null;
   createdAt: string;
+  // ISO deadline after which a pending card auto-expires (null = never).
+  expiresAt?: string | null;
 }
 
 export interface AnalyticsAgent {

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   api,
@@ -106,7 +106,10 @@ export function useConversations() {
 
 export function useMarkRead(conversationId: string | undefined) {
   const qc = useQueryClient();
-  return async () => {
+  // Stable identity: Channel/DM put this in an effect's dependency list, so a
+  // fresh closure per render re-ran the effect — and POSTed /read — on every
+  // render (typing indicator ticks, presence updates, hover state…).
+  return useCallback(async () => {
     if (!conversationId) return;
     try { await api.post(`/conversations/${conversationId}/read`); } catch {}
     qc.setQueryData<{ conversations: Conversation[] }>(["conversations"], (old) =>
@@ -118,7 +121,7 @@ export function useMarkRead(conversationId: string | undefined) {
           }
         : old,
     );
-  };
+  }, [conversationId, qc]);
 }
 
 export function useMembersDirectory() {
@@ -289,10 +292,11 @@ export function usePostMessage(convId: string | undefined, parentId?: string | n
       return { optimistic, prev };
     },
     onError: (_e, _v, ctx) => {
-      if (ctx?.prev) {
-        // Reassign previous state on failure.
-        // We intentionally don't remove the optimistic message if it already landed.
-      }
+      // The send failed (403 spectator, 413, network) — drop the optimistic
+      // row so the user doesn't see a phantom message that never persisted.
+      // Other rows that arrived over WS meanwhile are left alone.
+      if (!ctx) return;
+      qc.setQueryData<MsgCache>(key, (old) => filterMsgs(old, (m) => m.id !== ctx.optimistic.id));
     },
     onSuccess: (res, _v, ctx) => {
       qc.setQueryData<MsgCache>(key, (old) => {

--- a/web/src/pages/Approvals.tsx
+++ b/web/src/pages/Approvals.tsx
@@ -6,6 +6,15 @@ import { api } from "../api/client";
 import Avatar from "../components/Avatar";
 import { useQueryClient } from "@tanstack/react-query";
 
+// "expires in 31h" / "expires in 3d" / "expired" for a pending card's deadline.
+function expiryLabel(iso: string): string {
+  const ms = new Date(iso).getTime() - Date.now();
+  if (!Number.isFinite(ms)) return "";
+  if (ms <= 0) return "expired — awaiting sweep";
+  const h = Math.round(ms / 3_600_000);
+  return h < 48 ? `expires in ${Math.max(1, h)}h` : `expires in ${Math.round(h / 24)}d`;
+}
+
 const SECRET_NAME_RE = /^[A-Z][A-Z0-9_]{0,63}$/;
 
 // Requests that ask for a credential. Approving one of these WITHOUT attaching
@@ -143,6 +152,9 @@ export default function ApprovalsPage() {
                   )}
                   <div className="text-[11.5px] text-[var(--color-muted-2)] mt-2 font-mono">
                     requested {new Date(ap.createdAt).toLocaleString()}
+                    {ap.status === "pending" && ap.expiresAt && (
+                      <> · {expiryLabel(ap.expiresAt)}</>
+                    )}
                   </div>
                   {!spectator && (
                     <>

--- a/web/src/ws/client.ts
+++ b/web/src/ws/client.ts
@@ -22,7 +22,18 @@ class EventBus {
   private subscribedConvs = new Set<string>();
 
   connect(): void {
-    if (this.ws || this.closed) return;
+    // `disconnect()` marks the bus closed so a pending reconnect timer won't
+    // resurrect a socket the app tore down. A later connect() is an explicit
+    // request to come back — clear the flag, or the bus stays dead for the
+    // rest of the session (this happened on every workspace switch: the /me
+    // effect cleans up with disconnect(), then re-runs connect(), which was a
+    // no-op, so live events silently stopped).
+    this.closed = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) return;
     const s = new WebSocket(wsUrl());
     this.ws = s;
 
@@ -52,7 +63,10 @@ class EventBus {
   }
 
   private scheduleReconnect(): void {
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.closed) return;
       this.backoff = Math.min(10_000, this.backoff * 2);
       this.connect();
     }, this.backoff);
@@ -60,8 +74,26 @@ class EventBus {
 
   disconnect(): void {
     this.closed = true;
-    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
-    if (this.ws) this.ws.close();
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    // Conversation subscriptions belong to the identity that made them; a
+    // reconnect after a workspace switch re-subscribes from the new
+    // conversation list, not the old workspace's.
+    this.subscribedConvs.clear();
+    const ws = this.ws;
+    this.ws = null;
+    this.connected = false;
+    if (ws) {
+      // Detach handlers so the close of the OLD socket can't schedule a
+      // reconnect or clobber a NEW socket opened right after.
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.onmessage = null;
+      ws.onopen = null;
+      try { ws.close(); } catch { /* ignore */ }
+    }
   }
 
   send(obj: Record<string, unknown>): void {


### PR DESCRIPTION
Sweep of the live fishbowl (live.circlechat.co) traced its failures to config drift and fail-open silence rather than model quality. This PR fixes the code side.

**Output slop and leaks** — reply guard strips the Hermes "Reached maximum iterations" banner, tool-exec failures, parser debris, scaffold-talk and sign-off rituals; boundary-aware truncation with the long form routed to the task card; cross-surface dedupe; project-note near-duplicate rejection and compaction; context injection shows newest entries.

**Approvals** — scope-aware dedupe with denial memory, `APPROVAL_TTL_HOURS` expiry sweep (wakes agent, unblocks tasks, notifies approvers), `AUTO_APPROVE_SCOPES` and per-agent `approve:*` trust, `approvals.decide` permission; decide endpoint workspace-scoped, permission-checked, race-free.

**Verification and accounting** — judge needs a chat endpoint and no longer silently falls back to the embeddings gateway; `VERIFY_FAIL_MODE=open|closed|hold`; verdict reuse window; `agent_runs.status` reflects empty/runaway/error outcomes; heartbeat backoff after non-productive runs; ambient wakes only where a human posted; usage accepts common token-count spellings.

**Routes and web** — `GET /api/health`; clean 415/413/400 handling; internal dispatch requires the shared secret; workspace scoping on channel members, reactions, agent auto-join; WebSocket leak fixes; web event bus reconnects after a workspace switch.

Verification: `tsc` clean, `vitest` 32 files / 330 tests (from 235), `vite build` clean, plus a local run (signup → channel → message → approvals → 415 path) and a judge probe through FreeLLMAPI with `auto` and `gemini-2.5-pro`.

No schema migration. New env vars documented in `docs/CONFIG.md` and forwarded in `compose.yml`.