### PR TITLE
Guide the first run: getting-started checklist, How it works page, clearer signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ docker compose up --build
 open http://localhost
 ```
 
-That's it. The first user to sign up becomes the workspace admin. Create a channel, send a message, you're live.
+That's it. The first user to sign up becomes the workspace admin. The signup wizard offers to install your first agent (Hermes or OpenClaw, on any OpenAI-compatible provider) and lands you in `#general` with a short checklist: @-mention the agent, give it a card on the Board, invite a teammate. The in-app **How it works** page (sidebar → Show more) explains the model in five minutes: agents are members, the Board is the work queue, done means verified, risky actions wait for you.
 
 Caddy serves the web bundle at `/` and reverse-proxies `/api/*`, `/events`, `/agent-socket`, and `/uploads/*` to the API container.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import AnalyticsPage from "./pages/Analytics";
 import BoardPage from "./pages/Board";
 import GoalsPage from "./pages/Goals";
 import SettingsPage from "./pages/Settings";
+import WelcomePage from "./pages/Welcome";
 import AutomationPage from "./pages/Automation";
 import PlatformPage from "./pages/Platform";
 import NeedsYouPage from "./pages/NeedsYou";
@@ -108,6 +109,7 @@ function Shell() {
         <Route path="/automation" element={<AutomationPage />} />
         <Route path="/platform" element={<PlatformPage />} />
         <Route path="/settings" element={<SettingsPage />} />
+        <Route path="/welcome" element={<WelcomePage />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -21,9 +21,12 @@ interface Props {
   conversationId: string;
   onTyping?: () => void;
   hideHint?: boolean;
+  // Text pushed into the box from outside (first-run "Mention @agent" button).
+  // `nonce` changes on every push so the same text can be re-applied.
+  prefill?: { text: string; nonce: number } | null;
 }
 
-export default function Composer({ placeholder, onSend, conversationId, onTyping, hideHint }: Props) {
+export default function Composer({ placeholder, onSend, conversationId, onTyping, hideHint, prefill }: Props) {
   const spectator = useSpectator();
   const [body, setBody] = useState("");
   const [files, setFiles] = useState<Attachment[]>([]);
@@ -43,6 +46,18 @@ export default function Composer({ placeholder, onSend, conversationId, onTyping
     : [];
 
   useEffect(() => setMentionIdx(0), [mentionOpen?.q]);
+
+  useEffect(() => {
+    if (!prefill || !prefill.text) return;
+    setBody(prefill.text);
+    const t = ref.current;
+    setTimeout(() => {
+      if (!t) return;
+      t.focus();
+      t.setSelectionRange(prefill.text.length, prefill.text.length);
+    }, 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefill?.nonce]);
 
   const [emojiOpen, setEmojiOpen] = useState(false);
   const EMOJIS = ["👍", "❤️", "😂", "🎉", "🔥", "🙏", "✅", "👀", "🚀", "🍜", "😊", "😢", "🤔", "💯", "👋", "🙌"];

--- a/web/src/components/GettingStarted.tsx
+++ b/web/src/components/GettingStarted.tsx
@@ -1,0 +1,73 @@
+import { Link } from "react-router-dom";
+import { Check, ChevronDown, ChevronUp, X } from "lucide-react";
+import { useState } from "react";
+import type { OnboardingState } from "../lib/onboarding";
+
+interface Props {
+  state: OnboardingState;
+  // Puts text into the channel composer (used by "Say hello").
+  onPrefill?: (text: string) => void;
+}
+
+// Compact first-run card shown at the top of a new workspace's first channel.
+// Every step is derived from live data (see lib/onboarding.ts) and ticks itself.
+export default function GettingStarted({ state, onPrefill }: Props) {
+  const [open, setOpen] = useState(true);
+  if (!state.ready || state.dismissed || state.complete) return null;
+  const a = state.agent;
+
+  return (
+    <section className="gs" aria-label="Getting started">
+      <div className="gs-head">
+        <div className="min-w-0">
+          <div className="gs-title">Welcome to CircleChat</div>
+          <div className="gs-sub">
+            Team chat where AI agents are members. They read the channels, take work from the Board, do it in
+            their own sandbox, and ask you before anything risky.{" "}
+            <Link to="/welcome" className="gs-link">How it works →</Link>
+          </div>
+        </div>
+        <div className="gs-actions">
+          <span className="gs-progress">{state.doneCount}/{state.steps.length}</span>
+          <button type="button" className="gs-icon" onClick={() => setOpen((v) => !v)} title={open ? "Collapse" : "Expand"}>
+            {open ? <ChevronUp size={14} strokeWidth={2} /> : <ChevronDown size={14} strokeWidth={2} />}
+          </button>
+          <button type="button" className="gs-icon" onClick={state.dismiss} title="Hide getting started (find it again under Show more → How it works)">
+            <X size={14} strokeWidth={2} />
+          </button>
+        </div>
+      </div>
+      {open && (
+        <ol className="gs-steps">
+          {state.steps.map((s, i) => (
+            <li key={s.id} className={`gs-step ${s.done ? "done" : ""}`}>
+              <span className="gs-num">{s.done ? <Check size={12} strokeWidth={3} /> : i + 1}</span>
+              <div className="min-w-0 flex-1">
+                <div className="gs-step-title">{s.title}</div>
+                {!s.done && <div className="gs-step-why">{s.why}</div>}
+                {s.status && !s.done && s.id !== "agent" ? null : s.status && <div className="gs-step-status">{s.status}</div>}
+              </div>
+              {!s.done && (
+                <div className="gs-step-cta">
+                  {s.id === "agent" && <Link to="/members?add=agent" className="btn sm primary">Add agent</Link>}
+                  {s.id === "hello" && a && (
+                    <button
+                      type="button"
+                      className="btn sm primary"
+                      onClick={() => onPrefill?.(`@${a.handle} hello! What can you do in this workspace?`)}
+                    >
+                      Mention @{a.handle}
+                    </button>
+                  )}
+                  {s.id === "hello" && !a && <span className="gs-step-status">Add an agent first</span>}
+                  {s.id === "task" && <Link to="/board" className="btn sm">Open Board</Link>}
+                  {s.id === "invite" && <Link to="/members" className="btn sm">Members</Link>}
+                </div>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useEffect, useMemo, useState } from "react";
-import { Hash, Plus, FolderOpen, Network, BookOpen, Inbox, LayoutGrid, Target, BarChart3, MoreHorizontal, Workflow, Boxes } from "lucide-react";
+import { Hash, Plus, FolderOpen, Network, BookOpen, Inbox, LayoutGrid, Target, BarChart3, MoreHorizontal, Workflow, Boxes, Sparkles, CircleHelp } from "lucide-react";
+import { useOnboarding } from "../lib/onboarding";
 import { useConversations, useMe, useMembersDirectory, useNeedsYou, useTasks, useSpectator } from "../lib/hooks";
 import { api, type Conversation, type DirMember } from "../api/client";
 import { useQueryClient } from "@tanstack/react-query";
@@ -101,6 +102,9 @@ export default function Sidebar() {
       });
   }, [dir.data, existingDms, me.data]);
 
+  const onboarding = useOnboarding();
+  const showGettingStarted = onboarding.ready && !onboarding.dismissed && !onboarding.complete;
+
   async function createChannel() {
     if (!newName) return;
     const handle = newName.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
@@ -121,6 +125,27 @@ export default function Sidebar() {
       </div>
 
       <div className="sb-group">
+        {showGettingStarted && (
+          <Link
+            to="/welcome"
+            className={`sb-item ${location.pathname === "/welcome" ? "active" : ""}`}
+          >
+            <span className="sb-glyph"><Sparkles size={14} strokeWidth={2} /></span>
+            <span className="sb-name">Getting started</span>
+            <span className="sb-badge">{onboarding.doneCount}/{onboarding.steps.length}</span>
+          </Link>
+        )}
+        {spectator && (
+          // Public read-only visitors get the explainer up front — it is the
+          // fastest way to understand what they are watching.
+          <Link
+            to="/welcome"
+            className={`sb-item ${location.pathname === "/welcome" ? "active" : ""}`}
+          >
+            <span className="sb-glyph"><CircleHelp size={14} strokeWidth={2} /></span>
+            <span className="sb-name">How it works</span>
+          </Link>
+        )}
         <Link
           to="/board"
           className={`sb-item ${location.pathname === "/board" ? "active" : ""} ${boardUnread > 0 ? "unread" : ""}`}
@@ -204,6 +229,15 @@ export default function Sidebar() {
               </span>
               <span className="sb-name">Org chart</span>
             </Link>
+            {!showGettingStarted && !spectator && (
+              <Link
+                to="/welcome"
+                className={`sb-item ${location.pathname === "/welcome" ? "active" : ""}`}
+              >
+                <span className="sb-glyph"><CircleHelp size={14} strokeWidth={2} /></span>
+                <span className="sb-name">How it works</span>
+              </Link>
+            )}
           </>
         )}
         <button

--- a/web/src/lib/onboarding.ts
+++ b/web/src/lib/onboarding.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAgents, useConversations, useMe, useMembersDirectory, useMessages, useSpectator, useTasks } from "./hooks";
+
+// First-run checklist, derived from real workspace state rather than a stored
+// wizard position — so it stays correct if the admin adds an agent from
+// Members, posts from another device, or skips a step. Dismissal is the only
+// thing persisted (per workspace, in localStorage).
+
+export interface OnboardingStep {
+  id: "agent" | "hello" | "task" | "invite";
+  title: string;
+  why: string;
+  done: boolean;
+  // Short live status under the title (e.g. "@ceo is starting…").
+  status?: string;
+}
+
+export interface OnboardingState {
+  ready: boolean;
+  steps: OnboardingStep[];
+  doneCount: number;
+  complete: boolean;
+  dismissed: boolean;
+  dismiss: () => void;
+  restore: () => void;
+  // The agent to suggest in copy/prefills (first one installed), if any.
+  agent: { handle: string; name: string; status: string } | null;
+  firstChannelId: string | null;
+  // True while the workspace looks brand new: no agent reply anywhere yet.
+  fresh: boolean;
+}
+
+function storageKey(workspaceId: string | null | undefined): string {
+  return `cc.onboarding.dismissed.${workspaceId ?? "ws"}`;
+}
+
+function readDismissed(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function useOnboarding(channelId?: string | null): OnboardingState {
+  const me = useMe();
+  const spectator = useSpectator();
+  const agents = useAgents();
+  const dir = useMembersDirectory();
+  const tasks = useTasks();
+  const convs = useConversations();
+
+  const channels = useMemo(
+    () => (convs.data?.conversations ?? []).filter((c) => c.kind === "channel"),
+    [convs.data],
+  );
+  const firstChannelId = channels[0]?.id ?? null;
+  const watchId = channelId ?? firstChannelId ?? undefined;
+  const msgs = useMessages(watchId);
+
+  const key = storageKey(me.data?.workspaceId);
+  const [dismissed, setDismissed] = useState<boolean>(() => readDismissed(key));
+  useEffect(() => setDismissed(readDismissed(key)), [key]);
+
+  const dismiss = useCallback(() => {
+    try {
+      localStorage.setItem(key, "1");
+    } catch {
+      // private mode etc. — in-memory state still hides it for this session
+    }
+    setDismissed(true);
+  }, [key]);
+  const restore = useCallback(() => {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+    setDismissed(false);
+  }, [key]);
+
+  const agentRows = agents.data?.agents ?? [];
+  const first = agentRows[0] ?? null;
+  const agentMemberIds = useMemo(
+    () => new Set((dir.data?.agents ?? []).map((a) => a.memberId)),
+    [dir.data],
+  );
+  const humans = dir.data?.humans ?? [];
+
+  const agentReplied = (msgs.messages ?? []).some((m) => agentMemberIds.has(m.memberId));
+  const hasTask = (tasks.data?.tasks ?? []).length > 0;
+
+  const agentStatus = first
+    ? first.status === "provisioning"
+      ? `@${first.handle} is starting — first boot pulls the runtime image and can take a few minutes`
+      : first.status === "paused"
+        ? `@${first.handle} is paused — resume it from its profile`
+        : `@${first.handle} is connected`
+    : undefined;
+
+  const steps: OnboardingStep[] = [
+    {
+      id: "agent",
+      title: "Add an agent",
+      why: "Agents are members here, not bots: they have a handle, a role, and they read the same channels you do.",
+      done: agentRows.length > 0,
+      status: agentStatus,
+    },
+    {
+      id: "hello",
+      title: first ? `Say hello to @${first.handle}` : "Say hello to your agent",
+      why: "Agents reply when @-mentioned or DM'd. Ask what it can do — it will tell you in its own words.",
+      done: agentReplied,
+    },
+    {
+      id: "task",
+      title: "Give it a task on the Board",
+      why: "The Board is the work queue. Assign a card to an agent; it picks it up on its next beat, works in its own sandbox, and attaches the deliverable to the card.",
+      done: hasTask,
+    },
+    {
+      id: "invite",
+      title: "Invite a teammate",
+      why: "Humans and agents sit in the same channels. Invites go out from Members; teammates see the same history.",
+      done: humans.length > 1,
+    },
+  ];
+  const doneCount = steps.filter((s) => s.done).length;
+  const ready = !agents.isLoading && !dir.isLoading && !tasks.isLoading && !convs.isLoading && !msgs.isLoading;
+
+  return {
+    ready,
+    steps,
+    doneCount,
+    complete: doneCount === steps.length,
+    dismissed: dismissed || spectator,
+    dismiss,
+    restore,
+    agent: first ? { handle: first.handle, name: first.name, status: first.status } : null,
+    firstChannelId,
+    fresh: !agentReplied,
+  };
+}

--- a/web/src/pages/Channel.tsx
+++ b/web/src/pages/Channel.tsx
@@ -8,6 +8,8 @@ import AgentActivity from "../components/AgentActivity";
 import Menu from "../components/Menu";
 import Modal from "../components/Modal";
 import Avatar from "../components/Avatar";
+import GettingStarted from "../components/GettingStarted";
+import { useOnboarding } from "../lib/onboarding";
 import { useConversation, useConversations, useMessages, usePostMessage, useMe, useMarkRead, useMembersDirectory, useMarkConversationNotificationsRead, useSpectator } from "../lib/hooks";
 import { api } from "../api/client";
 import { useBus } from "../state/store";
@@ -17,6 +19,9 @@ export default function ChannelPage() {
   const { id } = useParams<{ id: string }>();
   const me = useMe();
   const spectator = useSpectator();
+  const onboarding = useOnboarding(id);
+  const [prefill, setPrefill] = useState<{ text: string; nonce: number } | null>(null);
+
   const conv = useConversation(id);
   const msgs = useMessages(id);
   const post = usePostMessage(id);
@@ -61,6 +66,7 @@ export default function ChannelPage() {
   if (!id) return null;
 
   const c = conv.data?.conversation;
+  const showGettingStarted = !spectator && c?.kind === "channel" && id === onboarding.firstChannelId;
   const memberCount = (conv.data?.members ?? []).length;
   const myRole = (conv.data?.members ?? []).find((m) => m.memberId === me.data?.memberId)?.role;
   const isAdmin = myRole === "admin";
@@ -211,6 +217,10 @@ export default function ChannelPage() {
           </div>
         </header>
 
+        {showGettingStarted && (
+          <GettingStarted state={onboarding} onPrefill={(text) => setPrefill({ text, nonce: Date.now() })} />
+        )}
+
         <MessageList
           key={id}
           messages={msgs.messages}
@@ -236,7 +246,14 @@ export default function ChannelPage() {
         )}
 
         <Composer
-          placeholder={c?.kind === "dm" ? `Message ${dmTitle ?? ""}` : `Message #${c?.name ?? ""}`}
+          placeholder={
+            c?.kind === "dm"
+              ? `Message ${dmTitle ?? ""}`
+              : showGettingStarted && onboarding.fresh && onboarding.agent
+                ? `Message #${c?.name ?? ""} — try "@${onboarding.agent.handle} hello"`
+                : `Message #${c?.name ?? ""}`
+          }
+          prefill={prefill}
           conversationId={id}
           onTyping={() => {
             api.post(`/conversations/${id}/typing`).catch(() => {

--- a/web/src/pages/HomeRedirect.tsx
+++ b/web/src/pages/HomeRedirect.tsx
@@ -6,5 +6,6 @@ export default function HomeRedirect() {
   if (conversations.isLoading) return null;
   const channels = (conversations.data?.conversations ?? []).filter((c) => c.kind === "channel");
   if (channels.length) return <Navigate to={`/c/${channels[0].id}`} replace />;
-  return <Navigate to="/members" replace />;
+  // No channel yet (deleted #general?) — land on the explainer rather than an empty Members list.
+  return <Navigate to="/welcome" replace />;
 }

--- a/web/src/pages/Members.tsx
+++ b/web/src/pages/Members.tsx
@@ -29,7 +29,10 @@ export default function MembersPage() {
   const [tab, setTab] = useState<Tab>("humans");
   const [q, setQ] = useState("");
   const [inviteOpen, setInviteOpen] = useState(false);
-  const [agentOpen, setAgentOpen] = useState(false);
+  const [agentOpen, setAgentOpen] = useState<boolean>(
+    // /members?add=agent (from the first-run checklist) opens the add-agent flow directly.
+    () => new URLSearchParams(window.location.search).get("add") === "agent",
+  );
   const nav = useNavigate();
   const qc = useQueryClient();
   const presence = useBus((s) => s.presence);
@@ -445,7 +448,7 @@ function AddAgentModePicker({
             </span>
           </div>
           <div className="text-[12.5px] text-[var(--color-muted)] mt-0.5">
-            We'll create a fresh Hermes instance on this Pi, wire in your API key, and start it up.
+            We'll create a fresh agent in its own container on this server, wire in your API key, and start it up.
             You won't run anything on your own infra.
           </div>
         </button>

--- a/web/src/pages/Signup.tsx
+++ b/web/src/pages/Signup.tsx
@@ -90,7 +90,8 @@ export default function SignupPage() {
       if (runtime === "hermes") payload.apiKeyLabel = `${agentName} (${providerId})`;
       await api.post(endpoint, payload);
       await qc.invalidateQueries();
-      nav("/members", { replace: true });
+      // Land in #general with the getting-started card, not on an empty list.
+      nav("/", { replace: true });
     } catch (e) {
       setErr(humanizeError(e));
     } finally {
@@ -100,7 +101,7 @@ export default function SignupPage() {
 
   async function skip(): Promise<void> {
     await qc.invalidateQueries();
-    nav("/members", { replace: true });
+    nav("/", { replace: true });
   }
 
   return (
@@ -119,7 +120,11 @@ export default function SignupPage() {
             }}
           >
             <h1 className="text-[18px] font-semibold mb-1">Name your workspace</h1>
-            <p className="text-[13px] text-[var(--color-muted)] mb-5">You can create more later from the rail.</p>
+            <p className="text-[13px] text-[var(--color-muted)] mb-2">
+              CircleChat is team chat where AI agents are members: they sit in your channels, take work from a
+              shared board, and ask you before doing anything risky. This first workspace is yours to run.
+            </p>
+            <p className="text-[13px] text-[var(--color-muted)] mb-5">Three quick steps: name it, create your admin account, add an agent.</p>
             <input
               autoFocus
               placeholder="Acme Team"
@@ -200,10 +205,14 @@ export default function SignupPage() {
             }}
           >
             <h1 className="text-[18px] font-semibold mb-1">Add your first agent</h1>
+            <p className="text-[13px] text-[var(--color-muted)] mb-2">
+              An agent is a member of your workspace, not a bot: it gets a handle, a role, and reads the same
+              channels you do. It runs in its own container on this server and talks to the model provider you
+              pick below — your key never leaves this machine.
+            </p>
             <p className="text-[13px] text-[var(--color-muted)] mb-4">
-              We'll run it on this server, wire in your API key, and install the CircleChat MCP + skill for
-              you. You can skip this and add one later from{" "}
-              <span className="font-mono">Members → Add agent</span>.
+              After this, @-mention it in <span className="font-mono">#general</span> or give it a card on the
+              Board. You can skip and add one later from <span className="font-mono">Members → Add agent</span>.
             </p>
 
             <div className="space-y-3">
@@ -294,11 +303,11 @@ export default function SignupPage() {
                   <input
                     value={apiBaseUrl}
                     onChange={(e) => setApiBaseUrl(e.target.value)}
-                    placeholder="http://localhost:3200/v1"
+                    placeholder="http://localhost:3001/v1"
                     className="w-full border border-[var(--color-hair-2)] rounded px-3 py-2 text-[13px] font-mono"
                   />
                   <div className="text-[11.5px] text-[var(--color-muted)] mt-1">
-                    Running on this Pi? Use <code className="font-mono">http://localhost:3200/v1</code>.{" "}
+                    Running FreeLLMAPI on this server? Use <code className="font-mono">http://localhost:3001/v1</code>.{" "}
                     <a
                       href="https://github.com/tashfeenahmed/freellmapi"
                       target="_blank"
@@ -341,6 +350,12 @@ export default function SignupPage() {
             </div>
 
             {err && <p className="text-[12px] text-[var(--color-err)] mt-3">{err}</p>}
+            {busy && (
+              <p className="text-[12px] text-[var(--color-muted)] mt-3">
+                Setting up… the first install downloads the agent runtime image (several GB), so this can take a
+                few minutes. Keep this tab open.
+              </p>
+            )}
 
             <div className="flex justify-between items-center mt-5">
               <button type="button" onClick={skip} className="text-[13px] text-[var(--color-muted)]">

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -1,0 +1,124 @@
+import { Link } from "react-router-dom";
+import { Check, Bot, LayoutGrid, ShieldCheck, Inbox, MessageSquare, FolderOpen } from "lucide-react";
+import { useOnboarding } from "../lib/onboarding";
+import { useSpectator } from "../lib/hooks";
+
+// "How it works" — the one page a new admin (or a returning one) can read to
+// understand the model: agents are members, the Board is the work queue,
+// done means verified, risky things wait for you. Also hosts the checklist so
+// it can be found again after the in-channel card is dismissed.
+export default function WelcomePage() {
+  const ob = useOnboarding();
+  const spectator = useSpectator();
+  const a = ob.agent;
+  const chan = ob.firstChannelId ? `/c/${ob.firstChannelId}` : "/";
+
+  const concepts = [
+    {
+      icon: <Bot size={16} strokeWidth={2} />,
+      title: "Agents are members",
+      body:
+        "An agent has a handle, a role, and a reporting line, and it sees exactly what a human member sees: channels, DMs, threads, files. It runs on your server against your model provider. @-mention it or DM it and it replies; leave it alone and it works its own task list on a heartbeat.",
+    },
+    {
+      icon: <LayoutGrid size={16} strokeWidth={2} />,
+      title: "The Board is the work queue",
+      body:
+        "Backlog → in progress → review → done. Assign a card to an agent and it picks it up, works in its own sandbox, and attaches the deliverable (a file, a page, a report) to the card. Progress lives on the card, not in chat scrollback.",
+    },
+    {
+      icon: <ShieldCheck size={16} strokeWidth={2} />,
+      title: "Done means verified",
+      body:
+        "With the verification gate on, a card cannot move review → done on an agent's say-so. An independent judge scores the actual deliverable against the card's acceptance criteria; a fail sends it back with the reason. Verdicts show on the card.",
+    },
+    {
+      icon: <Inbox size={16} strokeWidth={2} />,
+      title: "Risky things wait for you",
+      body:
+        "Anything that leaves the workspace — email, paid APIs, publishing, deleting — becomes an approval card in Needs you. Approve, deny, or attach a credential that lands only in the agent's environment. Cards expire on their own, so nothing waits forever.",
+    },
+    {
+      icon: <MessageSquare size={16} strokeWidth={2} />,
+      title: "Chat is for people",
+      body:
+        "Agents are held to a reply guard: no runtime noise, no repeating themselves, no sign-offs. One new fact per message; the long form goes on the task card. If an agent is quiet, that is usually the right behaviour.",
+    },
+    {
+      icon: <FolderOpen size={16} strokeWidth={2} />,
+      title: "Files and memory are shared",
+      body:
+        "Deliverables live under a shared workspace folder every agent can read. Project status, decisions and changelogs are kept in small files agents update and reread, so a decision made in chat is not lost.",
+    },
+  ];
+
+  return (
+    <main className="flex-1 min-w-0 overflow-auto bg-paper">
+      <div className="max-w-[860px] mx-auto px-6 py-8">
+        <div className="text-[11px] uppercase tracking-widest text-[var(--color-muted)] font-mono mb-2">How CircleChat works</div>
+        <h1 className="text-[22px] font-semibold leading-tight mb-2">Humans and AI agents, same channels, same board.</h1>
+        <p className="text-[14px] text-[var(--color-muted)] max-w-[640px]">
+          You run it; agents work in it. This page is the whole mental model — five minutes, then you will not need it again.
+        </p>
+
+        <div className="gs-grid mt-6">
+          {concepts.map((c) => (
+            <div key={c.title} className="gs-card">
+              <div className="gs-card-head">
+                <span className="gs-card-icon">{c.icon}</span>
+                <span className="gs-card-title">{c.title}</span>
+              </div>
+              <p className="gs-card-body">{c.body}</p>
+            </div>
+          ))}
+        </div>
+
+        {!spectator && (
+          <section className="mt-8">
+            <div className="flex items-center justify-between mb-2">
+              <h2 className="text-[15px] font-semibold">Your first run</h2>
+              <span className="gs-progress">{ob.doneCount}/{ob.steps.length} done</span>
+            </div>
+            <ol className="gs-steps standalone">
+              {ob.steps.map((s, i) => (
+                <li key={s.id} className={`gs-step ${s.done ? "done" : ""}`}>
+                  <span className="gs-num">{s.done ? <Check size={12} strokeWidth={3} /> : i + 1}</span>
+                  <div className="min-w-0 flex-1">
+                    <div className="gs-step-title">{s.title}</div>
+                    <div className="gs-step-why">{s.why}</div>
+                    {s.status && <div className="gs-step-status">{s.status}</div>}
+                  </div>
+                  {!s.done && (
+                    <div className="gs-step-cta">
+                      {s.id === "agent" && <Link to="/members?add=agent" className="btn sm primary">Add agent</Link>}
+                      {s.id === "hello" && (a ? <Link to={chan} className="btn sm primary">Open #general</Link> : <span className="gs-step-status">Add an agent first</span>)}
+                      {s.id === "task" && <Link to="/board" className="btn sm">Open Board</Link>}
+                      {s.id === "invite" && <Link to="/members" className="btn sm">Members</Link>}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ol>
+            {ob.dismissed && !ob.complete && (
+              <button type="button" className="btn sm ghost mt-3" onClick={ob.restore}>
+                Show the checklist in the channel again
+              </button>
+            )}
+          </section>
+        )}
+
+        <section className="mt-8 text-[13px] text-[var(--color-muted)]">
+          <h2 className="text-[15px] font-semibold text-[var(--color-ink)] mb-2">Where things are</h2>
+          <ul className="gs-where">
+            <li><Link to="/members" className="gs-link">Members</Link> — people and agents; add, invite, pause, or inspect an agent.</li>
+            <li><Link to="/board" className="gs-link">Board</Link> — the work queue; open a card to see comments, artifacts and the verification verdict.</li>
+            <li><Link to="/needs-you" className="gs-link">Needs you</Link> — everything waiting on a human: approvals, reviews, publish requests.</li>
+            <li><Link to="/goals" className="gs-link">Projects &amp; Goals</Link> — the longer arc agents plan tasks against.</li>
+            <li><Link to="/files" className="gs-link">Files</Link> — every deliverable and upload in one place.</li>
+            <li><Link to="/settings" className="gs-link">Settings</Link> — profile, notifications, theme, workspace roles. The verification gate and approval policy are server settings (see docs/CONFIG.md in the repo).</li>
+          </ul>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3151,3 +3151,33 @@ body { position: relative; }
   text-underline-offset: 2px;
   margin-left: 14px;
 }
+
+/* ── Getting started (first run) ─────────────────────────────────────── */
+.gs { margin: 10px 14px 0; border: 1px solid var(--color-hair-2); border-radius: 8px; background: var(--color-bg-2); padding: 12px 14px; flex: none; }
+.gs-head { display: flex; align-items: flex-start; gap: 12px; }
+.gs-title { font-size: 14px; font-weight: 600; letter-spacing: -0.01em; }
+.gs-sub { font-size: 12.5px; color: var(--color-muted); margin-top: 2px; line-height: 1.45; max-width: 640px; }
+.gs-link { color: var(--color-ink); text-decoration: underline; text-underline-offset: 2px; }
+.gs-link:hover { color: var(--color-ink-hover); }
+.gs-actions { margin-left: auto; display: flex; align-items: center; gap: 4px; flex: none; }
+.gs-progress { font-family: var(--font-mono); font-size: 11px; color: var(--color-muted); padding: 1px 6px; border: 1px solid var(--color-hair-2); border-radius: 999px; }
+.gs-icon { display: inline-grid; place-items: center; width: 24px; height: 24px; border-radius: 6px; color: var(--color-muted); }
+.gs-icon:hover { background: var(--color-hi); color: var(--color-ink); }
+.gs-steps { list-style: none; margin: 10px 0 0; padding: 0; display: grid; gap: 6px; }
+.gs-steps.standalone { gap: 8px; }
+.gs-step { display: flex; align-items: flex-start; gap: 10px; padding: 8px 10px; border-radius: 6px; background: var(--color-paper); border: 1px solid var(--color-hair); }
+.gs-step.done { opacity: 0.6; }
+.gs-num { flex: none; display: inline-grid; place-items: center; width: 20px; height: 20px; border-radius: 999px; border: 1px solid var(--color-hair-2); font-family: var(--font-mono); font-size: 11px; color: var(--color-muted); margin-top: 1px; }
+.gs-step.done .gs-num { background: var(--color-ok); border-color: var(--color-ok); color: #fff; }
+.gs-step-title { font-size: 13px; font-weight: 500; }
+.gs-step-why { font-size: 12px; color: var(--color-muted); margin-top: 2px; line-height: 1.45; }
+.gs-step-status { font-family: var(--font-mono); font-size: 11px; color: var(--color-muted); margin-top: 3px; }
+.gs-step-cta { flex: none; margin-left: auto; align-self: center; }
+.gs-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 10px; }
+.gs-card { border: 1px solid var(--color-hair-2); border-radius: 8px; padding: 12px 14px; background: var(--color-bg-2); }
+.gs-card-head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.gs-card-icon { display: inline-grid; place-items: center; width: 26px; height: 26px; border-radius: 6px; background: var(--color-hi); color: var(--color-ink); }
+.gs-card-title { font-size: 13.5px; font-weight: 600; }
+.gs-card-body { font-size: 12.5px; color: var(--color-muted); line-height: 1.5; margin: 0; }
+.gs-where { list-style: none; padding: 0; margin: 0; display: grid; gap: 6px; line-height: 1.5; }
+@media (max-width: 720px) { .gs { margin: 8px 8px 0; } .gs-step { flex-wrap: wrap; } .gs-step-cta { margin-left: 30px; } }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
     port: 5173,
     host: true,
     proxy: {
-      "/api": { target: "http://localhost:3000", changeOrigin: true, rewrite: (p) => p.replace(/^\/api/, "") },
+      // The API mounts every route under /api (the prefix Caddy proxies in
+      // production), so the path is forwarded untouched. Stripping it made
+      // `npm run dev` hit the API's SPA fallback and get index.html for every call.
+      "/api": { target: "http://localhost:3000", changeOrigin: true },
       "/events": { target: "ws://localhost:3000", ws: true, changeOrigin: true },
       "/agent-socket": { target: "ws://localhost:3000", ws: true, changeOrigin: true },
     },


### PR DESCRIPTION
A new admin landed on an empty Members page with no explanation of what CircleChat is or how to get an agent to do anything. This adds a live-state Getting started card in #general (add an agent → say hello → give it a task → invite a teammate), a /welcome How-it-works page reachable from the sidebar (and shown up front to public spectators), clearer signup copy that explains what an agent is and warns about the runtime image download, landing in #general after signup, a Members deep link for adding an agent, and a fix to the Vite dev proxy that made local development receive the SPA fallback for every API call. Verified in a browser against a fresh local database: empty state, agent-present state with live status, mention prefill, deep link, welcome page. web tsc and vite build clean.