### PR TITLE
Make the workspace read like a team chat: strip runtime notices, chip raw ids, calm the board and Needs you

### DIFF
--- a/api/hermes-multi-bridge.mjs
+++ b/api/hermes-multi-bridge.mjs
@@ -357,8 +357,26 @@ const RUNAWAY_BANNER_RE =
   /(?:^|\n)[ \t]*\u26A0?\uFE0F?[ \t]*Reached maximum iterations(?:\s*\(\d+\))?\.?(?:[ \t]*Requesting (?:a )?summary(?:\.{1,3}|…)?)?[ \t]*(?:\n|$)/gi;
 const TOOL_EXEC_FAIL_RE =
   /(?:^|\n)[ \t]*\u26A0?\uFE0F?[ \t]*Could not execute tool\(s\)[^\n]*(?:\n(?![ \t]*\n)[^\n]*)*/gi;
+// "⚠️ File-mutation verifier: N file(s) were NOT modified …" + one bullet per
+// denied write. Header + bullets/continuations are dropped as a block.
+function stripFileMutationNotice(text) {
+  if (!/File-mutation verifier:/i.test(text)) return text;
+  const out = [];
+  let skipping = false;
+  for (const line of String(text).split("\n")) {
+    if (/File-mutation verifier:/i.test(line)) { skipping = true; continue; }
+    if (skipping) {
+      if (/^\s*[•\-*]\s/.test(line) || /Write denied|WRITE_SAFE_ROOT|Unset the variable|directory prefix/i.test(line)) continue;
+      skipping = false;
+      if (!line.trim()) continue;
+    }
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
 function stripRuntimeNoise(text) {
-  return String(text || "")
+  return stripFileMutationNotice(String(text || ""))
     .replace(RUNAWAY_BANNER_RE, "\n")
     .replace(TOOL_EXEC_FAIL_RE, "\n")
     .replace(/\n{3,}/g, "\n\n")
@@ -750,8 +768,9 @@ const STYLE_RULES = [
   `  • ONE NEW FACT PER MESSAGE. Say the thing that changed since your last post, in 1–2 sentences. Do not restate the task, your role, the plan, or what was already on the card. A reply over ${CHAT_BODY_MAX} chars is cut at a sentence boundary — put long-form on the task card, not in chat.`,
   `  • ONE SURFACE PER FACT. Never post the same fact to chat AND a task_comment AND project_note. Task progress → task_comment/share_to_task only. Project-level decisions/status → project_note only. Chat → only what a human needs to see right now. The server drops near-duplicate bodies across these surfaces (duplicate_of_recent) and near-duplicate tracker entries.`,
   `  • NO INVENTED WORK. Do not manufacture "proof packages", re-verify what is already verified, bump a version number on a status doc, or re-announce a fact already on the card to have something to post. If nothing real changed: HEARTBEAT_OK.`,
-  `  • NEVER paste runtime output into a reply: "Reached maximum iterations", "Requesting summary", "Could not execute tool(s)", @@ARG markers, or a summary of your tool calls. If you ran out of tool turns, say the one concrete outcome (or HEARTBEAT_OK) — not a transcript. Do not talk to the prompt ("I read the attached history file…") — reply to the people.`,
-  `  • Scratch files (test scripts, fetch helpers) go under /workspace/tmp/, never your home or cwd, and are never shared or mentioned in chat.`,
+  `  • NEVER paste runtime output into a reply: "Reached maximum iterations", "Requesting summary", "Could not execute tool(s)", "File-mutation verifier", "Write denied", @@ARG markers, or a summary of your tool calls. If you ran out of tool turns, say the one concrete outcome (or HEARTBEAT_OK) — not a transcript. Do not talk to the prompt ("I read the attached history file…") — reply to the people.`,
+  `  • NO IDS OR HASHES IN CHAT. Refer to a task by its title in quotes ("the streaming pipeline card"), never by task_… / ap_… / goal_… ids, and never paste SHA-256 or commit hashes — the card already has them. Say "ready for review", "marked done", "blocked on X" — not "flip", "review flip", "unblock the card".`,
+  `  • Scratch files (test scripts, fetch helpers) go under /opt/data/tmp/ (inside your writable root), never the root of your home or /workspace, and are never shared or mentioned in chat.`,
 ].join("\n");
 
 function buildPrompt(entry, packet) {
@@ -1583,13 +1602,13 @@ function connect(entry) {
             actions.push({
               type: "task_comment",
               task_id: routeTaskId,
-              body_md: full.length < postBody.length ? `${full}\n\n_(trimmed — ${postBody.length - full.length} chars cut)_` : full,
+              body_md: full,
             });
-            chatBody = `${leadOf(postBody, CHAT_POINTER_MAX)}\n\n_(full update on the task card: ${routeTaskId})_`;
+            chatBody = `${leadOf(postBody, CHAT_POINTER_MAX)}\n\n_Full update on the task card: ${routeTaskId}_`;
             console.log(`[${entry.handle}] ${trigger} → ${postBody.length}-char prose routed to task_comment on ${routeTaskId}; chat gets a ${chatBody.length}-char pointer`);
           } else {
             const cut = truncateAtBoundary(postBody, CHAT_BODY_MAX - 80);
-            chatBody = `${cut}\n\n_(trimmed — ${postBody.length - cut.length} chars cut; keep chat short, put long-form on a task card)_`;
+            chatBody = cut;
             console.log(`[${entry.handle}] ${trigger} → ${postBody.length}-char prose cut at a boundary to ${chatBody.length} for chat`);
           }
         }
@@ -1616,7 +1635,7 @@ function connect(entry) {
           actions.push({
             type: "task_comment",
             task_id: targetTaskId,
-            body_md: wrapped.length < postBody.length ? `${wrapped}\n\n_(trimmed — ${postBody.length - wrapped.length} chars cut)_` : wrapped,
+            body_md: wrapped,
           });
         } else {
           console.log(`[${entry.handle}] task-only: dropping ${postBody.length}-char prose (no conv and no task to wrap into)`);

--- a/api/src/__tests__/bridge-reply.test.ts
+++ b/api/src/__tests__/bridge-reply.test.ts
@@ -100,3 +100,11 @@ describe("bridge isEntrypointNoise — gateway boot banner", () => {
     expect(m.isEntrypointNoise("Backend verified on port 3000.")).toBe(false);
   });
 });
+
+describe("bridge stripRuntimeNoise — file-mutation verifier notice", () => {
+  it("drops the header and its bullets, keeps the reply", () => {
+    const text = "Backend is live on port 3000.\n\n⚠️ File-mutation verifier: 1 file(s) were NOT modified this turn despite any wording above.\n  • `/workspace/tmp/x.py` — [write_file] Write denied: outside HERMES_WRITE_SAFE_ROOT (/opt/data). Unset the variable or add this path's directory prefix.";
+    const out = bridge.stripRuntimeNoise(text);
+    expect(out).toBe("Backend is live on port 3000.");
+  });
+});

--- a/api/src/__tests__/reply-guard.test.ts
+++ b/api/src/__tests__/reply-guard.test.ts
@@ -348,3 +348,25 @@ describe("checkReplyBody — Hermes gateway boot banner (live leak 5 Sep 2026)",
     expect(stripLeakedScaffolding(boxed).stripped).toContain("gateway_boot");
   });
 });
