### PR TITLE
Stop exposing agent-harness jargon and internals to visitors

### DIFF
--- a/api/hermes-multi-bridge.mjs
+++ b/api/hermes-multi-bridge.mjs
@@ -375,12 +375,105 @@ function stripFileMutationNotice(text) {
   return out.join("\n");
 }
 
-function stripRuntimeNoise(text) {
-  return stripFileMutationNotice(String(text || ""))
-    .replace(RUNAWAY_BANNER_RE, "\n")
-    .replace(TOOL_EXEC_FAIL_RE, "\n")
+// ───────── prose rewrites (mirror of api/src/agents/reply-guard.ts) ─────────
+// MINIMAL MIRROR of `applyProseRewrites` / the block table in
+// api/src/agents/reply-guard.ts (`sanitizeAgentProse`). The bridge can't import
+// the TypeScript module (it lives outside the api `rootDir` and ships as plain
+// ESM), so the tables are duplicated. Keep the two in step: the server is the
+// authority for what gets STORED, this copy keeps the bridge's own log line and
+// task-card pointer reading the same way.
+const PROSE_TOOL_BLOCK_RE =
+  /<tool_call\b[^>]*>[\s\S]*?<\/tool_call>|<function=[^>\n]*>[\s\S]*?<\/function>|<parameter=[^>\n]*>[\s\S]*?<\/parameter>|<\/?tool_call\b[^>]*>|<function=[^>\n]*>|<\/?function\b[^>]*>|<parameter=[^>\n]*>|<\/?parameter\b[^>]*>/gi;
+const PROSE_LOG_LINE_RE =
+  /(?:^|\n)[ \t]*(?:WARNING|WARN|ERROR|INFO|DEBUG)[ \t]+gateway\.[\w.]+[^\n]*/gi;
+const PROSE_INVALID_TOOL_CALL_RE = /(?:^|\n)[^\n]*Model generated invalid tool call[^\n]*/gi;
+const PROSE_OUTPUT_ERROR_RE = /(?:^|\n)[ \t]*\*{0,2}OUTPUT_ERROR\*{0,2}[^\n]*/gi;
+const PROSE_MODEL_TOKEN_RE = /<[｜|][^>\n]{0,40}(?:[｜|]>?|$)/g;
+const PROSE_TASK_ONLY_MODE_RE = /(?:^|\n)[^\n]*HERMES IS IN TASK-ONLY MODE[^\n]*/gi;
+const PROSE_PATH_RE = /(^|[\s("'[<])(\/(?:opt\/data|workspace|tmp)(?:\/[\w.@%+-]+)*)\/?/g;
+const PROSE_LOCALHOST_RE =
+  /\b(?:https?:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0)(?::\d{2,5})?(?:\/[\w./?=&%-]*)?/gi;
+const PROSE_ON_PORT_RE = /\s*\b(?:on|at|via)\s+port\s+\d{2,5}\b/gi;
+const PROSE_BARE_PORT_RE = /(^|[\s(])::?\d{2,5}\b/g;
+const PROSE_VOCAB = [
+  [/\breview[ -]flips?\b/gi, "review"],
+  [/\bflipped\s+it\s+to\s+done\b/gi, "moved it to done"],
+  [/\bflipped\s+to\s+done\b/gi, "moved to done"],
+  [/\bflipping\s+it\s+to\s+done\b/gi, "moving it to done"],
+  [/\bflipping\s+to\s+done\b/gi, "moving to done"],
+  [/\bflips\s+it\s+to\s+done\b/gi, "moves it to done"],
+  [/\bflips\s+to\s+done\b/gi, "moves to done"],
+  [/\bflip\s+it\s+to\s+done\b/gi, "move it to done"],
+  [/\bflip\s+to\s+done\b/gi, "move to done"],
+  [/\bflipped\b/gi, "moved"],
+  [/\bflipping\b/gi, "moving"],
+  [/\bflips\b/gi, "moves"],
+  [/\bthis turn\b/gi, "today"],
+  [/\bauto-?verifiers?\b/gi, "automated check"],
+  [/\bverifiers?\b/gi, "automated check"],
+  [/\bheartbeats?\b/gi, "status check"],
+  [/\bshare_to_task\b/g, "attach to the card"],
+  [/\bproject_note\b/g, "the project notes"],
+  [/\btask_comment\b/g, "a card comment"],
+  [/\bHERMES_[A-Z0-9_]+\b/g, "the runtime"],
+];
+
+// Rewrite one chunk of NON-FENCED prose. Mirrors applyProseRewrites().
+function applyProseRewrites(chunk) {
+  let out = chunk;
+  out = out.replace(PROSE_PATH_RE, (m, pre, p) => {
+    if (m.endsWith("/")) return pre;
+    const last = p.split("/").filter(Boolean).pop() ?? "";
+    const bare = last && last !== "workspace" && last !== "tmp" && last !== "data";
+    return bare ? `${pre}\`${last}\`` : pre;
+  });
+  out = out.replace(PROSE_LOCALHOST_RE, "the server");
+  out = out.replace(PROSE_ON_PORT_RE, "");
+  out = out.replace(PROSE_BARE_PORT_RE, "$1");
+  for (const [re, to] of PROSE_VOCAB) out = out.replace(re, to);
+  return out;
+}
+
+// Apply `fn` only outside ``` fenced blocks — a snippet is a command, not prose.
+function outsideFences(text, fn) {
+  return String(text || "")
+    .split(/(```[\s\S]*?```)/g)
+    .map((chunk, i) => (i % 2 === 1 ? chunk : fn(chunk)))
+    .join("");
+}
+
+// Strip the machinery blocks and apply the rewrites. Mirrors the non-rejecting
+// half of sanitizeAgentProse().
+function sanitizeProse(text) {
+  let out = String(text || "");
+  for (const re of [
+    PROSE_TOOL_BLOCK_RE,
+    PROSE_LOG_LINE_RE,
+    PROSE_INVALID_TOOL_CALL_RE,
+    PROSE_OUTPUT_ERROR_RE,
+    PROSE_MODEL_TOKEN_RE,
+    PROSE_TASK_ONLY_MODE_RE,
+  ]) {
+    out = outsideFences(out, (chunk) => {
+      re.lastIndex = 0;
+      return chunk.replace(re, "");
+    });
+  }
+  out = outsideFences(out, applyProseRewrites);
+  return out
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/[ \t]+([,.;:!?])/g, "$1")
+    .replace(/\(\s*\)/g, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
+}
+
+function stripRuntimeNoise(text) {
+  return sanitizeProse(
+    stripFileMutationNotice(String(text || ""))
+      .replace(RUNAWAY_BANNER_RE, "\n")
+      .replace(TOOL_EXEC_FAIL_RE, "\n"),
+  );
 }
 
 // Cut `text` to at most `max` chars WITHOUT slicing mid-sentence: prefer the
@@ -1701,6 +1794,8 @@ export {
   canonicalActionType,
   extractReply,
   stripRuntimeNoise,
+  sanitizeProse,
+  applyProseRewrites,
   truncateAtBoundary,
   leadOf,
   isEntrypointNoise,

--- a/api/src/__tests__/agent-prose.test.ts
+++ b/api/src/__tests__/agent-prose.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyProseRewrites,
+  sanitizeAgentProse,
+  checkReplyBody,
+  guardRejectHint,
+} from "../agents/reply-guard.js";
+import { redactDeleted } from "../lib/deleted-rows.js";
+import { stalledDetail } from "../lib/needs-you-copy.js";
+import { publicAgentView } from "../lib/agent-view.js";
+
+// Every string quoted here is verbatim from a live workspace: an agent talking
+// about its own container instead of the work. The sanitizer's job is to keep
+// the sentence and drop the machinery.
+
+describe("sanitizeAgentProse rewrites container paths", () => {
+  it("keeps the sentence and reduces the path to a filename", () => {
+    const r = sanitizeAgentProse(
+      "I can't write to /workspace/tmp (outside HERMES_WRITE_SAFE_ROOT), so I'll deliver the draft as a card comment instead.",
+    );
+    expect(r.text).not.toContain("/workspace");
+    expect(r.text).not.toContain("HERMES_WRITE_SAFE_ROOT");
+    expect(r.text).toContain("the runtime");
+    expect(r.text).toContain("so I'll deliver the draft");
+  });
+
+  it("reduces every absolute runtime path in a status line", () => {
+    const r = sanitizeAgentProse(
+      "server.js is persisted on shared disk at /workspace/backend/server.js and the backend is running from /opt/data/workspace/backend/ … ready for @nova's flip to done.",
+    );
+    expect(r.text).not.toMatch(/\/workspace|\/opt\/data/);
+    expect(r.text).toContain("`server.js`");
+    expect(r.text).toContain("ready for @nova's move to done.");
+    // The trailing-slash directory leaves nothing behind.
+    expect(r.text).toContain("running from …");
+  });
+
+  it("leaves paths inside a code fence alone", () => {
+    const body = "Run this:\n```\ncat /workspace/report.md\n```\nThen review it.";
+    const r = sanitizeAgentProse(body);
+    expect(r.text).toContain("cat /workspace/report.md");
+    expect(r.text).toContain("Then review it.");
+  });
+
+  it("bare /workspace with no filename leaves nothing behind", () => {
+    const r = sanitizeAgentProse("The files live under /workspace and are synced nightly.");
+    expect(r.text).not.toContain("/workspace");
+    expect(r.text).toContain("The files live under and are synced nightly.");
+  });
+});
+
+describe("sanitizeAgentProse removes local endpoints and ports", () => {
+  it("localhost URLs become 'the server'", () => {
+    const r = sanitizeAgentProse("The preview is at http://localhost:3000/dashboard — take a look.");
+    expect(r.text).not.toMatch(/localhost|3000/);
+    expect(r.text).toContain("the server");
+  });
+
+  it("127.0.0.1 with a port too", () => {
+    const r = sanitizeAgentProse("Health check passes against 127.0.0.1:8080.");
+    expect(r.text).not.toMatch(/127\.0\.0\.1|8080/);
+  });
+
+  it("'running on port 3000' loses the port", () => {
+    const r = sanitizeAgentProse("The API is running on port 3000 and answering.");
+    expect(r.text).toBe("The API is running and answering.");
+  });
+});
+
+describe("sanitizeAgentProse rewrites harness vocabulary", () => {
+  const cases: Array<[string, RegExp, RegExp]> = [
+    ["Waiting on the review flip before I start the next card.", /review flip/i, /\breview\b/],
+    ["@iris flipped it to done this morning.", /flipped/i, /moved it to done/],
+    ["I did three things this turn.", /this turn/i, /today/],
+    ["The heartbeat found nothing new.", /heartbeat/i, /status check/],
+    ["The auto-verifier rejected the draft.", /verifier/i, /automated check/],
+    ["Use share_to_task to ship the file.", /share_to_task/, /attach to the card/],
+    ["Logged it in project_note for the record.", /project_note/, /the project notes/],
+    ["Left a task_comment with the numbers.", /task_comment/, /a card comment/],
+    ["HERMES_WRITE_SAFE_ROOT is set to the data mount.", /HERMES_/, /the runtime/],
+  ];
+  for (const [input, gone, present] of cases) {
+    it(`rewrites: ${input.slice(0, 40)}…`, () => {
+      const out = sanitizeAgentProse(input).text;
+      expect(out).not.toMatch(gone);
+      expect(out).toMatch(present);
+    });
+  }
+
+  it("does not rewrite inside a fence", () => {
+    const out = sanitizeAgentProse("Call it like:\n```\nshare_to_task(task_id=\"x\")\n```\nDone.").text;
+    expect(out).toContain('share_to_task(task_id="x")');
+  });
+});
+
+describe("sanitizeAgentProse rejects bodies that are only machinery", () => {
+  it("a lone gateway warning", () => {
+    const r = sanitizeAgentProse("WARNING gateway.run: No env user allowlists configured.");
+    expect(r.text).toBe("");
+    expect(r.emptyReason).toBe("runtime_log_line");
+  });
+
+  it("a lone tool_call block", () => {
+    const r = sanitizeAgentProse("<tool_call>\n<function=read_file>\n<parameter=path>x</parameter>\n</function>\n</tool_call>");
+    expect(r.text).toBe("");
+    expect(r.emptyReason).toBe("tool_call_markup");
+  });
+
+  it("the invalid-tool-call notice", () => {
+    const r = sanitizeAgentProse("Model generated invalid tool call: missing required argument.");
+    expect(r.emptyReason).toBe("invalid_tool_call_notice");
+  });
+
+  it("an OUTPUT_ERROR marker", () => {
+    const r = sanitizeAgentProse("**OUTPUT_ERROR**");
+    expect(r.emptyReason).toBe("output_error_notice");
+  });
+
+  it("a misspelled heartbeat sentinel", () => {
+    const r = sanitizeAgentProse("HEARTBERAT_OK");
+    expect(r.emptyReason).toBe("heartbeat_leaked");
+  });
+
+  it("a model-breakdown token", () => {
+    const r = sanitizeAgentProse("<｜DSML｜");
+    expect(r.emptyReason).toBe("model_breakdown_token");
+  });
+
+  it("the task-only-mode banner", () => {
+    const r = sanitizeAgentProse("HERMES IS IN TASK-ONLY MODE — no conversation is attached.");
+    expect(r.emptyReason).toBe("task_only_mode_banner");
+  });
+
+  it("a bare section header with nothing under it", () => {
+    const r = sanitizeAgentProse("**Status Update:**");
+    expect(r.text).toBe("");
+    expect(r.emptyReason).toBe("empty_body");
+  });
+
+  it("but keeps a section header that HAS content", () => {
+    const r = sanitizeAgentProse("**Status Update:**\nThe copy is drafted and on the card.");
+    expect(r.emptyReason).toBeUndefined();
+    expect(r.text).toContain("The copy is drafted");
+  });
+});
+
+describe("sanitizeAgentProse strips machinery mixed into real prose", () => {
+  it("keeps the prose either side of a gateway log line", () => {
+    const r = sanitizeAgentProse(
+      "Draft is on the card.\nWARNING gateway.run: No env user allowlists configured.\nReview when you can.",
+    );
+    expect(r.text).not.toContain("gateway.run");
+    expect(r.text).toContain("Draft is on the card.");
+    expect(r.text).toContain("Review when you can.");
+    expect(r.stripped).toContain("runtime_log_line");
+  });
+
+  it("keeps the 'Full update on the task card:' pointer", () => {
+    const r = sanitizeAgentProse("Shipped the copy. Full update on the task card:");
+    expect(r.text).toContain("Full update on the task card:");
+  });
+});
+
+describe("checkReplyBody stores the sanitized body", () => {
+  it("a real reply with a path is accepted, cleaned", () => {
+    const r = checkReplyBody(
+      "server.js is persisted on shared disk at /workspace/backend/server.js — ready for @nova's flip to done.",
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.bodyMd).not.toContain("/workspace");
+      expect(r.bodyMd).toContain("move to done");
+    }
+  });
+
+  it("a body that is only a gateway warning is refused with a hint", () => {
+    const r = checkReplyBody("WARNING gateway.run: No env user allowlists configured.");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("runtime_log_line");
+      expect(guardRejectHint(r.reason)).toMatch(/diagnostics/i);
+    }
+  });
+
+  it("the canonical HEARTBEAT_OK sentinel is still rejected, not rewritten", () => {
+    const r = checkReplyBody("HEARTBEAT_OK");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("heartbeat_leaked");
+  });
+
+  it("a typed-out action call is still rejected (rewrites don't disarm the guard)", () => {
+    const r = checkReplyBody('task_comment(task_id="task_abcdefghijkl", body_md="hi")');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("tool_call_syntax");
+  });
+});
+
+describe("applyProseRewrites is pure", () => {
+  it("leaves ordinary prose untouched", () => {
+    const s = "The landing page copy is drafted and waiting for a second pair of eyes.";
+    expect(applyProseRewrites(s)).toBe(s);
+  });
+});
+
+describe("redactDeleted", () => {
+  it("blanks the body and attachments of a soft-deleted row", () => {
+    const row = {
+      id: "m_1",
+      bodyMd: "the secret original text",
+      attachmentsJson: [{ key: "u/x/y.png" }],
+      deletedAt: new Date(),
+    };
+    const out = redactDeleted(row);
+    expect(out.bodyMd).toBe("");
+    expect(out.attachmentsJson).toEqual([]);
+    expect(out.id).toBe("m_1");
+  });
+
+  it("returns a live row unchanged", () => {
+    const row = { id: "m_2", bodyMd: "hello", attachmentsJson: [], deletedAt: null };
+    expect(redactDeleted(row)).toBe(row);
+  });
+});
+
+describe("needs-you stalled goal detail", () => {
+  it("reads as a date, not planner bookkeeping", () => {
+    expect(stalledDetail(new Date("2026-09-03T10:00:00Z"))).toBe("No movement since 3 Sep.");
+  });
+});
+
+describe("publicAgentView", () => {
+  it("keeps identity fields and drops the wiring", () => {
+    const row = {
+      id: "a_1",
+      handle: "nova",
+      name: "Nova",
+      avatarColor: "blue",
+      title: "Researcher",
+      brief: "Researches topics.",
+      status: "idle",
+      memberId: "m_1",
+      model: "claude",
+      kind: "hermes",
+      adapter: "socket",
+      configJson: { baseUrl: "http://internal:8080" },
+      scopes: ["channels.read"],
+      botToken: "cc_***",
+      callbackUrl: "http://internal/hook",
+      heartbeatIntervalSec: 60,
+      budgetUsdMonth: 10,
+      pauseReason: null,
+    };
+    const out = publicAgentView(row) as Record<string, unknown>;
+    expect(Object.keys(out).sort()).toEqual(
+      ["avatarColor", "brief", "handle", "id", "memberId", "model", "name", "status", "title"],
+    );
+  });
+});

--- a/api/src/__tests__/bridge-reply.test.ts
+++ b/api/src/__tests__/bridge-reply.test.ts
@@ -105,6 +105,9 @@ describe("bridge stripRuntimeNoise — file-mutation verifier notice", () => {
   it("drops the header and its bullets, keeps the reply", () => {
     const text = "Backend is live on port 3000.\n\n⚠️ File-mutation verifier: 1 file(s) were NOT modified this turn despite any wording above.\n  • `/workspace/tmp/x.py` — [write_file] Write denied: outside HERMES_WRITE_SAFE_ROOT (/opt/data). Unset the variable or add this path's directory prefix.";
     const out = bridge.stripRuntimeNoise(text);
-    expect(out).toBe("Backend is live on port 3000.");
+    // stripRuntimeNoise now also runs the prose rewrites (mirror of
+    // sanitizeAgentProse in api/src/agents/reply-guard.ts), so the dev port
+    // goes with the notice.
+    expect(out).toBe("Backend is live.");
   });
 });

--- a/api/src/agents/context.ts
+++ b/api/src/agents/context.ts
@@ -1,5 +1,6 @@
 import { and, eq, gt, inArray, desc, asc, isNull } from "drizzle-orm";
 import { db } from "../db/index.js";
+import { redactDeleted } from "../lib/deleted-rows.js";
 import {
   agents,
   members,
@@ -582,7 +583,10 @@ export async function buildContext(opts: {
         .from(messages)
         .where(and(eq(messages.parentId, rootId), isNull(messages.deletedAt)))
         .orderBy(asc(messages.ts));
-      const chain = [rootMsg, ...replies].filter(Boolean) as typeof replies;
+      // The thread ROOT is fetched by id, so (unlike the replies) a
+      // soft-deleted root would otherwise reach the agent's packet with its
+      // body intact. Redact instead of dropping — the thread shape matters.
+      const chain = [rootMsg, ...replies].filter(Boolean).map((m) => redactDeleted(m!)) as typeof replies;
       // Ensure every author is in the directory.
       const missing = chain
         .map((m) => m.memberId)

--- a/api/src/agents/executor.ts
+++ b/api/src/agents/executor.ts
@@ -14,7 +14,7 @@ import {
 } from "../db/schema.js";
 import { id } from "../lib/ids.js";
 import { publishToConversation, publishToWorkspace } from "../lib/events.js";
-import { checkReplyBody, guardRejectHint } from "./reply-guard.js";
+import { checkReplyBody, guardRejectHint, sanitizeAgentProse } from "./reply-guard.js";
 import { checkRecentDuplicate, checkRecentDuplicateTaskComment } from "./dedupe.js";
 import {
   extractMentionHandles,
@@ -1068,12 +1068,25 @@ async function applyOne(
         .from(agents)
         .where(eq(agents.id, agentId))
         .limit(1);
+      // Project notes are read by humans in the files pane, so they get the
+      // same prose sanitizer as chat and card comments: container paths, dev
+      // ports and harness vocabulary rewritten, machinery blocks stripped.
+      // A note that is nothing but machinery is refused rather than filed.
+      const noteProse = a.note === undefined ? null : sanitizeAgentProse(String(a.note));
+      if (noteProse?.emptyReason) {
+        out.errors.push(
+          `project_note rejected: ${noteProse.emptyReason}.${guardRejectHint(noteProse.emptyReason)}`,
+        );
+        return;
+      }
+      const summaryProse =
+        a.summary === undefined ? null : sanitizeAgentProse(String(a.summary));
       const r = await writeProjectFile({
         project: a.project,
         file: a.file,
         mode: a.mode,
-        note: a.note,
-        summary: a.summary,
+        note: noteProse ? noteProse.text : a.note,
+        summary: summaryProse && summaryProse.text ? summaryProse.text : a.summary,
         triggers: a.triggers,
         actorHandle: self?.handle ?? "agent",
       });

--- a/api/src/agents/reply-guard.ts
+++ b/api/src/agents/reply-guard.ts
@@ -393,6 +393,186 @@ export function stripLeakedScaffolding(s: string): ScaffoldStrip {
   return { text: out.replace(/\n{3,}/g, "\n\n").trim(), stripped };
 }
 
+// ───────────────────── sanitizeAgentProse ─────────────────────
+// The durable fix for "the workspace reads like an agent harness".
+//
+// Everything above rejects a body that IS machinery. This pass handles the far
+// more common case: real prose with machinery embedded in it — a container path
+// mid-sentence, a dev port, the harness's own vocabulary ("flip to done", "this
+// turn", "heartbeat", "auto-verifier", "share_to_task"), or a stray log line
+// glued to an otherwise fine paragraph. Rejecting those would throw away real
+// work; leaving them is what visitors were reading on the public demo.
+//
+// Two halves:
+//   (a) BLOCK detection — text that is only machinery is reported so the caller
+//       can reject it with a hint; the same blocks are stripped when they are
+//       mixed into real prose.
+//   (b) REWRITE — paths, ports and harness vocabulary become plain English.
+//
+// Code fences are never touched: an agent quoting a path inside ``` is showing
+// a command, and rewriting it would break the snippet.
+//
+// The bridge (api/hermes-multi-bridge.mjs) carries a minimal mirror of the
+// rewrite table in `applyProseRewrites()` so its own log/pointer path agrees
+// with what the server stores. Keep the two in step.
+
+// ── (a) machinery blocks ──
+// XML-ish tool-call scaffolding some models emit as plain text.
+// Paired blocks first (so the ARGUMENT TEXT inside them goes too — a stray
+// `x` left over from <parameter=path>x</parameter> is not a message), then the
+// unpaired tags a truncated generation leaves behind.
+const PROSE_TOOL_BLOCK_RE =
+  /<tool_call\b[^>]*>[\s\S]*?<\/tool_call>|<function=[^>\n]*>[\s\S]*?<\/function>|<parameter=[^>\n]*>[\s\S]*?<\/parameter>|<\/?tool_call\b[^>]*>|<function=[^>\n]*>|<\/?function\b[^>]*>|<parameter=[^>\n]*>|<\/?parameter\b[^>]*>/gi;
+// Gateway / runtime log lines that end up inside a reply.
+const PROSE_LOG_LINE_RE =
+  /(?:^|\n)[ \t]*(?:WARNING|WARN|ERROR|INFO|DEBUG)[ \t]+gateway\.[\w.]+[^\n]*/gi;
+const PROSE_INVALID_TOOL_CALL_RE = /(?:^|\n)[^\n]*Model generated invalid tool call[^\n]*/gi;
+const PROSE_OUTPUT_ERROR_RE = /(?:^|\n)[ \t]*\*{0,2}OUTPUT_ERROR\*{0,2}[^\n]*/gi;
+// HEARTBEAT_OK and its misspellings (HEARTBERAT_OK observed live). The strict
+// HEARTBEAT_RE above still rejects the canonical sentinel; this catches the
+// typo'd variants so they get stripped rather than posted.
+// Excludes the canonical HEARTBEAT / HEARTBEAT_OK: those are the silence
+// sentinel and are REJECTED outright by HEARTBEAT_RE above. Only the observed
+// misspellings (HEARTBERAT_OK, HEARBEAT_OK, HEARTBEAT_OK_OK) are stripped here.
+const PROSE_HEARTBEAT_VARIANT_RE = /\b(?!HEARTBEAT(?:_OK)?\b)HE[A-Z]*(?:BEAT|BERAT|BEART)[A-Z_]*\b/g;
+// Model-breakdown control tokens, e.g. `<｜DSML｜`, `<|im_start|>`. Full-width
+// pipes included — the DeepSeek-family tokens use U+FF5C.
+const PROSE_MODEL_TOKEN_RE = /<[｜|][^>\n]{0,40}(?:[｜|]>?|$)/g;
+// A "task-only mode" banner the runtime prints; never a message.
+const PROSE_TASK_ONLY_MODE_RE = /(?:^|\n)[^\n]*HERMES IS IN TASK-ONLY MODE[^\n]*/gi;
+
+// Every block pattern with the reject reason it implies when it is ALL there is.
+const PROSE_BLOCKS: Array<{ re: RegExp; reason: string }> = [
+  { re: PROSE_TOOL_BLOCK_RE, reason: "tool_call_markup" },
+  { re: PROSE_LOG_LINE_RE, reason: "runtime_log_line" },
+  { re: PROSE_INVALID_TOOL_CALL_RE, reason: "invalid_tool_call_notice" },
+  { re: PROSE_OUTPUT_ERROR_RE, reason: "output_error_notice" },
+  { re: PROSE_HEARTBEAT_VARIANT_RE, reason: "heartbeat_leaked" },
+  { re: PROSE_MODEL_TOKEN_RE, reason: "model_breakdown_token" },
+  { re: PROSE_TASK_ONLY_MODE_RE, reason: "task_only_mode_banner" },
+];
+
+// ── (b) rewrites ──
+// Absolute container paths → the bare filename in backticks. `/workspace` and
+// `/opt/data` are the agent's mounts; a teammate can't open either.
+const PROSE_PATH_RE = /(^|[\s("'[<])(\/(?:opt\/data|workspace|tmp)(?:\/[\w.@%+-]+)*)\/?/g;
+// Local endpoints and port mentions.
+const PROSE_LOCALHOST_RE =
+  /\b(?:https?:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0)(?::\d{2,5})?(?:\/[\w./?=&%-]*)?/gi;
+const PROSE_ON_PORT_RE = /\s*\b(?:on|at|via)\s+port\s+\d{2,5}\b/gi;
+const PROSE_BARE_PORT_RE = /(^|[\s(])::?\d{2,5}\b/g;
+
+// Harness vocabulary → what a colleague would say. Ordered: the multi-word
+// phrases must run before the single words they contain.
+const PROSE_VOCAB: Array<[RegExp, string]> = [
+  [/\breview[ -]flips?\b/gi, "review"],
+  // Longest-first: "flipped it to done" must not be eaten by the bare "flipped"
+  // rule below, and each form keeps its own tense.
+  [/\bflipped\s+it\s+to\s+done\b/gi, "moved it to done"],
+  [/\bflipped\s+to\s+done\b/gi, "moved to done"],
+  [/\bflipping\s+it\s+to\s+done\b/gi, "moving it to done"],
+  [/\bflipping\s+to\s+done\b/gi, "moving to done"],
+  [/\bflips\s+it\s+to\s+done\b/gi, "moves it to done"],
+  [/\bflips\s+to\s+done\b/gi, "moves to done"],
+  [/\bflip\s+it\s+to\s+done\b/gi, "move it to done"],
+  [/\bflip\s+to\s+done\b/gi, "move to done"],
+  [/\bflipped\b/gi, "moved"],
+  [/\bflipping\b/gi, "moving"],
+  [/\bflips\b/gi, "moves"],
+  [/\bthis turn\b/gi, "today"],
+  [/\bauto-?verifiers?\b/gi, "automated check"],
+  [/\bverifiers?\b/gi, "automated check"],
+  [/\bheartbeats?\b/gi, "status check"],
+  [/\bshare_to_task\b/g, "attach to the card"],
+  [/\bproject_note\b/g, "the project notes"],
+  [/\btask_comment\b/g, "a card comment"],
+  [/\bHERMES_[A-Z0-9_]+\b/g, "the runtime"],
+];
+
+// Split on fenced code blocks so the rewrites never touch a snippet. Odd
+// indices of the returned array are fences (including their ``` markers).
+function splitFences(s: string): string[] {
+  return s.split(/(```[\s\S]*?```)/g);
+}
+function outsideFences(s: string, fn: (chunk: string) => string): string {
+  return splitFences(s)
+    .map((chunk, i) => (i % 2 === 1 ? chunk : fn(chunk)))
+    .join("");
+}
+
+// Pure: apply the path / port / vocabulary rewrites to one non-fenced chunk.
+// Exported for tests and mirrored by the bridge.
+export function applyProseRewrites(chunk: string): string {
+  let out = chunk;
+  out = out.replace(PROSE_PATH_RE, (m: string, pre: string, p: string) => {
+    // A path written with a trailing slash is a directory — there is no
+    // filename worth showing, so it goes entirely.
+    if (m.endsWith("/")) return pre;
+    const last = p.split("/").filter(Boolean).pop() ?? "";
+    const bare = last && last !== "workspace" && last !== "tmp" && last !== "data";
+    return bare ? `${pre}\`${last}\`` : pre;
+  });
+  out = out.replace(PROSE_LOCALHOST_RE, "the server");
+  out = out.replace(PROSE_ON_PORT_RE, "");
+  out = out.replace(PROSE_BARE_PORT_RE, "$1");
+  for (const [re, to] of PROSE_VOCAB) out = out.replace(re, to);
+  return out;
+}
+
+export interface ProseSanitize {
+  text: string;
+  // Block classes removed, in the order found.
+  stripped: string[];
+  // Set when nothing substantive survived — the caller should reject with this
+  // reason rather than store an empty body.
+  emptyReason?: string;
+}
+
+// A body with nothing left to say: no letters, or only a bolded section header
+// ("**Status Update:**") with no content under it.
+const HEADER_ONLY_RE =
+  /^[*_#\s]*(?:status\s+update|update|summary|progress|report|note|status)\s*[:\-—]?\s*[*_]*\s*$/i;
+function isSubstantive(s: string, strippedAnything: boolean): boolean {
+  const t = s.trim();
+  if (!t) return false;
+  if (HEADER_ONLY_RE.test(t)) return false;
+  // A short ack ("+1", "👍") is a perfectly good message on its own — but the
+  // same residue left behind AFTER stripping a machinery block (the argument
+  // text out of a <parameter=…> tag, say) is not. Only demand real words when
+  // something was actually removed.
+  if (strippedAnything && !/[a-z]{3}/i.test(t)) return false;
+  return true;
+}
+
+export function sanitizeAgentProse(text: string): ProseSanitize {
+  const stripped: string[] = [];
+  let out = String(text ?? "");
+  // Strip machinery blocks OUTSIDE fences (a fenced example of a tool call is
+  // a teaching snippet, not a leak).
+  for (const { re, reason } of PROSE_BLOCKS) {
+    let hit = false;
+    out = outsideFences(out, (chunk) => {
+      re.lastIndex = 0;
+      if (!re.test(chunk)) return chunk;
+      hit = true;
+      re.lastIndex = 0;
+      return chunk.replace(re, "");
+    });
+    if (hit) stripped.push(reason);
+  }
+  out = outsideFences(out, applyProseRewrites);
+  out = out
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/[ \t]+([,.;:!?])/g, "$1")
+    .replace(/\(\s*\)/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  if (!isSubstantive(out, stripped.length > 0)) {
+    return { text: "", stripped, emptyReason: stripped[0] ?? "empty_body" };
+  }
+  return { text: out, stripped };
+}
+
 // Actionable guidance appended to the rejection error fed back to the agent
 // on its next turn. Only reasons where the fix isn't obvious from the name.
 export function guardRejectHint(reason: string): string {
@@ -445,6 +625,18 @@ export function guardRejectHint(reason: string): string {
       return " Your reply was only the runtime's 'File-mutation verifier' notice — a write was denied. That is diagnostics for you, not a message. Fix the path (write under /opt/data) and post only the outcome a teammate needs.";
     case "gateway_boot":
       return " Your reply was only the Hermes gateway's boot banner ('Hermes Gateway Starting…') — runtime output, not a message. Say the one new fact for the team, or stay silent with HEARTBEAT_OK.";
+    case "tool_call_markup":
+      return " Your reply contained raw tool-call markup (<tool_call>, <function=…>, <parameter=…>) instead of prose. Those tags are for the runtime, never for a channel. Put board actions in an <actions>[…]</actions> block and write the message itself in plain sentences.";
+    case "runtime_log_line":
+      return " Your reply was a runtime log line (\"WARNING gateway.run: …\"). That's operator diagnostics, not a message — never post it. Say the one concrete outcome, or stay silent with exactly HEARTBEAT_OK.";
+    case "invalid_tool_call_notice":
+      return " Your reply carried the runtime's \"Model generated invalid tool call\" notice — a tool call you emitted was malformed. Re-issue it correctly (or emit the board action as an <actions> JSON block); don't post the error.";
+    case "output_error_notice":
+      return " Your reply was an **OUTPUT_ERROR** notice. That's a runtime failure marker, not a message. Retry the work and report the outcome in plain prose.";
+    case "model_breakdown_token":
+      return " Your reply contained model control tokens (e.g. <｜…｜>) — the generation broke down. Re-read the last message and answer in plain English.";
+    case "task_only_mode_banner":
+      return " Your reply was the runtime's task-only-mode banner. That's internal state, not a message — post the work outcome on the card instead.";
     case "signoff_only":
       return " Your reply was only a signature/sign-off. Chat messages carry no sign-offs, no name/title lines, no hash footers — say the one new fact, then stop.";
     default:
@@ -466,6 +658,13 @@ export function checkReplyBody(
     const lead = stripped.find((r) => r !== "summary_leadin");
     return { ok: false, reason: lead === "signoff" ? "signoff_only" : lead || "empty_body" };
   }
+  // The prose pass strips embedded machinery blocks and rewrites container
+  // paths / dev ports / harness vocabulary into plain English. Its OUTPUT is
+  // what gets stored, but every rejection check below still runs against the
+  // PRE-rewrite text: the rewrites turn `task_comment` into "a card comment",
+  // which would otherwise disarm the tool-call / action-JSON detectors.
+  const prose = sanitizeAgentProse(scrubbed);
+  if (prose.emptyReason) return { ok: false, reason: prose.emptyReason };
   if (ARG_DEBRIS_RE.test(trimmed)) return { ok: false, reason: "tool_parse_debris" };
   if (SCAFFOLD_TALK_RE.test(trimmed)) return { ok: false, reason: "scaffold_talk" };
   if (HEARTBEAT_RE.test(trimmed)) return { ok: false, reason: "heartbeat_leaked" };
@@ -502,5 +701,5 @@ export function checkReplyBody(
   if (opts && opts.hasAttachments === false && ATTACHMENT_CLAIM_RE.test(trimmed)) {
     return { ok: false, reason: "attachment_claim_no_file" };
   }
-  return { ok: true, bodyMd: scrubbed };
+  return { ok: true, bodyMd: prose.text };
 }

--- a/api/src/lib/agent-brief.ts
+++ b/api/src/lib/agent-brief.ts
@@ -1,0 +1,22 @@
+// An agent's `brief` is the one-line job description humans read in the member
+// directory, on the org chart and on the agent's profile. It is NOT the agent's
+// instructions — those live in the skill templates. Briefs that described the
+// harness ("Reads the channels I belong to… on scheduled beats", "writes to
+// /workspace and shares via share_to_task", "posts to #build-log") were being
+// shown to visitors on the public demo as if they were job titles.
+
+import { applyProseRewrites } from "../agents/reply-guard.js";
+
+// Used when a caller creates an agent without supplying one.
+export const DEFAULT_AGENT_BRIEF =
+  "Answers questions in the channels they are in, picks up work from the board, and shares what changed.";
+
+// Strip runtime vocabulary / container paths / dev ports out of a supplied
+// brief and fall back to the default when nothing readable is left. Same
+// rewrite table as agent prose, so a brief and a chat message read alike.
+export function normalizeAgentBrief(brief: string | undefined | null): string {
+  const raw = (brief ?? "").trim();
+  if (!raw) return DEFAULT_AGENT_BRIEF;
+  const cleaned = applyProseRewrites(raw).replace(/[ \t]{2,}/g, " ").trim();
+  return cleaned || DEFAULT_AGENT_BRIEF;
+}

--- a/api/src/lib/agent-view.ts
+++ b/api/src/lib/agent-view.ts
@@ -1,0 +1,56 @@
+// What an agent row looks like to somebody who is not a workspace admin.
+//
+// `GET /agents`, `GET /agents/:id` and the member directory used to return the
+// whole `agents` row: runtime kind, adapter, the raw `configJson` (which can
+// carry a provider base URL and other deployment detail), the granted scopes,
+// the masked bot token, the callback URL, the heartbeat interval and the budget
+// / pause bookkeeping. On live.circlechat.co that is served to anonymous
+// spectators, so the public demo was publishing the harness wiring of every
+// agent. None of it is needed to render a member card, a member directory row
+// or an agent profile — those want the identity and what the agent does.
+//
+// Admins keep the full row (they configure it). Everyone else — spectators AND
+// ordinary members/guests — gets this projection.
+
+import type { FastifyRequest } from "fastify";
+import { workspaceAccess, permits } from "./access-control.js";
+
+// The only agent fields a non-admin ever needs. Anything not listed here is
+// dropped, so a new column added to the schema is private by default.
+export const PUBLIC_AGENT_FIELDS = [
+  "id",
+  "handle",
+  "name",
+  "avatarColor",
+  "title",
+  "brief",
+  "status",
+  "memberId",
+  "model",
+] as const;
+
+export type PublicAgentField = (typeof PUBLIC_AGENT_FIELDS)[number];
+
+// Pure: pick the public subset out of an agent-shaped object. Fields that are
+// absent on the input stay absent on the output (so `/members` rows, which
+// carry no `model`, don't sprout a `model: undefined`).
+export function publicAgentView<T extends Record<string, unknown>>(row: T): Partial<T> {
+  const out: Partial<T> = {};
+  for (const key of PUBLIC_AGENT_FIELDS) {
+    if (key in row) (out as Record<string, unknown>)[key] = row[key];
+  }
+  return out;
+}
+
+// True when the caller may see an agent's configuration. Spectators never can
+// (the shared read-only identity is not an admin even if its user row happened
+// to hold the role); everyone else needs the workspace admin permission.
+export async function canSeeAgentInternals(req: FastifyRequest): Promise<boolean> {
+  if (req.spectator) return false;
+  const workspaceId = req.auth?.workspaceId;
+  const userId = req.auth?.userId;
+  if (!workspaceId || !userId) return false;
+  const access = await workspaceAccess(workspaceId, userId);
+  if (!access) return false;
+  return access.role === "admin" || permits(access.permissions, "*");
+}

--- a/api/src/lib/deleted-rows.ts
+++ b/api/src/lib/deleted-rows.ts
@@ -1,0 +1,33 @@
+// A soft-deleted message / task comment keeps its row (so thread structure,
+// reaction counts and reply counts stay intact) but its BODY is gone as far as
+// any reader is concerned. The delete route has zeroed `bodyMd` since it was
+// written, but rows soft-deleted before that — and rows deleted by other paths
+// (admin cleanup, the janitor) — still carry their original text, and the
+// message-list handler used to ship them over the wire verbatim. On the public
+// fishbowl that meant 131 deleted bodies were readable by anyone who opened
+// devtools, even though the UI filtered them out of the rendered list.
+//
+// Redact on READ, not just on write: it's the only place that can't be bypassed
+// by an older row or a future delete path that forgets to blank the column.
+
+export interface SoftDeletable {
+  bodyMd?: string;
+  attachmentsJson?: unknown[];
+  deletedAt?: Date | string | null;
+}
+
+// Returns the row unchanged when it is not deleted; otherwise a copy with an
+// empty body and no attachments. Pure — safe to unit test and to map over a
+// result set.
+export function redactDeleted<T extends SoftDeletable>(row: T): T {
+  if (!row || !row.deletedAt) return row;
+  return {
+    ...row,
+    ...(row.bodyMd === undefined ? {} : { bodyMd: "" }),
+    ...(row.attachmentsJson === undefined ? {} : { attachmentsJson: [] }),
+  };
+}
+
+export function redactDeletedRows<T extends SoftDeletable>(rows: T[]): T[] {
+  return rows.map(redactDeleted);
+}

--- a/api/src/lib/needs-you-copy.ts
+++ b/api/src/lib/needs-you-copy.ts
@@ -1,0 +1,19 @@
+// Human-facing copy for the "Needs you" queue. Pure string builders, kept out
+// of the route so they can be unit tested without touching the DB.
+
+// Shown instead of the judge's raw rationale on the public read-only demo. The
+// rationale is written for the reviewer agent — it quotes rubric wording, file
+// paths and tool names — so a visitor gets the fact, not the machinery.
+export const SPECTATOR_VERIFICATION_DETAIL =
+  "An automated check flagged this deliverable — open the card to see what is missing.";
+
+// "3 stalled assessment(s); 1 re-plan(s)" counted the planner's own bookkeeping;
+// nobody can act on it. What a human wants is how long the goal has sat still.
+// Fixed month names rather than toLocaleDateString: the ICU short form for
+// September is "Sept" on some Node builds and "Sep" on others, and this string
+// is asserted in tests and read on the public demo.
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+export function stalledDetail(updatedAt: Date): string {
+  return `No movement since ${updatedAt.getUTCDate()} ${MONTHS[updatedAt.getUTCMonth()]}.`;
+}

--- a/api/src/routes/agent-api.ts
+++ b/api/src/routes/agent-api.ts
@@ -32,6 +32,7 @@ import { createHash } from "node:crypto";
 import { publishToConversation } from "../lib/events.js";
 import { notifyForMessage } from "../lib/notifications.js";
 import { checkReplyBody, guardRejectHint } from "../agents/reply-guard.js";
+import { redactDeleted } from "../lib/deleted-rows.js";
 import { checkRecentDuplicate } from "../agents/dedupe.js";
 import { sanitizeAttachments, applyActions, type AgentAction } from "../agents/executor.js";
 import {
@@ -125,7 +126,11 @@ function makeResolver(
   memberDir: Record<string, { handle: string; name: string; kind: string }>,
   rxMap: Map<string, Array<{ emoji: string; memberId: string; memberHandle: string }>>,
 ) {
-  return (m: typeof messages.$inferSelect) => ({
+  return (raw: typeof messages.$inferSelect) => {
+    // A soft-deleted message can still be reached (it's the root of a thread,
+    // or an older row whose body was never blanked) — never hand its text out.
+    const m = redactDeleted(raw);
+    return {
     id: m.id,
     conversationId: m.conversationId,
     memberId: m.memberId,
@@ -137,7 +142,8 @@ function makeResolver(
     ts: m.ts.toISOString(),
     reactions: rxMap.get(m.id) ?? [],
     attachments: m.attachmentsJson ?? [],
-  });
+    };
+  };
 }
 
 async function reactionsFor(

--- a/api/src/routes/agent-install.ts
+++ b/api/src/routes/agent-install.ts
@@ -25,6 +25,7 @@ import {
 import { HERMES_RUNTIME, buildHermesCommand } from "../agents/hermes-runtime.js";
 import { buildOpenClawCommand } from "../agents/openclaw-runtime.js";
 import { equipOpenClawAgent } from "../agents/openclaw-equip.js";
+import { normalizeAgentBrief } from "../lib/agent-brief.js";
 
 // Where Hermes per-agent homes live and where the multi-bridge reads its
 // connection list. Both are overridable for dev.
@@ -260,7 +261,7 @@ export default async function agentInstallRoutes(app: FastifyInstance): Promise<
       scopes: ["channels.read", "channels.reply", "tasks.write"],
       status: "provisioning",
       title: body.title ?? "",
-      brief: body.brief ?? "",
+      brief: normalizeAgentBrief(body.brief),
       botToken,
       heartbeatIntervalSec: body.heartbeatIntervalSec ?? 3600,
       callbackUrl: null,
@@ -487,7 +488,7 @@ export default async function agentInstallRoutes(app: FastifyInstance): Promise<
       scopes: ["channels.read", "channels.reply", "tasks.write"],
       status: "provisioning",
       title: body.title ?? "",
-      brief: body.brief ?? "",
+      brief: normalizeAgentBrief(body.brief),
       botToken,
       heartbeatIntervalSec: body.heartbeatIntervalSec ?? 3600,
       callbackUrl: null,

--- a/api/src/routes/agents.ts
+++ b/api/src/routes/agents.ts
@@ -16,6 +16,8 @@ import { enqueueAgentEvent } from "../agents/enqueue.js";
 import { scheduleAgentHeartbeat, cancelAgentHeartbeat, clearHeartbeatBackoff } from "../agents/scheduler.js";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { filterWorkspaceConversationIds } from "../lib/workspace-scope.js";
+import { canSeeAgentInternals, publicAgentView } from "../lib/agent-view.js";
+import { normalizeAgentBrief } from "../lib/agent-brief.js";
 
 const CreateBody = z.object({
   name: z.string().min(1).max(100),
@@ -103,13 +105,16 @@ export default async function agentRoutes(app: FastifyInstance): Promise<void> {
           )
       : [];
     const mmap = new Map(memberRows.map((m) => [m.refId, m.id]));
-    return {
-      agents: rows.map((a) => ({
-        ...a,
-        botToken: mask(a.botToken),
-        memberId: mmap.get(a.id),
-      })),
-    };
+    // Only an admin sees the wiring (runtime kind, adapter, config, scopes,
+    // token, callback, heartbeat, budget). Spectators and ordinary members get
+    // the identity projection — see lib/agent-view.ts.
+    const full = await canSeeAgentInternals(req);
+    const shaped = rows.map((a) => ({
+      ...a,
+      botToken: mask(a.botToken),
+      memberId: mmap.get(a.id),
+    }));
+    return { agents: full ? shaped : shaped.map(publicAgentView) };
   });
 
   app.post("/agents", { preHandler: requireWorkspace }, async (req, reply) => {
@@ -141,7 +146,7 @@ export default async function agentRoutes(app: FastifyInstance): Promise<void> {
       scopes,
       status: "provisioning",
       title: body.title ?? "",
-      brief: body.brief ?? "",
+      brief: normalizeAgentBrief(body.brief),
       botToken,
       heartbeatIntervalSec: body.heartbeatIntervalSec ?? 3600,
       callbackUrl: body.callbackUrl ?? null,
@@ -210,8 +215,10 @@ export default async function agentRoutes(app: FastifyInstance): Promise<void> {
       .where(eq(agentRuns.agentId, aId))
       .orderBy(desc(agentRuns.startedAt))
       .limit(25);
+    const full = await canSeeAgentInternals(req);
+    const shaped = { ...a, botToken: mask(a.botToken), memberId: mem?.id };
     return {
-      agent: { ...a, botToken: mask(a.botToken), memberId: mem?.id },
+      agent: full ? shaped : publicAgentView(shaped),
       channels: channels.map((c) => c.conversation),
       recentRuns,
     };
@@ -506,7 +513,7 @@ async function createAgentFromSpec(
     scopes: spec.scopes ?? ["channels.read", "channels.reply", "tasks.write"],
     status: "provisioning",
     title: spec.title ?? "",
-    brief: spec.brief ?? "",
+    brief: normalizeAgentBrief(spec.brief),
     botToken,
     heartbeatIntervalSec: spec.heartbeatIntervalSec ?? 3600,
     callbackUrl: null,

--- a/api/src/routes/conversations.ts
+++ b/api/src/routes/conversations.ts
@@ -17,6 +17,7 @@ import {
 import { requireWorkspace } from "../auth/session.js";
 import { id } from "../lib/ids.js";
 import { filterWorkspaceMemberIds } from "../lib/workspace-scope.js";
+import { canSeeAgentInternals } from "../lib/agent-view.js";
 
 function dmId(a: string, b: string): string {
   const sorted = [a, b].sort().join(":");
@@ -521,7 +522,14 @@ export default async function conversationRoutes(app: FastifyInstance): Promise<
     // must never see them. Null the field before it leaves the server so no
     // amount of client tampering can reveal a member's email on the fishbowl.
     const humans = req.spectator ? u.map((h) => ({ ...h, email: null })) : u;
-    return { humans, agents: a };
+    // `agentKind` is the runtime that drives the agent ("hermes"/"openclaw") —
+    // harness detail the directory printed next to every agent's name. Only an
+    // admin has any use for it; for everyone else it's jargon (and on the
+    // public demo, deployment detail). Null it rather than dropping the key so
+    // the row shape stays stable for the client.
+    const full = await canSeeAgentInternals(req);
+    const agentRows = full ? a : a.map((row) => ({ ...row, agentKind: null }));
+    return { humans, agents: agentRows };
   });
 
   // Presence snapshot for every member of the current workspace. Reads the

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -19,6 +19,7 @@ import { enqueueAgentEvent } from "../agents/enqueue.js";
 import { fireChannelPostTrigger, resolveHandlesToMemberIds } from "../agents/mention-triggers.js";
 import { notifyForMessage } from "../lib/notifications.js";
 import { sanitizeAttachments } from "../agents/executor.js";
+import { redactDeleted } from "../lib/deleted-rows.js";
 
 // Query-string helpers: `Number("abc")` is NaN and `new Date("garbage")` is an
 // Invalid Date — both used to flow straight into the SQL builder and 500.
@@ -119,8 +120,11 @@ export default async function messageRoutes(app: FastifyInstance): Promise<void>
     }
 
     return {
+      // A soft-deleted message stays in the list (the client renders a
+      // tombstone and thread counts stay right) but its body/attachments never
+      // leave the server — see lib/deleted-rows.ts.
       messages: rows.map((m) => ({
-        ...m,
+        ...redactDeleted(m),
         reactions: rxMap.get(m.id) ?? [],
         replyCount: tcMap.get(m.id) ?? 0,
       })),

--- a/api/src/routes/needs-you.ts
+++ b/api/src/routes/needs-you.ts
@@ -16,6 +16,7 @@ import {
 } from "../db/schema.js";
 import { requireWorkspace } from "../auth/session.js";
 import { approvalExpiresAt, isCredentialAsk } from "../lib/approval-policy.js";
+import { SPECTATOR_VERIFICATION_DETAIL, stalledDetail } from "../lib/needs-you-copy.js";
 
 type ReviewItem = {
   id: string;
@@ -81,12 +82,18 @@ export default async function needsYouRoutes(app: FastifyInstance): Promise<void
     for (const task of reviewTasks) {
       const failed = latestFailed.get(task.id);
       if (failed) {
-        items.push({ id: `verification:${failed.verification.id}`, kind: "verification_failed", priority: "high", title: `Needs review: ${task.title}`, detail: `Verification failed — ${failed.verification.rationale || `score ${failed.verification.score ?? "n/a"}`}`, link: `/board?task=${task.id}`, targetId: task.id, createdAt: failed.verification.createdAt.toISOString(), actions: ["open"] });
+        // The judge's rationale is written for the reviewer agent: it quotes
+        // file paths, tool names and rubric wording. A logged-in reviewer needs
+        // it; the public read-only spectator gets a plain-English stand-in.
+        const detail = req.spectator
+          ? SPECTATOR_VERIFICATION_DETAIL
+          : `Verification failed — ${failed.verification.rationale || `score ${failed.verification.score ?? "n/a"}`}`;
+        items.push({ id: `verification:${failed.verification.id}`, kind: "verification_failed", priority: "high", title: `Needs review: ${task.title}`, detail, link: `/board?task=${task.id}`, targetId: task.id, createdAt: failed.verification.createdAt.toISOString(), actions: ["open"] });
       } else {
         items.push({ id: `task:${task.id}`, kind: "task_review", priority: "normal", title: `Needs review: ${task.title}`, detail: "The assignee marked this card ready. Open it to check the deliverable and move it to done.", link: `/board?task=${task.id}`, targetId: task.id, createdAt: task.updatedAt.toISOString(), actions: ["open"] });
       }
     }
-    for (const row of stalledGoals) items.push({ id: `goal:${row.ledger.goalId}`, kind: "stalled_goal", priority: row.ledger.stallCount >= 3 ? "critical" : "high", title: `Stalled goal: ${row.title}`, detail: `${row.ledger.stallCount} stalled assessment(s); ${row.ledger.replanCount} re-plan(s).`, link: "/goals", targetId: row.ledger.goalId, createdAt: row.ledger.updatedAt.toISOString(), actions: ["open"] });
+    for (const row of stalledGoals) items.push({ id: `goal:${row.ledger.goalId}`, kind: "stalled_goal", priority: row.ledger.stallCount >= 3 ? "critical" : "high", title: `Stalled goal: ${row.title}`, detail: stalledDetail(row.ledger.updatedAt), link: "/goals", targetId: row.ledger.goalId, createdAt: row.ledger.updatedAt.toISOString(), actions: ["open"] });
     for (const row of waits) items.push({ id: `workflow-wait:${row.run.id}`, kind: "workflow_wait", priority: "high", title: `${row.name} is waiting for you`, detail: `State ${row.run.currentStateId ?? "unknown"}`, link: "/automation", targetId: row.run.id, createdAt: row.run.updatedAt.toISOString(), actions: ["resume", "cancel", "steer"] });
     for (const row of failures) items.push({ id: `workflow-failed:${row.run.id}`, kind: "workflow_failed", priority: "high", title: `${row.name} failed`, detail: row.run.errorText ?? "Workflow failed without an error message.", link: "/automation", targetId: row.run.id, createdAt: row.run.updatedAt.toISOString(), actions: ["open"] });
     for (const connector of connectorErrors) items.push({ id: `connector:${connector.id}`, kind: "connector_error", priority: "high", title: `Connector error: ${connector.name}`, detail: connector.lastError ?? "Health check failed.", link: "/automation", targetId: connector.id, createdAt: connector.updatedAt.toISOString(), actions: ["recheck"] });

--- a/api/src/routes/org.ts
+++ b/api/src/routes/org.ts
@@ -9,6 +9,7 @@ import {
   workspaceMembers,
 } from "../db/schema.js";
 import { requireWorkspace } from "../auth/session.js";
+import { canSeeAgentInternals } from "../lib/agent-view.js";
 
 const AssignBody = z.object({
   memberId: z.string().min(1),
@@ -36,7 +37,10 @@ export default async function orgRoutes(app: FastifyInstance): Promise<void> {
   app.get("/org", async (req) => {
     const { workspaceId } = req.auth!;
     const nodes = await loadOrgNodes(workspaceId!);
-    return { nodes };
+    // The runtime that drives an agent is admin-only wiring — the org chart
+    // renders a person, not a harness. See lib/agent-view.ts.
+    if (await canSeeAgentInternals(req)) return { nodes };
+    return { nodes: nodes.map((node) => ({ ...node, agentKind: null })) };
   });
 
   // Reassign a member's manager. Admin-only; rejects cycles and cross-workspace

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -133,7 +133,8 @@ export interface AgentMember {
   name: string;
   handle: string;
   avatarColor: string;
-  agentKind: string;
+  // Runtime kind ("hermes"/"openclaw") — admin-only; null for everyone else.
+  agentKind: string | null;
   status: string;
   title: string;
   brief: string;
@@ -142,27 +143,32 @@ export interface AgentMember {
 
 export type DirMember = HumanMember | AgentMember;
 
+// The server ships the full row to workspace admins only. Spectators and
+// ordinary members get the identity projection (see api/src/lib/agent-view.ts),
+// so every configuration field below is optional and must be rendered
+// defensively — never assume `agent.scopes` or `agent.configJson` is there.
 export interface AgentRow {
   id: string;
   handle: string;
   name: string;
   avatarColor: string;
-  kind: string;
-  adapter: "webhook" | "socket";
-  configJson: Record<string, unknown>;
-  model: string;
-  scopes: string[];
+  model?: string;
   status: string;
-  pauseReason: "manual" | "budget" | null;
   title: string;
   brief: string;
-  heartbeatIntervalSec: number;
-  budgetUsdMonth: number | null;
-  botToken: string;
-  callbackUrl: string | null;
-  createdBy: string;
-  createdAt: string;
   memberId?: string;
+  // ─── admin-only, absent for spectators and non-admin members ───
+  kind?: string;
+  adapter?: "webhook" | "socket";
+  configJson?: Record<string, unknown>;
+  scopes?: string[];
+  pauseReason?: "manual" | "budget" | null;
+  heartbeatIntervalSec?: number;
+  budgetUsdMonth?: number | null;
+  botToken?: string;
+  callbackUrl?: string | null;
+  createdBy?: string;
+  createdAt?: string;
 }
 
 export interface AgentRun {

--- a/web/src/components/Board.tsx
+++ b/web/src/components/Board.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { Plus, MessageSquare, GitBranch, Link2, Calendar, Lock } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTasks, useMembersDirectory, useMe, useSpectator } from "../lib/hooks";
+import { scrubIds } from "../lib/md";
 import { api, type Task, type TaskStatus } from "../api/client";
 import Avatar from "./Avatar";
 import TaskModal from "./TaskModal";
@@ -280,7 +281,7 @@ export default function Board() {
                     onClick={() => openTask(c.id)}
                     title={c.id}
                   >
-                    <div className="kc-title">{c.title}</div>
+                    <div className="kc-title">{scrubIds(c.title)}</div>
                     {c.blockedBy && c.blockedBy.length > 0 && (
                       <div className="kc-blocked" title={`Blocked by ${c.blockedBy.length} unfinished task(s)`}>
                         <Lock size={10} strokeWidth={2.2} />

--- a/web/src/components/MemberDetailsPanel.tsx
+++ b/web/src/components/MemberDetailsPanel.tsx
@@ -6,6 +6,7 @@ import { useBus } from "../state/store";
 import { api } from "../api/client";
 import Avatar from "./Avatar";
 import { usePaneResize } from "../lib/usePaneResize";
+import { scrubIds } from "../lib/md";
 import { useSpectator } from "../lib/hooks";
 import { AssignDialog, type OrgNode } from "../pages/Org";
 
@@ -42,7 +43,8 @@ export default function MemberDetailsPanel() {
   const isAgent = (member as { kind: string }).kind === "agent";
   const title = (member as { title?: string }).title ?? "";
   const brief = (member as { brief?: string }).brief ?? "";
-  const agentKind = (member as { agentKind?: string }).agentKind;
+  // Null unless the viewer is a workspace admin — see api/src/lib/agent-view.ts.
+  const agentKind = (member as { agentKind?: string | null }).agentKind;
   const status = presence[memberId] ?? (isAgent ? (member as { status?: string }).status ?? "idle" : "offline");
   const email = (member as { email?: string }).email;
   const agentId = (member as { id?: string }).id;
@@ -108,8 +110,12 @@ export default function MemberDetailsPanel() {
           )}
           {isAgent && (
             <>
-              <dt>Kind</dt>
-              <dd className="font-mono text-[12px]">{agentKind ?? "-"}</dd>
+              {agentKind && (
+                <>
+                  <dt>Kind</dt>
+                  <dd className="font-mono text-[12px]">{agentKind}</dd>
+                </>
+              )}
               <dt>Status</dt>
               <dd className="font-mono text-[12px]">{status}</dd>
             </>
@@ -139,7 +145,7 @@ export default function MemberDetailsPanel() {
         {brief && (
           <div className="mt-5">
             <div className="text-[11px] uppercase tracking-wider text-[var(--color-muted)] font-mono mb-1">Brief</div>
-            <p className="text-[13px] leading-relaxed whitespace-pre-wrap">{brief}</p>
+            <p className="text-[13px] leading-relaxed whitespace-pre-wrap">{scrubIds(brief)}</p>
           </div>
         )}
       </div>

--- a/web/src/components/TaskModal.tsx
+++ b/web/src/components/TaskModal.tsx
@@ -24,7 +24,7 @@ import Modal from "./Modal";
 import VerificationBadge from "./VerificationBadge";
 import { Popover } from "@base-ui/react/popover";
 import { useMentionPicker, resolveMentionIds } from "../lib/useMentionPicker";
-import { renderMarkdown } from "../lib/md";
+import { renderMarkdown, scrubIds } from "../lib/md";
 import { useBus } from "../state/store";
 
 const STATUS_LABELS: Record<TaskStatus, string> = {
@@ -301,7 +301,7 @@ export default function TaskModal({
         <div className="task-modal-body tm-split">
           <div className="tm-main">
             {spectator ? (
-              <div className="tm-title">{t.title}</div>
+              <div className="tm-title">{scrubIds(t.title)}</div>
             ) : (
               <input
                 className="tm-title"
@@ -317,7 +317,7 @@ export default function TaskModal({
               />
             )}
             {spectator ? (
-              t.bodyMd ? <div className="tm-body whitespace-pre-wrap">{t.bodyMd}</div> : null
+              t.bodyMd ? <div className="tm-body whitespace-pre-wrap">{scrubIds(t.bodyMd)}</div> : null
             ) : (
               <textarea
                 className="tm-body"
@@ -601,7 +601,7 @@ export default function TaskModal({
                     already gets it, and a human deciding whether to override a
                     failed gate needs it just as much. Card view only has it on
                     hover; here there is room to print it. */}
-                {t.verification.rationale && (
+                {t.verification.rationale && !spectator && (
                   <div className="tm-verify-why">{t.verification.rationale}</div>
                 )}
               </div>

--- a/web/src/components/VerificationBadge.tsx
+++ b/web/src/components/VerificationBadge.tsx
@@ -1,5 +1,6 @@
 import { ShieldCheck, ShieldAlert } from "lucide-react";
 import type { TaskVerification } from "../api/client";
+import { useSpectator } from "../lib/hooks";
 
 // The verification gate's verdict, rendered wherever a task is shown.
 //
@@ -18,6 +19,10 @@ interface Props {
 }
 
 export default function VerificationBadge({ verification, size = "card" }: Props) {
+  // The rationale is the judge's working notes — it quotes file paths, rubric
+  // wording and tool names. The verdict itself is public; the reasoning is not
+  // shown on the read-only demo.
+  const spectator = useSpectator();
   if (!verification) return null;
   const passed = verification.verdict === "pass";
   // Score is null for non-rubric methods (the deterministic render gate), so
@@ -26,7 +31,7 @@ export default function VerificationBadge({ verification, size = "card" }: Props
   const label = passed ? (score ? `Verified · ${score}` : "Verified") : "Verification failed";
   // The rationale is the judge's reason. On the card it's the only way to see
   // it (hover); the rail prints it below.
-  const title = verification.rationale
+  const title = verification.rationale && !spectator
     ? `${label} — ${verification.rationale}`
     : passed
       ? "Passed the verification gate"

--- a/web/src/lib/md.ts
+++ b/web/src/lib/md.ts
@@ -20,6 +20,57 @@ md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
   return defaultLinkOpen(tokens, idx, options, env, self);
 };
 
+// ─────────────────────────── scrubIds ───────────────────────────
+// The markdown path below turns ids and hashes into chips, but plenty of agent
+// text is rendered as PLAIN TEXT — a task title, a board card label, a goal
+// body, an agent's brief, a "Needs you" detail line. Those surfaces were
+// showing raw `task_…` ids, SHA-256 digests, container paths
+// (`/opt/data/workspace/backend/server.js`) and `localhost:3000` to visitors.
+//
+// scrubIds is the plain-text counterpart of chipIds: same vocabulary, no HTML.
+// It is deliberately conservative — it rewrites machine identifiers and runtime
+// paths and leaves every other word alone.
+//
+// Mirrors the rewrite table in api/src/agents/reply-guard.ts
+// (`sanitizeAgentProse`), which stops this text being written in the first
+// place. This one cleans what is already stored.
+// Leading group is the delimiter, kept verbatim — avoids a lookbehind so the
+// expression stays portable across browser regex engines.
+const RUNTIME_PATH_RE = /(^|[\s("'`[<])(\/(?:opt\/data|workspace|tmp)(?:\/[\w.@%+-]+)*)\/?/g;
+const PORT_URL_RE = /\b(?:https?:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0)(?::\d{2,5})?(?:\/[\w./?=&%-]*)?/gi;
+const ON_PORT_RE = /\s*\b(?:on|at|via)\s+port\s+\d{2,5}\b/gi;
+const BARE_PORT_RE = /(^|[\s(])::?\d{2,5}\b/g;
+
+export function scrubIds(text: string): string {
+  if (!text) return "";
+  let out = String(text);
+  // Internal ids → what the thing actually is.
+  out = out.replace(/\btask_[a-z0-9]{12,28}\b/g, "this card");
+  out = out.replace(/\bap_[a-z0-9]{12,28}\b/g, "an approval");
+  out = out.replace(/\bgoal_[a-z0-9]{12,28}\b/g, "this goal");
+  // Content digests / commit hashes → a short, still-recognisable prefix.
+  out = out.replace(/\b([0-9a-f]{32,64})\b/g, (_m, h: string) => `${h.slice(0, 8)}…`);
+  // Container paths → the bare filename. `/workspace/backend/server.js` is
+  // meaningless to a reader; `server.js` is the part they can act on. A bare
+  // directory ("/workspace") leaves nothing worth printing.
+  out = out.replace(RUNTIME_PATH_RE, (_m, pre: string, p: string) => {
+    const last = p.split("/").filter(Boolean).pop() ?? "";
+    const keep = last && last !== "workspace" && last !== "tmp" && last !== "data" ? last : "";
+    return `${pre}${keep}`;
+  });
+  // Local dev endpoints → "the server"; port mentions → gone.
+  out = out.replace(PORT_URL_RE, "the server");
+  out = out.replace(ON_PORT_RE, "");
+  out = out.replace(BARE_PORT_RE, "$1");
+  // Tidy up the whitespace/punctuation the removals leave behind.
+  return out
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/[ \t]+([,.;:!?])/g, "$1")
+    .replace(/\(\s*\)/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 // Agents refer to board cards, approvals and files by their internal ids and
 // hashes. Humans should never have to read `task_tor0bjwcr6zcasklr4sq`: cards
 // become a chip with the card's title (linking to the board), approval ids a

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -2,6 +2,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useEffect, useRef, useState } from "react";
 import { FlaskConical, HeartPulse, Pause, Play, Download } from "lucide-react";
 import { useAgent, useSpectator } from "../lib/hooks";
+import { scrubIds } from "../lib/md";
 import { api, type AgentRun } from "../api/client";
 import Avatar from "../components/Avatar";
 import { useQueryClient } from "@tanstack/react-query";
@@ -152,16 +153,21 @@ export default function AgentDetailPage() {
         <div className="grid grid-cols-2 gap-6 mt-6">
           <section>
             <h2 className="text-[11px] uppercase tracking-wider text-[var(--color-muted)] font-mono">Brief</h2>
-            <p className="text-[14px] mt-1 whitespace-pre-wrap">{agent.brief || "—"}</p>
+            <p className="text-[14px] mt-1 whitespace-pre-wrap">{scrubIds(agent.brief) || "—"}</p>
           </section>
-          <section>
-            <h2 className="text-[11px] uppercase tracking-wider text-[var(--color-muted)] font-mono">Scopes</h2>
-            <div className="flex flex-wrap gap-1 mt-1">
-              {agent.scopes.map((s) => (
-                <span key={s} className="chip font-mono">{s}</span>
-              ))}
-            </div>
-          </section>
+          {/* Scopes, heartbeat and budget are configuration: the server only
+              sends them to workspace admins (see api/src/lib/agent-view.ts), so
+              these panels simply aren't there for everyone else. */}
+          {agent.scopes && (
+            <section>
+              <h2 className="text-[11px] uppercase tracking-wider text-[var(--color-muted)] font-mono">Scopes</h2>
+              <div className="flex flex-wrap gap-1 mt-1">
+                {agent.scopes.map((s) => (
+                  <span key={s} className="chip font-mono">{s}</span>
+                ))}
+              </div>
+            </section>
+          )}
           <section>
             <h2 className="text-[11px] uppercase tracking-wider text-[var(--color-muted)] font-mono">Channels</h2>
             <div className="flex flex-wrap gap-1 mt-1">
@@ -179,25 +185,29 @@ export default function AgentDetailPage() {
               ))}
             </div>
           </section>
-          <section>
-            <h2 className="text-[11px] uppercase tracking-wider text-[var(--color-muted)] font-mono">Heartbeat</h2>
-            <HeartbeatControl
-              agentId={agent.id}
-              currentSec={agent.heartbeatIntervalSec}
-              onSaved={refresh}
-              readOnly={spectator}
-            />
-          </section>
-          <section>
-            <h2 className="text-[11px] uppercase tracking-wider text-[var(--color-muted)] font-mono">Monthly budget</h2>
-            <BudgetControl
-              agentId={agent.id}
-              currentUsd={agent.budgetUsdMonth}
-              pausedForBudget={agent.status === "paused" && agent.pauseReason === "budget"}
-              onSaved={refresh}
-              readOnly={spectator}
-            />
-          </section>
+          {agent.heartbeatIntervalSec != null && (
+            <section>
+              <h2 className="text-[11px] uppercase tracking-wider text-[var(--color-muted)] font-mono">Heartbeat</h2>
+              <HeartbeatControl
+                agentId={agent.id}
+                currentSec={agent.heartbeatIntervalSec}
+                onSaved={refresh}
+                readOnly={spectator}
+              />
+            </section>
+          )}
+          {agent.budgetUsdMonth !== undefined && (
+            <section>
+              <h2 className="text-[11px] uppercase tracking-wider text-[var(--color-muted)] font-mono">Monthly budget</h2>
+              <BudgetControl
+                agentId={agent.id}
+                currentUsd={agent.budgetUsdMonth}
+                pausedForBudget={agent.status === "paused" && agent.pauseReason === "budget"}
+                onSaved={refresh}
+                readOnly={spectator}
+              />
+            </section>
+          )}
         </div>
 
         <section className="mt-8">

--- a/web/src/pages/Goals.tsx
+++ b/web/src/pages/Goals.tsx
@@ -4,6 +4,7 @@ import { Target, Plus, Wand2, ChevronRight, ChevronDown, FolderKanban } from "lu
 import { api, type Goal, type Task, type PlanResult } from "../api/client";
 import { humanizeError } from "../api/errors";
 import { useGoals, useTasks, useMembersDirectory, useSpectator } from "../lib/hooks";
+import { scrubIds } from "../lib/md";
 import Segmented from "../components/Segmented";
 
 const STATUS_LABEL: Record<string, string> = {
@@ -254,7 +255,7 @@ export default function GoalsPage() {
                           Project
                         </span>
                       )}
-                      <span className="truncate min-w-0">{g.title}</span>
+                      <span className="truncate min-w-0">{scrubIds(g.title)}</span>
                     </div>
                     <div className="text-[12px] text-[var(--color-muted)] flex items-center gap-2 flex-wrap mt-0.5">
                       {parent && (
@@ -297,7 +298,7 @@ export default function GoalsPage() {
                   <div className="goal-expand-inner">
                   <div className="border-t border-[var(--color-border)] px-3 py-2">
                     {g.bodyMd && (
-                      <div className="text-[12px] text-[var(--color-muted)] mb-2 whitespace-pre-wrap">{g.bodyMd}</div>
+                      <div className="text-[12px] text-[var(--color-muted)] mb-2 whitespace-pre-wrap">{scrubIds(g.bodyMd)}</div>
                     )}
                     {gTasks.length === 0 ? (
                       <div className="text-[12px] text-[var(--color-muted)] py-1">

--- a/web/src/pages/Members.tsx
+++ b/web/src/pages/Members.tsx
@@ -12,6 +12,12 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { useMembersDirectory, useConversations, useMe, useSpectator } from "../lib/hooks";
+import { scrubIds } from "../lib/md";
+
+// The brief is what a human reads in the member directory: a job description,
+// never tool names, channel names or paths.
+const DEFAULT_AGENT_BRIEF =
+  "Answers questions in the channels they are in, picks up work from the board, and shares what changed.";
 import { api } from "../api/client";
 import { humanizeError } from "../api/errors";
 import Avatar from "../components/Avatar";
@@ -210,13 +216,16 @@ export default function MembersPage() {
                       {(aa as { title?: string }).title && (
                         <span className="text-[12px] text-[var(--color-ink)]">· {(aa as { title?: string }).title}</span>
                       )}
+                      {/* The runtime kind is admin-only (the server nulls it
+                          for everyone else) — the directory is a people list,
+                          not a deployment inventory. */}
                       <span className="text-[11px] font-mono text-[var(--color-muted-2)]">
-                        · {aa.agentKind} · {aa.status}
+                        {aa.agentKind ? `· ${aa.agentKind} ` : ""}· {aa.status}
                       </span>
                     </div>
                     {aa.brief && (
                       <div className="text-[12.5px] text-[var(--color-muted)] mt-0.5 line-clamp-2 max-w-[640px]">
-                        {aa.brief}
+                        {scrubIds(aa.brief)}
                       </div>
                     )}
                   </div>
@@ -504,9 +513,9 @@ function InstallAgent({
   const [name, setName] = useState("CEO");
   const [handle, setHandle] = useState("ceo");
   const [title, setTitle] = useState("Chief Executive Officer");
-  const [brief, setBrief] = useState(
-    "Reads the channels I belong to. Replies to @mentions and DMs; on scheduled beats, surfaces relevant updates.",
-  );
+  // Job-description prose, not a description of the harness — see
+  // DEFAULT_BRIEF in Signup.tsx.
+  const [brief, setBrief] = useState(DEFAULT_AGENT_BRIEF);
   const [runtime, setRuntime] = useState<"hermes" | "openclaw">("hermes");
   const [providerId, setProviderId] = useState<(typeof PROVIDERS)[number]["id"]>("anthropic");
   const provider = PROVIDERS.find((p) => p.id === providerId)!;
@@ -811,9 +820,9 @@ function AttachAgent({
   const [adapter, setAdapter] = useState<"webhook" | "socket">("socket");
   const [name, setName] = useState("CEO");
   const [handle, setHandle] = useState("ceo");
-  const [brief, setBrief] = useState(
-    "Reads the channels I belong to. Replies to @mentions and DMs; on scheduled beats, surfaces relevant updates.",
-  );
+  // Job-description prose, not a description of the harness — see
+  // DEFAULT_BRIEF in Signup.tsx.
+  const [brief, setBrief] = useState(DEFAULT_AGENT_BRIEF);
   const [model, setModel] = useState("");
   const [callbackUrl, setCallbackUrl] = useState("");
   const [interval, setInterval] = useState(60);

--- a/web/src/pages/NeedsYou.tsx
+++ b/web/src/pages/NeedsYou.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Check, ExternalLink, Inbox, RefreshCw, X } from "lucide-
 import { Link } from "react-router-dom";
 import { api } from "../api/client";
 import { useSpectator } from "../lib/hooks";
+import { scrubIds } from "../lib/md";
 
 type Item = {
   id: string;
@@ -61,7 +62,7 @@ export default function NeedsYouPage() {
       {items.length === 0 && !query.isLoading && <div className="px-6 py-16 text-center text-[13px] text-[var(--color-muted)]">Nothing needs you. Approvals, reviews, failed verification, stalled work, budgets, app releases, and connector errors will collect here.</div>}
       <ul className="divide-y divide-[var(--color-hair)]">{items.map((item) => <li key={item.id} className="px-6 py-4 flex gap-4 items-start">
         <div className={`mt-0.5 w-8 h-8 rounded grid place-items-center ${item.priority === "critical" ? "bg-red-100 text-red-700" : item.priority === "high" ? "bg-amber-100 text-amber-800" : "bg-[var(--color-surface-2)]"}`}>{item.priority === "normal" ? <Inbox size={14} /> : <AlertTriangle size={14} />}</div>
-        <div className="min-w-0 flex-1"><div className="flex gap-2 items-center"><strong className="text-[14px]">{item.title}</strong><span className="tag">{item.kind.replaceAll("_", " ")}</span><span className="tag">{item.priority}</span></div><p className="mt-1 text-[12.5px] text-[var(--color-muted)]">{item.detail}</p><p className="mt-2 text-[10.5px] font-mono text-[var(--color-muted-2)]">{new Date(item.createdAt).toLocaleString()}</p></div>
+        <div className="min-w-0 flex-1"><div className="flex gap-2 items-center"><strong className="text-[14px]">{item.title}</strong><span className="tag">{item.kind.replaceAll("_", " ")}</span><span className="tag">{item.priority}</span></div><p className="mt-1 text-[12.5px] text-[var(--color-muted)]">{scrubIds(item.detail)}</p><p className="mt-2 text-[10.5px] font-mono text-[var(--color-muted-2)]">{new Date(item.createdAt).toLocaleString()}</p></div>
         <div className="flex gap-1 shrink-0">{item.actions.map((value) => value === "open" || value === "preview" ? <Link key={value} className="btn xs ghost" to={item.link}>{value === "preview" ? "Preview" : "Open"} <ExternalLink size={10} /></Link> : !spectator && <button key={value} className={`btn xs ${value === "approve" || value === "resume" ? "" : "ghost"}`} disabled={working === item.id} onClick={() => action(item, value)}>{value === "approve" || value === "resume" ? <Check size={10} /> : value === "deny" || value === "reject" || value === "cancel" ? <X size={10} /> : <RefreshCw size={10} />}{value.replace("_", " ")}</button>)}</div>
       </li>)}</ul>
     </div>

--- a/web/src/pages/Signup.tsx
+++ b/web/src/pages/Signup.tsx
@@ -19,8 +19,12 @@ const PROVIDERS: Array<{
   { id: "custom:freeapi", label: "FreeLLMAPI (self-hosted)", hint: "OpenAI-compatible proxy. Set up from github.com/tashfeenahmed/freellmapi, then paste its base URL + unified key.", defaultModel: "gemini-2.5-pro", placeholder: "freellmapi-…" },
 ];
 
+// A brief is the one-line job description shown to HUMANS in the member
+// directory and on the agent's profile — it should read like the "what they do"
+// line on an org chart. Never mention tools, channels that may not exist, file
+// paths or runtime behaviour: that's the agent's instructions, not its role.
 const DEFAULT_BRIEF =
-  "Reads the channels I belong to. Replies to @mentions and DMs; on scheduled beats, surfaces relevant updates.";
+  "Answers questions in the channels they are in, picks up work from the board, and shares what changed.";
 
 export default function SignupPage() {
   const [step, setStep] = useState(0);

--- a/web/src/pages/Skills.tsx
+++ b/web/src/pages/Skills.tsx
@@ -23,10 +23,19 @@ interface AgentRow {
 export default function SkillsPage() {
   const dir = useMembersDirectory();
 
+  // The server only tells workspace admins which runtime drives an agent (see
+  // api/src/lib/agent-view.ts), and skill installs are admin-only anyway — so
+  // when every row comes back without an `agentKind` this viewer simply can't
+  // use this page. Distinguish that from "no Hermes agents exist" below.
+  const runtimeHidden = useMemo(() => {
+    const all = (dir.data?.agents ?? []) as DirMember[];
+    return all.length > 0 && all.every((a) => !(a as { agentKind?: string | null }).agentKind);
+  }, [dir.data]);
+
   const agents = useMemo<AgentRow[]>(() => {
     const all = (dir.data?.agents ?? []) as DirMember[];
     return all
-      .filter((a) => (a as { agentKind?: string }).agentKind === "hermes")
+      .filter((a) => (a as { agentKind?: string | null }).agentKind === "hermes")
       .map((a) => {
         const aa = a as {
           id: string;
@@ -70,7 +79,9 @@ export default function SkillsPage() {
         )}
         {!dir.isLoading && agents.length === 0 && (
           <div className="p-8 text-[13px] text-[var(--color-muted)]">
-            No Hermes agents in this workspace yet.
+            {runtimeHidden
+              ? "Skills are managed by workspace admins."
+              : "No Hermes agents in this workspace yet."}
           </div>
         )}
         <div className="max-w-[960px] mx-auto py-6 px-6 space-y-6">


### PR DESCRIPTION
A data audit of the public demo found 806 messages and 239 comments carrying runtime paths, ports, and harness vocabulary, agent rows over-shared to spectators, and 131 soft-deleted message bodies still sent over the wire. The data was cleaned by hand; this PR makes the code stop producing and exposing it: deleted bodies redacted on read, allowlisted public agent view, spectator-safe Needs-you copy, rationale hidden from spectators, scrubIds() on plain-text surfaces, a prose sanitizer on every agent post/comment/note (mirrored in the bridge), and plain-English default briefs. Tests: api tsc clean, 34 files / 379 tests, web tsc and vite build clean.