+
+describe("checkReplyBody — Hermes file-mutation verifier notice (live leak 5 Sep 2026)", () => {
+  const notice = [
+    "⚠️ File-mutation verifier: 1 file(s) were NOT modified this turn despite any wording above that may suggest otherwise. Run `git status` or `read_file` to confirm.",
+    "  • `/workspace/tmp/fetch_tasks.py` — [write_file] Write denied: '`/workspace/tmp/fetch_tasks.py`' is outside HERMES_WRITE_SAFE_ROOT (/opt/data). Unset the variable or add this path's directory prefix.",
+  ].join("\n");
+  it("rejects a reply that is only the notice", () => {
+    const r = checkReplyBody(notice);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("file_mutation_notice");
+    expect(guardRejectHint("file_mutation_notice")).toMatch(/write was denied/);
+  });
+  it("keeps the substantive part and drops the notice block", () => {
+    const r = checkReplyBody(`Archive verified: 85 records, 0 mismatches. Evidence is on the card.\n\n${notice}`);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.bodyMd).toMatch(/^Archive verified/);
+      expect(r.bodyMd).not.toMatch(/File-mutation|Write denied|WRITE_SAFE_ROOT/);
+    }
+    expect(stripLeakedScaffolding(notice).stripped).toContain("file_mutation_notice");
+  });
+});

--- a/api/src/agents/reply-guard.ts
+++ b/api/src/agents/reply-guard.ts
@@ -334,6 +334,32 @@ const BOX_ONLY_LINE_RE = /(?:^|\n)[ \t]*[┌┐└┘├┤─│╭╮╰╯═
 const GATEWAY_BOOT_INLINE_RE =
   /[┌┐└┘├┤─│╭╮╰╯═║╔╗╚╝ \t]*(?:⚕[ \t]*)?Hermes Gateway Starting\.{0,3}[ \t┌┐└┘├┤─│╭╮╰╯═║╔╗╚╝]*(?:Messaging platforms \+ cron scheduler)?[ \t┌┐└┘├┤─│╭╮╰╯═║╔╗╚╝]*(?:Press Ctrl\+C to stop)?[ \t┌┐└┘├┤─│╭╮╰╯═║╔╗╚╝]*/gi;
 
+// Hermes "file-mutation verifier" notice: a header line followed by one bullet
+// per denied write, e.g.
+//   ⚠️ File-mutation verifier: 1 file(s) were NOT modified this turn despite …
+//     • `/workspace/tmp/x.py` — [write_file] Write denied: '…' is outside HERMES_WRITE_SAFE_ROOT (/opt/data). Unset …
+// Runtime diagnostics, never something a teammate should read.
+export function stripFileMutationNotice(s: string): { text: string; hit: boolean } {
+  const lines = s.split("\n");
+  const out: string[] = [];
+  let hit = false;
+  let skipping = false;
+  for (const line of lines) {
+    if (/File-mutation verifier:/i.test(line)) {
+      hit = true;
+      skipping = true;
+      continue;
+    }
+    if (skipping) {
+      if (/^\s*[•\-*]\s/.test(line) || /Write denied|WRITE_SAFE_ROOT|Unset the variable|directory prefix/i.test(line)) continue;
+      skipping = false;
+      if (!line.trim()) continue;
+    }
+    out.push(line);
+  }
+  return { text: hit ? out.join("\n") : s, hit };
+}
+
 export function stripLeakedScaffolding(s: string): ScaffoldStrip {
   const stripped: string[] = [];
   let out = s;
@@ -347,6 +373,13 @@ export function stripLeakedScaffolding(s: string): ScaffoldStrip {
   };
   step(RUNAWAY_BANNER_RE, "runaway_banner");
   step(TOOL_EXEC_FAIL_RE, "tool_exec_failure");
+  {
+    const fm = stripFileMutationNotice(out);
+    if (fm.hit) {
+      stripped.push("file_mutation_notice");
+      out = fm.text;
+    }
+  }
   if (/Hermes Gateway Starting|Messaging platforms \+ cron scheduler|Press Ctrl\+C to stop/i.test(out)) {
     stripped.push("gateway_boot");
     out = out.replace(GATEWAY_BOOT_LINE_RE, "\n").replace(GATEWAY_BOOT_INLINE_RE, " ").replace(BOX_ONLY_LINE_RE, "\n");
@@ -408,6 +441,8 @@ export function guardRejectHint(reason: string): string {
       return " Your reply carried the runtime's 'Could not execute tool(s)' notice / @@ARG parser debris — a tool call you emitted was malformed. That's diagnostics, not a message. Re-issue the tool call correctly (valid enum values, no stray delimiters) or emit the board action as an <actions> JSON block; only post prose that a teammate should read.";
     case "scaffold_talk":
       return " You addressed the prompt scaffolding ('CURRENT REQUEST', 'attached conversation history file') instead of the team. Nobody attached a file — the context you were given IS the conversation. Reply to the last human message in plain prose, or stay silent with HEARTBEAT_OK.";
+    case "file_mutation_notice":
+      return " Your reply was only the runtime's 'File-mutation verifier' notice — a write was denied. That is diagnostics for you, not a message. Fix the path (write under /opt/data) and post only the outcome a teammate needs.";
     case "gateway_boot":
       return " Your reply was only the Hermes gateway's boot banner ('Hermes Gateway Starting…') — runtime output, not a message. Say the one new fact for the team, or stay silent with HEARTBEAT_OK.";
     case "signoff_only":

--- a/api/src/routes/needs-you.ts
+++ b/api/src/routes/needs-you.ts
@@ -40,7 +40,9 @@ export default async function needsYouRoutes(app: FastifyInstance): Promise<void
     const [approvalRows, reviewTasks, failedVerdicts, stalledGoals, waits, failures, connectorErrors, pendingApps, workspace] = await Promise.all([
       agentIds.length ? db.select({ approval: approvals, agentName: agents.name }).from(approvals).innerJoin(agents, eq(agents.id, approvals.agentId)).where(and(inArray(approvals.agentId, agentIds), eq(approvals.status, "pending"))).orderBy(desc(approvals.createdAt)) : [],
       db.select().from(tasks).where(and(eq(tasks.workspaceId, workspaceId), eq(tasks.status, "review"), eq(tasks.archived, false))).orderBy(desc(tasks.updatedAt)),
-      db.select({ verification: taskVerifications, taskTitle: tasks.title }).from(taskVerifications).innerJoin(tasks, eq(tasks.id, taskVerifications.taskId)).where(and(eq(taskVerifications.workspaceId, workspaceId), eq(taskVerifications.verdict, "fail"))).orderBy(desc(taskVerifications.createdAt)),
+      // Only cards still sitting in review can act on a failed verdict; a fail on a
+      // card that has since moved (done, back to in_progress, archived) is history.
+      db.select({ verification: taskVerifications, taskTitle: tasks.title }).from(taskVerifications).innerJoin(tasks, eq(tasks.id, taskVerifications.taskId)).where(and(eq(taskVerifications.workspaceId, workspaceId), eq(taskVerifications.verdict, "fail"), eq(tasks.status, "review"), eq(tasks.archived, false))).orderBy(desc(taskVerifications.createdAt)),
       db.select({ ledger: goalLedgers, title: goals.title }).from(goalLedgers).innerJoin(goals, eq(goals.id, goalLedgers.goalId)).where(and(eq(goalLedgers.workspaceId, workspaceId), gt(goalLedgers.stallCount, 0))).orderBy(desc(goalLedgers.updatedAt)),
       db.select({ run: workflowRuns, name: workflows.name }).from(workflowRuns).innerJoin(workflows, eq(workflows.id, workflowRuns.workflowId)).where(and(eq(workflowRuns.workspaceId, workspaceId), eq(workflowRuns.status, "waiting"), eq(workflowRuns.waitKind, "human"))).orderBy(desc(workflowRuns.updatedAt)),
       db.select({ run: workflowRuns, name: workflows.name }).from(workflowRuns).innerJoin(workflows, eq(workflows.id, workflowRuns.workflowId)).where(and(eq(workflowRuns.workspaceId, workspaceId), eq(workflowRuns.status, "failed"))).orderBy(desc(workflowRuns.updatedAt)).limit(20),
@@ -72,10 +74,18 @@ export default async function needsYouRoutes(app: FastifyInstance): Promise<void
         actions: ["approve", "deny"],
       });
     }
-    for (const task of reviewTasks) items.push({ id: `task:${task.id}`, kind: "task_review", priority: "normal", title: task.title, detail: "Task is ready for human review.", link: `/board?task=${task.id}`, targetId: task.id, createdAt: task.updatedAt.toISOString(), actions: ["open"] });
+    // One item per review card. If its latest verdict is a fail, the item says
+    // so (with the judge's reason) instead of a second "verification failed" row.
     const latestFailed = new Map<string, (typeof failedVerdicts)[number]>();
     for (const row of failedVerdicts) if (!latestFailed.has(row.verification.taskId)) latestFailed.set(row.verification.taskId, row);
-    for (const row of latestFailed.values()) items.push({ id: `verification:${row.verification.id}`, kind: "verification_failed", priority: "high", title: `Verification failed: ${row.taskTitle}`, detail: row.verification.rationale || `Score ${row.verification.score ?? "n/a"}`, link: `/board?task=${row.verification.taskId}`, targetId: row.verification.taskId, createdAt: row.verification.createdAt.toISOString(), actions: ["open"] });
+    for (const task of reviewTasks) {
+      const failed = latestFailed.get(task.id);
+      if (failed) {
+        items.push({ id: `verification:${failed.verification.id}`, kind: "verification_failed", priority: "high", title: `Needs review: ${task.title}`, detail: `Verification failed — ${failed.verification.rationale || `score ${failed.verification.score ?? "n/a"}`}`, link: `/board?task=${task.id}`, targetId: task.id, createdAt: failed.verification.createdAt.toISOString(), actions: ["open"] });
+      } else {
+        items.push({ id: `task:${task.id}`, kind: "task_review", priority: "normal", title: `Needs review: ${task.title}`, detail: "The assignee marked this card ready. Open it to check the deliverable and move it to done.", link: `/board?task=${task.id}`, targetId: task.id, createdAt: task.updatedAt.toISOString(), actions: ["open"] });
+      }
+    }
     for (const row of stalledGoals) items.push({ id: `goal:${row.ledger.goalId}`, kind: "stalled_goal", priority: row.ledger.stallCount >= 3 ? "critical" : "high", title: `Stalled goal: ${row.title}`, detail: `${row.ledger.stallCount} stalled assessment(s); ${row.ledger.replanCount} re-plan(s).`, link: "/goals", targetId: row.ledger.goalId, createdAt: row.ledger.updatedAt.toISOString(), actions: ["open"] });
     for (const row of waits) items.push({ id: `workflow-wait:${row.run.id}`, kind: "workflow_wait", priority: "high", title: `${row.name} is waiting for you`, detail: `State ${row.run.currentStateId ?? "unknown"}`, link: "/automation", targetId: row.run.id, createdAt: row.run.updatedAt.toISOString(), actions: ["resume", "cancel", "steer"] });
     for (const row of failures) items.push({ id: `workflow-failed:${row.run.id}`, kind: "workflow_failed", priority: "high", title: `${row.name} failed`, detail: row.run.errorText ?? "Workflow failed without an error message.", link: "/automation", targetId: row.run.id, createdAt: row.run.updatedAt.toISOString(), actions: ["open"] });

--- a/web/src/components/Board.tsx
+++ b/web/src/components/Board.tsx
@@ -86,10 +86,20 @@ export default function Board() {
     [q.data?.tasks],
   );
 
+  // Done keeps the board honest without turning into an archive: only cards
+  // finished in the last two weeks show by default; the rest sit behind a
+  // "show older" toggle. Every other column shows everything.
+  const DONE_WINDOW_MS = 14 * 24 * 3600 * 1000;
+  const [showOlderDone, setShowOlderDone] = useState(false);
+  const olderDoneCount = useMemo(
+    () => topLevel.filter((t) => t.status === "done" && Date.now() - Date.parse(t.updatedAt) > DONE_WINDOW_MS).length,
+    [topLevel],
+  );
   function byCol(col: TaskStatus): Task[] {
     return topLevel
       .filter((t) => t.status === col)
-      .sort((a, b) => a.position - b.position || a.createdAt.localeCompare(b.createdAt));
+      .filter((t) => col !== "done" || showOlderDone || Date.now() - Date.parse(t.updatedAt) <= DONE_WINDOW_MS)
+      .sort((a, b) => (col === "done" ? b.updatedAt.localeCompare(a.updatedAt) : a.position - b.position || a.createdAt.localeCompare(b.createdAt)));
   }
 
   async function addTask(col: TaskStatus) {
@@ -181,6 +191,11 @@ export default function Board() {
                 <span className="kh-glyph">{col.glyph}</span>
                 <span className="kh-title">{col.title}</span>
                 <span className="kh-count">{cards.length}</span>
+                {col.id === "done" && olderDoneCount > 0 && (
+                  <button type="button" className="kh-older" onClick={() => setShowOlderDone((v) => !v)}>
+                    {showOlderDone ? "hide older" : `+${olderDoneCount} older`}
+                  </button>
+                )}
                 <span className="kh-spacer" />
                 {!spectator && (
                   <button

--- a/web/src/components/MessageRow.tsx
+++ b/web/src/components/MessageRow.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useTasks } from "../lib/hooks";
 import { MessageSquare, Pencil, Trash2 } from "lucide-react";
 import { useBus } from "../state/store";
 import Avatar from "./Avatar";
@@ -58,9 +59,11 @@ export default function MessageRow({
 
   const displayName = who?.name ?? (msg.memberId === meMemberId ? "me" : msg.memberId.slice(0, 6));
   const handle = who?.handle;
+  const tasksQ = useTasks();
+  const taskTitles = useMemo(() => new Map((tasksQ.data?.tasks ?? []).map((t) => [t.id, t.title])), [tasksQ.data]);
   const html = useMemo(
-    () => renderMarkdown(msg.bodyMd, (h) => isAgentHandle(h, dir)),
-    [msg.bodyMd, dir],
+    () => renderMarkdown(msg.bodyMd, (h) => isAgentHandle(h, dir), (id) => taskTitles.get(id)),
+    [msg.bodyMd, dir, taskTitles],
   );
 
   const rxByEmoji: Record<string, string[]> = {};

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -186,22 +186,22 @@ export default function Sidebar() {
             <span className="sb-badge mention">{pendingNeeds}</span>
           )}
         </Link>
-        <Link
-          to="/automation"
-          className={`sb-item ${location.pathname === "/automation" ? "active" : ""}`}
-        >
-          <span className="sb-glyph"><Workflow size={14} strokeWidth={2} /></span>
-          <span className="sb-name">Automation</span>
-        </Link>
-        <Link
-          to="/platform"
-          className={`sb-item ${location.pathname === "/platform" ? "active" : ""}`}
-        >
-          <span className="sb-glyph"><Boxes size={14} strokeWidth={2} /></span>
-          <span className="sb-name">Platform</span>
-        </Link>
         {moreOpen && (
           <>
+            <Link
+              to="/automation"
+              className={`sb-item ${location.pathname === "/automation" ? "active" : ""}`}
+            >
+              <span className="sb-glyph"><Workflow size={14} strokeWidth={2} /></span>
+              <span className="sb-name">Automation</span>
+            </Link>
+            <Link
+              to="/platform"
+              className={`sb-item ${location.pathname === "/platform" ? "active" : ""}`}
+            >
+              <span className="sb-glyph"><Boxes size={14} strokeWidth={2} /></span>
+              <span className="sb-name">Platform</span>
+            </Link>
             <Link
               to="/analytics"
               className={`sb-item ${location.pathname === "/analytics" ? "active" : ""}`}

--- a/web/src/lib/md.ts
+++ b/web/src/lib/md.ts
@@ -20,9 +20,31 @@ md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
   return defaultLinkOpen(tokens, idx, options, env, self);
 };
 
+// Agents refer to board cards, approvals and files by their internal ids and
+// hashes. Humans should never have to read `task_tor0bjwcr6zcasklr4sq`: cards
+// become a chip with the card's title (linking to the board), approval ids a
+// plain "approval" chip, and long hashes a short code span.
+export type TaskResolver = (taskId: string) => string | null | undefined;
+function chipIds(html: string, resolveTask?: TaskResolver): string {
+  let out = html.replace(/(?:<code>)?\b(task_[a-z0-9]{12,28})\b(?:<\/code>)?/g, (_m, id: string) => {
+    const title = resolveTask?.(id);
+    const label = title ? escapeHtml(title.length > 60 ? `${title.slice(0, 57)}…` : title) : "task card";
+    return `<a class="idchip task" href="/board?task=${id}" title="Open card">◇ ${label}</a>`;
+  });
+  out = out.replace(/(?:<code>)?\b(ap_[a-z0-9]{12,28})\b(?:<\/code>)?/g, '<a class="idchip approval" href="/approvals" title="Open approvals">✓ approval</a>');
+  out = out.replace(/(?:<code>)?\b(goal_[a-z0-9]{12,28})\b(?:<\/code>)?/g, '<a class="idchip goal" href="/goals" title="Open goals">◎ goal</a>');
+  // 32+ hex chars = SHA-1/SHA-256 style digests; keep the first 8 for eyeballing.
+  out = out.replace(/(?:<code>)?\b([0-9a-f]{32,64})\b(?:<\/code>)?/g, (_m, h: string) => `<code class="hash" title="${h}">${h.slice(0, 8)}…</code>`);
+  return out;
+}
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
 export function renderMarkdown(
   body: string,
   isAgentHandle: (handle: string) => boolean = () => false,
+  resolveTask?: TaskResolver,
 ): string {
   // Render markdown first (escapes user-supplied HTML because html:false).
   const base = md.render(body);
@@ -40,7 +62,8 @@ export function renderMarkdown(
       return `${pre}<span class="${klass}">@${h}</span>`;
     },
   );
-  return DOMPurify.sanitize(withMentions, {
+  const withChips = chipIds(withMentions, resolveTask);
+  return DOMPurify.sanitize(withChips, {
     ADD_ATTR: ["target", "rel"],
     // `style` is allowed so GFM table column alignment (markdown-it emits
     // `style="text-align:…"` on th/td) survives — DOMPurify sanitizes the

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3181,3 +3181,10 @@ body { position: relative; }
 .gs-card-body { font-size: 12.5px; color: var(--color-muted); line-height: 1.5; margin: 0; }
 .gs-where { list-style: none; padding: 0; margin: 0; display: grid; gap: 6px; line-height: 1.5; }
 @media (max-width: 720px) { .gs { margin: 8px 8px 0; } .gs-step { flex-wrap: wrap; } .gs-step-cta { margin-left: 30px; } }
+
+/* ── Inline id chips (task/approval/goal ids and hashes in agent prose) ── */
+.idchip { display: inline-flex; align-items: center; gap: 4px; padding: 0 6px; border-radius: 999px; border: 1px solid var(--color-hair-2); background: var(--color-hi); color: var(--color-ink); font-size: 12px; line-height: 18px; text-decoration: none; vertical-align: baseline; max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.idchip:hover { background: var(--color-hi-2); }
+code.hash { font-size: 11.5px; color: var(--color-muted); }
+.kh-older { font-family: var(--font-mono); font-size: 10.5px; color: var(--color-muted); padding: 0 6px; border-radius: 999px; border: 1px solid var(--color-hair-2); margin-left: 6px; }
+.kh-older:hover { color: var(--color-ink); background: var(--color-hi); }


### PR DESCRIPTION
Visitors to the live demo saw Hermes runtime notices in chat, raw task/approval ids and SHA hashes in every message, a Blocked column of July cards, 161 Done cards, and a Needs-you queue of 103 items of which 97 were stale verification failures on cards nobody was reviewing. This PR strips the notice in the guard and bridge, removes the bridge's meta trim notes, adds prompt rules against ids/hashes/jargon, renders ids as titled chips in the web, limits Needs you to cards actually in review (one item per card), caps the Done column to two weeks with a toggle, and moves Automation/Platform under Show more. Tests: tsc clean, 33 files / 342 tests, vite build clean.